### PR TITLE
Validate phone numbers globally

### DIFF
--- a/lib/common.dart
+++ b/lib/common.dart
@@ -4,16 +4,10 @@ import 'package:flutter/services.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:http/http.dart' as http;
 
+/// Remove non-digits from the phone number
 String normalizePhone(String phone) {
   // Remove non-digits
-  phone = phone.replaceAll(RegExp(r'[^\d]'), '');
-
-  // Ensure leading 1
-  if (phone[0] != '1') {
-    phone = '1$phone';
-  }
-
-  return phone;
+  return phone.replaceAll(RegExp(r'[^\d]'), '');
 }
 
 String formatPhone(String phone) {
@@ -26,6 +20,7 @@ String formatPhone(String phone) {
   }
 }
 
+/// Deny any non-digit (and some phone number related) characters from the input
 final phoneInputFilter =
     FilteringTextInputFormatter.deny(RegExp(r'[^+\(\) 0-9\-]'));
 

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -27,9 +27,9 @@ String formatPhone(String phone) {
     phoneNumberWithoutCountry,
     allowEndlessPhone: true,
     defaultCountryCode: countryCode.countryCode,
-    invalidPhoneAction: InvalidPhoneAction.ShowPhoneInvalidString,
+    invalidPhoneAction: InvalidPhoneAction.ShowUnformatted,
   )!;
-  // null-safety `!` ensured by the above enum value [InvalidPhoneAction.ShowPhoneInvalidString]
+  // null-safety `!` ensured by the above enum value [InvalidPhoneAction.ShowUnformatted]
 }
 
 /// Deny any non-digit (and some phone number related) characters from the input

--- a/lib/components/phone_number_field.dart
+++ b/lib/components/phone_number_field.dart
@@ -50,6 +50,8 @@ class _PhoneNumberFormFieldState extends State<PhoneNumberFormField> {
       _selectedPhoneCountry = defaultCountryData;
     }
 
+    _internalController.text = formatPhone(_internalController.text);
+
     _setupControllerListener();
   }
 

--- a/lib/components/phone_number_field.dart
+++ b/lib/components/phone_number_field.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_multi_formatter/flutter_multi_formatter.dart';
+import 'package:squadquest/common.dart';
+
+class PhoneNumberFormField extends StatefulWidget {
+  const PhoneNumberFormField({
+    super.key,
+    this.enabled = true,
+    this.autofocus = false,
+    this.onSubmitted,
+    this.phoneNumberController,
+    this.onPhoneNumberChanged,
+    this.decoration,
+    this.countryFieldDecoration,
+  });
+
+  final TextEditingController? phoneNumberController;
+  final ValueChanged<String>? onPhoneNumberChanged;
+  final void Function(String)? onSubmitted;
+
+  final bool autofocus;
+  final bool enabled;
+
+  final InputDecoration? decoration;
+  final InputDecoration? countryFieldDecoration;
+
+  @override
+  State<PhoneNumberFormField> createState() => _PhoneNumberFormFieldState();
+}
+
+class _PhoneNumberFormFieldState extends State<PhoneNumberFormField> {
+  late final TextEditingController _internalController;
+  late PhoneCountryData _selectedPhoneCountry;
+
+  String get completePhoneNumber =>
+      '+${_selectedPhoneCountry.internalPhoneCode} ${_internalController.text}';
+
+  static final defaultCountryData = PhoneCodes.getPhoneCountryDataByCountryCode("US")!;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _internalController = TextEditingController(text: widget.phoneNumberController?.text ?? '');
+
+    if (_internalController.text.isNotEmpty) {
+      _selectedPhoneCountry =
+          PhoneCodes.getCountryDataByPhone(_internalController.text) ?? defaultCountryData;
+    } else {
+      _selectedPhoneCountry = defaultCountryData;
+    }
+
+    _setupControllerListener();
+  }
+
+  void _setupControllerListener() {
+    _internalController.addListener(_notify);
+  }
+
+  void _notify() {
+    final newText = completePhoneNumber;
+    if (widget.onPhoneNumberChanged != null) {
+      widget.onPhoneNumberChanged!(newText);
+    }
+
+    if (widget.phoneNumberController != null &&
+        widget.phoneNumberController != _internalController) {
+      /// This can be bad if you want to manage other properties of the controller
+      /// such as selection and composition, but it's fine for our purposes
+      /// See [TextEditingController.text] setter for more details
+      widget.phoneNumberController?.text = newText;
+    }
+  }
+
+  @override
+  void dispose() {
+    _internalController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = widget.decoration ?? const InputDecoration(prefixIcon: Icon(Icons.phone));
+    final countryDecoration =
+        widget.countryFieldDecoration ?? const InputDecoration(labelText: 'Country Code');
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 140,
+          child: CountryDropdown(
+            printCountryName: true,
+            iconSize: 28, // match phone input field height
+            decoration: countryDecoration,
+            initialCountryData: _selectedPhoneCountry,
+            onCountrySelected: (value) {
+              setState(() {
+                _selectedPhoneCountry = value;
+                _notify();
+              });
+            },
+          ),
+        ),
+        const SizedBox.square(dimension: 8),
+        Expanded(
+          child: TextFormField(
+            autofocus: widget.autofocus,
+            readOnly: !widget.enabled,
+            controller: _internalController,
+            onChanged: widget.onPhoneNumberChanged != null
+                ? (value) => widget.onPhoneNumberChanged!(completePhoneNumber)
+                : null,
+            inputFormatters: [
+              phoneInputFilter,
+              PhoneInputFormatter(
+                defaultCountryCode: _selectedPhoneCountry.countryCode,
+                allowEndlessPhone: true,
+              )
+            ],
+            keyboardType: TextInputType.phone,
+            textInputAction: TextInputAction.done,
+            autofillHints: const [AutofillHints.telephoneNumber],
+            onFieldSubmitted:
+                widget.onSubmitted != null ? (value) => widget.onSubmitted!(value) : null,
+            decoration: decoration,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a phone number';
+              }
+
+              final masks = [
+                _selectedPhoneCountry.phoneMask,
+                _selectedPhoneCountry.phoneMaskWithoutCountryCode,
+                ...(_selectedPhoneCountry.altMasks ?? []),
+                ...(_selectedPhoneCountry.altMasksWithoutCountryCodes ?? []),
+              ];
+
+              final maskedOutValue = value.replaceAll(RegExp("[0-9]"), "0");
+              if (!masks.any((mask) => mask?.contains(maskedOutValue) == true)) {
+                return "Please enter a valid phone number";
+              }
+
+              return null;
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/friends.dart
+++ b/lib/screens/friends.dart
@@ -6,6 +6,7 @@ import 'package:grouped_list/grouped_list.dart';
 
 import 'package:squadquest/common.dart';
 import 'package:squadquest/app_scaffold.dart';
+import 'package:squadquest/components/phone_number_field.dart';
 import 'package:squadquest/controllers/auth.dart';
 import 'package:squadquest/controllers/friends.dart';
 import 'package:squadquest/models/friend.dart';
@@ -227,26 +228,14 @@ class _FriendsScreenState extends ConsumerState<FriendsScreen> {
                     Text('Send friend request',
                         style: theme.textTheme.titleLarge),
                     const SizedBox(height: 16),
-                    TextFormField(
+                    PhoneNumberFormField(
                       autofocus: true,
-                      autofillHints: const [AutofillHints.telephoneNumber],
-                      keyboardType: TextInputType.phone,
-                      textInputAction: TextInputAction.done,
                       decoration: const InputDecoration(
                         prefixIcon: Icon(Icons.phone),
                         labelText: 'Enter your friend\'s phone number',
                       ),
-                      inputFormatters: [phoneInputFilter],
-                      validator: (value) {
-                        if (value == null ||
-                            value.isEmpty ||
-                            normalizePhone(value).length != 11) {
-                          return 'Please enter a valid phone number';
-                        }
-                        return null;
-                      },
-                      controller: phoneController,
-                      onFieldSubmitted: (_) {
+                      phoneNumberController: phoneController,
+                      onSubmitted: (_) {
                         if (!formKey.currentState!.validate()) {
                           return;
                         }

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -1,11 +1,14 @@
 import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import 'package:squadquest/common.dart';
-import 'package:squadquest/app_scaffold.dart';
-import 'package:squadquest/controllers/auth.dart';
+import '../app_scaffold.dart';
+import '../common.dart';
+import '../components/phone_number_field.dart';
+import '../controllers/auth.dart';
+import '../services/supabase.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
   final String? redirect;
@@ -18,6 +21,7 @@ class LoginScreen extends ConsumerStatefulWidget {
 
 class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _formKey = GlobalKey<FormState>();
+
   final _phoneController = TextEditingController();
 
   bool submitted = false;
@@ -39,34 +43,33 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             phone: phone,
           );
       log('Sent SMS');
-    } catch (error) {
-      log('Error sending SMS: $error');
 
+      if (context.mounted) {
+        context
+            .pushNamed('verify',
+                queryParameters: widget.redirect == null ? {} : {'redirect': widget.redirect})
+            .then((_) {});
+      }
+    } catch (error, st) {
+      log('Error sending SMS:', error: error, stackTrace: st);
+      final errorMessage = switch (error) {
+        AuthException(:final message) => message,
+        _ => 'Unexpected error',
+      };
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(
+            'Failed to login, check phone number and try again.\n'
+            'Details: $errorMessage',
+          ),
+        ));
+      }
+    } finally {
       setState(() {
         submitted = false;
       });
-
-      if (!context.mounted) return;
-
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(
-            'Failed to login, check phone number and try again:\n\n$error'),
-      ));
-
-      return;
     }
-
-    if (!context.mounted) return;
-
-    context
-        .pushNamed('verify',
-            queryParameters:
-                widget.redirect == null ? {} : {'redirect': widget.redirect})
-        .then((_) {
-      setState(() {
-        submitted = false;
-      });
-    });
   }
 
   @override
@@ -80,27 +83,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           key: _formKey,
           child: Column(
             children: [
-              TextFormField(
+              PhoneNumberFormField(
                 autofocus: true,
-                readOnly: submitted,
-                autofillHints: const [AutofillHints.telephoneNumber],
-                keyboardType: TextInputType.phone,
-                textInputAction: TextInputAction.done,
+                onSubmitted: (_) => _submitPhone(context),
+                phoneNumberController: _phoneController,
                 decoration: const InputDecoration(
-                  prefixIcon: Icon(Icons.phone),
                   labelText: 'Enter your phone number',
                 ),
-                inputFormatters: [phoneInputFilter],
-                validator: (value) {
-                  if (value == null ||
-                      value.isEmpty ||
-                      normalizePhone(value).length != 11) {
-                    return 'Please enter a valid phone number';
-                  }
-                  return null;
-                },
-                controller: _phoneController,
-                onFieldSubmitted: (_) => _submitPhone(context),
               ),
               const SizedBox(height: 16),
               submitted
@@ -109,8 +98,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       onPressed: submitted ? null : () => _submitPhone(context),
                       child: const Text(
                         'Send login code via SMS',
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold, fontSize: 18),
+                        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
                       ),
                     )
             ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  base58check:
+    dependency: transitive
+    description:
+      name: base58check
+      sha256: "6c300dfc33e598d2fe26319e13f6243fea81eaf8204cb4c6b69ef20a625319a5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  bech32:
+    dependency: transitive
+    description:
+      name: bech32
+      sha256: "156cbace936f7720c79a79d16a03efad343b1ef17106716e04b8b8e39f99f7f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -382,6 +398,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_multi_formatter:
+    dependency: "direct main"
+    description:
+      name: flutter_multi_formatter
+      sha256: "3495dc0056c96e467039a05bd184a5285c271a0efb2024a7030c7e84ba828994"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.8"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,8 @@ dependencies:
   image_picker: ^1.1.2
   http: ^1.2.1
   package_info_plus: ^8.0.0
+  ## Multi Formatter
+  flutter_multi_formatter: ^2.12.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
# Validating phone numbers based on country

## Added

- New component that encapsulates both country selector and phone number form field.
  The package used ([`flutter_multi_formatter`](https://pub.dev/packages/flutter_multi_formatter)) leave its entries as static const values, so it will not delay in any way the initialization.
  I choose this package mainly because it does bring the phone mask which is used to format the phone number (add some spaces, hyphens, etc) and has a decent number of countries set (240 countries). 
  Additionally, the package is extremely popular on pub.dev, with a high popularity score based on frequent use by the community.
 - The new component is present on the **Login Page** and **Send Friend Request** dialog

## Modified

- The phone formatting function now relies on `flutter_multi_formatter` to format phone numbers. This change provides the application with some useful features:
  - If a number already has a country code attached (which is usually mandatory), the code is parsed as a country, and the number is formatted according to that country's standards.
  - If no country code is recognized at the start of the phone number, the formatter will attempt to apply the US standard. 
  - If the formatting fails, the number remains unformatted.

---

Despite the changes, the previous behavior remained unchanged: numbers from the United States/Canada (country code `+1`) are still considered the default.

This PR should close [my own issue](#111 )

> I CAN FINALLY LOG IN