### PR TITLE
feat: add semantic topic search with trigram and vector similarity

### DIFF
--- a/lib/components/pickers/topic.dart
+++ b/lib/components/pickers/topic.dart
@@ -1,7 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_typeahead/flutter_typeahead.dart';
 
 import 'package:squadquest/models/topic.dart';
 import 'package:squadquest/controllers/topics.dart';
@@ -32,29 +32,196 @@ class _FormTopicPickerState extends ConsumerState<FormTopicPicker> {
   final _textController = TextEditingController();
   final _focusNode = FocusNode();
   Topic? _activeTopic;
-  String? _lastSearch;
 
-  void _onValueChanged(Topic? value) {
-    _textController.text = value!.name;
+  // Search state
+  List<TopicSuggestion> _trigramResults = [];
+  List<TopicSuggestion> _semanticResults = [];
+  List<double>? _lastEmbedding;
+  bool _isSearching = false;
+  bool _hasSearched = false;
+  Timer? _trigramDebounce;
+  Timer? _semanticDebounce;
+
+  void _onTopicSelected(Topic value) {
+    _textController.text = value.label;
 
     ref.read(_valueProvider!.notifier).state = value;
 
-    if ((_activeTopic == null || value.name != _activeTopic!.name)) {
+    if (_activeTopic == null || value.name != _activeTopic!.name) {
       _activeTopic = value;
       if (widget.onChanged != null) {
         widget.onChanged!(value);
       }
     }
 
+    // Clear search results and unfocus
+    setState(() {
+      _trigramResults = [];
+      _semanticResults = [];
+      _hasSearched = false;
+    });
     FocusScope.of(context).nextFocus();
   }
 
-  void _onTextSaved(String? value) async {
-    value = value!.toLowerCase();
+  void _onSearchChanged(String value) {
+    final query = value.trim();
 
+    if (query.isEmpty) {
+      setState(() {
+        _trigramResults = [];
+        _semanticResults = [];
+        _hasSearched = false;
+        _lastEmbedding = null;
+      });
+      return;
+    }
+
+    // Trigram search with 200ms debounce
+    _trigramDebounce?.cancel();
+    _trigramDebounce = Timer(const Duration(milliseconds: 200), () {
+      _runTrigramSearch(query);
+    });
+
+    // Semantic search with 500ms debounce, minimum 3 chars
+    _semanticDebounce?.cancel();
+    if (query.length >= 3) {
+      _semanticDebounce = Timer(const Duration(milliseconds: 500), () {
+        _runSemanticSearch(query);
+      });
+    }
+  }
+
+  Future<void> _runTrigramSearch(String query) async {
+    try {
+      final results =
+          await ref.read(topicsProvider.notifier).searchTrigram(query);
+      if (mounted) {
+        setState(() {
+          _trigramResults = results;
+          _hasSearched = true;
+        });
+      }
+    } catch (_) {
+      // Fall back to client-side search on error
+      _fallbackClientSearch(query);
+    }
+  }
+
+  Future<void> _runSemanticSearch(String query) async {
+    if (_trigramResults.length >= 3) return; // Skip if trigram found enough
+
+    setState(() => _isSearching = true);
+
+    try {
+      final result =
+          await ref.read(topicsProvider.notifier).suggestTopics(query);
+      if (mounted) {
+        setState(() {
+          _semanticResults = result.suggestions;
+          _lastEmbedding = result.embedding;
+          _isSearching = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() => _isSearching = false);
+      }
+    }
+  }
+
+  void _fallbackClientSearch(String query) async {
     final topicsList = await ref.read(topicsProvider.future);
-    _onValueChanged(topicsList.firstWhere((topic) => topic.name == value,
-        orElse: () => Topic(id: null, name: value!)));
+    final lowerQuery = query.toLowerCase();
+    if (mounted) {
+      setState(() {
+        _trigramResults = topicsList
+            .where((t) => t.name.toLowerCase().contains(lowerQuery))
+            .map((t) => TopicSuggestion(
+                  id: t.id!,
+                  name: t.name,
+                  displayName: t.displayName,
+                  similarity: 1.0,
+                ))
+            .toList();
+        _hasSearched = true;
+      });
+    }
+  }
+
+  String _generateSlug(String displayName) {
+    return displayName
+        .toLowerCase()
+        .trim()
+        .replaceAll(RegExp(r'[^a-z0-9\s\-]'), '')
+        .replaceAll(RegExp(r'\s+'), '-');
+  }
+
+  Future<void> _createNewTopic() async {
+    final displayName = _textController.text.trim();
+    if (displayName.isEmpty) return;
+
+    final slug = _generateSlug(displayName);
+
+    // Check for high-similarity matches that should trigger a warning
+    final highMatches = [
+      ..._trigramResults.where((s) => s.similarity > 0.7),
+      ..._semanticResults.where((s) => s.similarity > 0.7),
+    ];
+
+    if (highMatches.isNotEmpty && mounted) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Similar topic exists'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                  'This looks similar to existing ${highMatches.length == 1 ? 'topic' : 'topics'}:'),
+              const SizedBox(height: 8),
+              ...highMatches.map((m) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Text('• ${m.label}',
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
+                  )),
+              const SizedBox(height: 12),
+              const Text('Create a new topic anyway?'),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Create anyway'),
+            ),
+          ],
+        ),
+      );
+
+      if (confirmed != true) return;
+    }
+
+    final newTopic = Topic(
+      id: null,
+      name: slug,
+      displayName: displayName,
+      embedding: _lastEmbedding,
+    );
+
+    try {
+      final savedTopic = await ref.read(topicsProvider.notifier).save(newTopic);
+      _onTopicSelected(savedTopic);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create topic: $e')),
+        );
+      }
+    }
   }
 
   @override
@@ -67,47 +234,84 @@ class _FormTopicPickerState extends ConsumerState<FormTopicPicker> {
     final initialValue = ref.read(_valueProvider!);
 
     if (initialValue != null) {
-      _textController.text = initialValue.name;
+      _textController.text = initialValue.label;
     }
 
-    _focusNode.addListener(() {
-      if (!_focusNode.hasFocus) {
-        _onTextSaved(_textController.text);
-      }
+    _textController.addListener(() {
+      _onSearchChanged(_textController.text);
     });
   }
 
   @override
-  Widget build(BuildContext context) {
-    return TypeAheadField<Topic>(
-      controller: _textController,
-      focusNode: _focusNode,
-      suggestionsCallback: (search) async {
-        final topicsList = await ref.read(topicsProvider.future);
+  void dispose() {
+    _trigramDebounce?.cancel();
+    _semanticDebounce?.cancel();
+    _textController.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
 
-        _lastSearch = search = search.toLowerCase();
-        return topicsList.where((topic) {
-          return topic.name.toLowerCase().contains(search);
-        })
-            // .take(5)
-            .toList();
-      },
-      builder: (context, controller, focusNode) {
-        return TextFormField(
+  @override
+  Widget build(BuildContext context) {
+    // Combine and deduplicate results
+    final allSuggestionIds = <String>{};
+    final combinedResults = <TopicSuggestion>[];
+
+    for (final result in _trigramResults) {
+      if (allSuggestionIds.add(result.id)) {
+        combinedResults.add(result);
+      }
+    }
+
+    // Add semantic results that aren't already in trigram results
+    final semanticOnly = <TopicSuggestion>[];
+    for (final result in _semanticResults) {
+      if (allSuggestionIds.add(result.id)) {
+        semanticOnly.add(result);
+      }
+    }
+
+    final showCreateButton =
+        _hasSearched && _textController.text.trim().isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextFormField(
           key: _formFieldKey,
-          onSaved: _onTextSaved,
-          controller: controller,
-          focusNode: focusNode,
+          controller: _textController,
+          focusNode: _focusNode,
           enableSuggestions: false,
-          textCapitalization: TextCapitalization.none,
-          inputFormatters: [
-            FilteringTextInputFormatter.deny(RegExp(r'[^a-z\.0-9\-]'))
-          ],
+          textCapitalization: TextCapitalization.words,
           decoration: InputDecoration(
             labelText: widget.required
                 ? 'Topic for event'
                 : 'Topic for event (optional)',
             prefixIcon: const Icon(Icons.category),
+            suffixIcon: _isSearching
+                ? const Padding(
+                    padding: EdgeInsets.all(12),
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  )
+                : _textController.text.isNotEmpty
+                    ? IconButton(
+                        icon: const Icon(Icons.clear),
+                        onPressed: () {
+                          _textController.clear();
+                          setState(() {
+                            _trigramResults = [];
+                            _semanticResults = [];
+                            _hasSearched = false;
+                            _lastEmbedding = null;
+                          });
+                        },
+                      )
+                    : null,
             filled: true,
             fillColor: Theme.of(context)
                 .colorScheme
@@ -115,48 +319,99 @@ class _FormTopicPickerState extends ConsumerState<FormTopicPicker> {
                 .withAlpha(80),
           ),
           validator: (value) {
-            if (widget.required && (value == null || value.isEmpty)) {
-              return 'Please select or enter a topic';
+            if (widget.required && (_activeTopic == null)) {
+              return 'Please select or create a topic';
             }
             return null;
           },
-        );
-      },
-      emptyBuilder: (context) => const Padding(
-          padding: EdgeInsets.all(16),
-          child:
-              Text('No existing topics found, but you can create a new one!')),
-      itemBuilder: (context, topic) {
-        int? matchIndex;
+        ),
 
-        if (_lastSearch != null && _lastSearch!.isNotEmpty) {
-          matchIndex =
-              topic.name.toLowerCase().indexOf(_lastSearch!.toLowerCase());
-          if (matchIndex == -1) {
-            matchIndex = null;
-          }
-        }
+        // Search results
+        if (combinedResults.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Container(
+            constraints: const BoxConstraints(maxHeight: 200),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceContainerLow,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: Theme.of(context).colorScheme.outlineVariant,
+              ),
+            ),
+            child: ListView(
+              shrinkWrap: true,
+              padding: EdgeInsets.zero,
+              children: [
+                ...combinedResults.map((s) => _buildSuggestionTile(s)),
+                if (semanticOnly.isNotEmpty) ...[
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    child: Text(
+                      'Similar topics',
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                  ),
+                  ...semanticOnly.map((s) => _buildSuggestionTile(s)),
+                ],
+              ],
+            ),
+          ),
+        ],
 
-        return ListTile(
-          title: RichText(
-              text: TextSpan(
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  children: matchIndex == null
-                      ? [TextSpan(text: topic.name)]
-                      : [
-                          TextSpan(text: topic.name.substring(0, matchIndex)),
-                          TextSpan(
-                              text: topic.name.substring(
-                                  matchIndex, matchIndex + _lastSearch!.length),
-                              style:
-                                  const TextStyle(fontWeight: FontWeight.bold)),
-                          TextSpan(
-                              text: topic.name
-                                  .substring(matchIndex + _lastSearch!.length))
-                        ])),
-        );
+        // Create new topic button
+        if (showCreateButton) ...[
+          const SizedBox(height: 4),
+          OutlinedButton.icon(
+            onPressed: _createNewTopic,
+            icon: const Icon(Icons.add, size: 18),
+            label: Text('Create "${_textController.text.trim()}"'),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSuggestionTile(TopicSuggestion suggestion) {
+    final similarity = suggestion.similarity;
+    final TextStyle? subtitleStyle;
+
+    if (similarity > 0.85) {
+      subtitleStyle = TextStyle(
+        color: Theme.of(context).colorScheme.error,
+        fontSize: 12,
+      );
+    } else if (similarity > 0.7) {
+      subtitleStyle = TextStyle(
+        color: Theme.of(context).colorScheme.tertiary,
+        fontSize: 12,
+      );
+    } else {
+      subtitleStyle = null;
+    }
+
+    return ListTile(
+      dense: true,
+      title: Text(suggestion.label),
+      subtitle: similarity > 0.7
+          ? Text(
+              similarity > 0.85
+                  ? 'This topic already exists'
+                  : 'Did you mean this?',
+              style: subtitleStyle,
+            )
+          : null,
+      onTap: () {
+        // Select the existing topic
+        _onTopicSelected(Topic(
+          id: suggestion.id,
+          name: suggestion.name,
+          displayName: suggestion.displayName,
+        ));
       },
-      onSelected: _onValueChanged,
     );
   }
 

--- a/lib/controllers/topics.dart
+++ b/lib/controllers/topics.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 
 import 'package:squadquest/common.dart';
 import 'package:squadquest/services/supabase.dart';
@@ -7,6 +10,32 @@ import 'package:squadquest/models/topic.dart';
 
 final topicsProvider =
     AsyncNotifierProvider<TopicsController, List<Topic>>(TopicsController.new);
+
+class TopicSuggestion {
+  final String id;
+  final String name;
+  final String? displayName;
+  final double similarity;
+
+  TopicSuggestion({
+    required this.id,
+    required this.name,
+    this.displayName,
+    required this.similarity,
+  });
+
+  String get label => displayName ?? name;
+}
+
+class SuggestTopicsResult {
+  final List<TopicSuggestion> suggestions;
+  final List<double> embedding;
+
+  SuggestTopicsResult({
+    required this.suggestions,
+    required this.embedding,
+  });
+}
 
 class TopicsController extends AsyncNotifier<List<Topic>> {
   @override
@@ -58,5 +87,84 @@ class TopicsController extends AsyncNotifier<List<Topic>> {
     }
 
     return savedTopic;
+  }
+
+  /// Fast trigram search for typeahead
+  Future<List<TopicSuggestion>> searchTrigram(String query,
+      {int maxResults = 10}) async {
+    final supabase = ref.read(supabaseClientProvider);
+
+    final data = await supabase.rpc('search_topics_trigram', params: {
+      'query': query,
+      'max_results': maxResults,
+    });
+
+    return (data as List).map((row) {
+      return TopicSuggestion(
+        id: row['id'] as String,
+        name: row['name'] as String,
+        displayName: row['display_name'] as String?,
+        similarity: (row['similarity'] as num).toDouble(),
+      );
+    }).toList();
+  }
+
+  /// Semantic search via the suggest-topics edge function
+  Future<SuggestTopicsResult> suggestTopics(String query) async {
+    final supabase = ref.read(supabaseClientProvider);
+    final session = supabase.auth.currentSession;
+
+    final response = await http.post(
+      Uri.parse(
+          '${supabase.rest.url.replaceAll('/rest/v1', '')}/functions/v1/suggest-topics'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ${session?.accessToken ?? ''}',
+      },
+      body: jsonEncode({'query': query}),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get topic suggestions: ${response.body}');
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+
+    final suggestions = (body['suggestions'] as List).map((row) {
+      return TopicSuggestion(
+        id: row['id'] as String,
+        name: row['name'] as String,
+        displayName: row['display_name'] as String?,
+        similarity: (row['similarity'] as num).toDouble(),
+      );
+    }).toList();
+
+    final embedding =
+        (body['embedding'] as List).map((e) => (e as num).toDouble()).toList();
+
+    return SuggestTopicsResult(
+      suggestions: suggestions,
+      embedding: embedding,
+    );
+  }
+
+  /// Get related topics for a given topic (neighborhoods)
+  Future<List<TopicSuggestion>> getRelatedTopics(String topicId,
+      {int maxResults = 5}) async {
+    final supabase = ref.read(supabaseClientProvider);
+
+    final data = await supabase.rpc('get_related_topics', params: {
+      'topic_id': topicId,
+      'max_results': maxResults,
+    });
+
+    return (data as List).map((row) {
+      return TopicSuggestion(
+        id: row['id'] as String,
+        name: row['name'] as String,
+        displayName: row['display_name'] as String?,
+        similarity: (row['similarity'] as num).toDouble(),
+      );
+    }).toList();
   }
 }

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -9,10 +9,16 @@ class Topic {
   Topic({
     required this.id,
     required this.name,
+    this.displayName,
+    this.embedding,
   });
 
   final TopicID? id;
   final String name;
+  final String? displayName;
+  final List<double>? embedding;
+
+  String get label => displayName ?? name;
 
   bool get isNull => id == null && name.isEmpty;
   bool get isNotNull => !isNull;
@@ -21,11 +27,17 @@ class Topic {
     return Topic(
       id: map['id'] as TopicID,
       name: map['name'] as String,
+      displayName: map['display_name'] as String?,
+      embedding: map['embedding'] != null
+          ? (map['embedding'] as List)
+              .map((e) => (e as num).toDouble())
+              .toList()
+          : null,
     );
   }
 
   Map<String, dynamic> toMap() {
-    final data = {
+    final data = <String, dynamic>{
       'name': name,
     };
 
@@ -33,11 +45,19 @@ class Topic {
       data['id'] = id!;
     }
 
+    if (displayName != null) {
+      data['display_name'] = displayName;
+    }
+
+    if (embedding != null) {
+      data['embedding'] = embedding;
+    }
+
     return data;
   }
 
   @override
   String toString() {
-    return 'Topic{id: $id, name: $name}';
+    return 'Topic{id: $id, name: $name, displayName: $displayName}';
   }
 }

--- a/lib/storybook/main.dart
+++ b/lib/storybook/main.dart
@@ -28,6 +28,12 @@ import 'package:squadquest/storybook/screens/communities/create_community.dart';
 import 'package:squadquest/storybook/screens/venues/venue_profile.dart';
 import 'package:squadquest/storybook/screens/topics/topics_list.v1.dart';
 import 'package:squadquest/storybook/screens/topics/topics_list.v2.dart';
+import 'package:squadquest/storybook/screens/topics/topics_list.v3.dart';
+import 'package:squadquest/storybook/screens/topics/topics_list.v4.dart';
+import 'package:squadquest/storybook/screens/topics/topics_list.v5.dart';
+import 'package:squadquest/storybook/screens/topics/topics_list.v6.dart';
+import 'package:squadquest/storybook/screens/topics/topics_search.dart';
+import 'package:squadquest/storybook/screens/topics/topics_list.v7.dart';
 import 'package:squadquest/storybook/screens/home/home_screen.v1.dart';
 import 'package:squadquest/storybook/screens/home/home_screen.v2.dart';
 import 'package:squadquest/storybook/screens/settings/settings_screen.dart';
@@ -227,6 +233,38 @@ class StorybookApp extends StatelessWidget {
               name: 'Redesign/Topics/Topics List v2',
               description: 'With search',
               builder: (context) => const TopicsListScreenV2(),
+            ),
+            Story(
+              name: 'Redesign/Topics/Topics List v3',
+              description: 'Hierarchical tree with expandable categories',
+              builder: (context) => const TopicsListScreenV3(),
+            ),
+            Story(
+              name: 'Redesign/Topics/Topics List v4',
+              description: 'Flat tags with chip cloud layout',
+              builder: (context) => const TopicsListScreenV4(),
+            ),
+            Story(
+              name: 'Redesign/Topics/Topics List v5',
+              description: 'Two-level category grid with horizontal bar',
+              builder: (context) => const TopicsListScreenV5(),
+            ),
+            Story(
+              name: 'Redesign/Topics/Topics List v6',
+              description: 'Multi-tag faceted browse with filter dimensions',
+              builder: (context) => const TopicsListScreenV6(),
+            ),
+            Story(
+              name: 'Redesign/Topics/Topics List v7',
+              description:
+                  'Category grid with search, semantic suggestions, and neighborhoods',
+              builder: (context) => const TopicsListScreenV7(),
+            ),
+            Story(
+              name: 'Redesign/Topics/Search & Neighborhoods',
+              description:
+                  'Search-first topics with semantic suggestions and neighborhoods',
+              builder: (context) => const TopicsSearchScreen(),
             ),
             // Squads screens
             Story(

--- a/lib/storybook/screens/topics/topics_list.v3.dart
+++ b/lib/storybook/screens/topics/topics_list.v3.dart
@@ -1,0 +1,414 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storybook_toolkit/storybook_toolkit.dart';
+import 'package:squadquest/app_scaffold.dart';
+
+class TopicsListScreenV3 extends ConsumerStatefulWidget {
+  const TopicsListScreenV3({super.key});
+
+  @override
+  ConsumerState<TopicsListScreenV3> createState() => _TopicsListScreenV3State();
+}
+
+class _TopicsListScreenV3State extends ConsumerState<TopicsListScreenV3> {
+  String _searchQuery = '';
+  final _searchController = TextEditingController();
+  final Set<String> _subscribedTopicIds = {};
+  final Set<String> _expandedCategories = {'Sports', 'Games'};
+
+  late final List<_MockCategory> _categories;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _categories = [
+      _MockCategory(name: 'Sports', icon: Icons.sports_basketball, topics: [
+        _MockTopic(id: '1', name: 'Basketball', events: 8),
+        _MockTopic(id: '2', name: 'Soccer', events: 12),
+        _MockTopic(id: '3', name: 'Tennis', events: 5),
+        _MockTopic(id: '4', name: 'Trail Running', events: 6),
+        _MockTopic(id: '5', name: 'Road Running', events: 4),
+        _MockTopic(id: '6', name: 'Swimming', events: 3),
+      ]),
+      _MockCategory(name: 'Outdoors', icon: Icons.landscape, topics: [
+        _MockTopic(id: '7', name: 'Hiking', events: 9),
+        _MockTopic(id: '8', name: 'Rock Climbing', events: 4),
+        _MockTopic(id: '9', name: 'Camping', events: 3),
+        _MockTopic(id: '10', name: 'Kayaking', events: 2),
+      ]),
+      _MockCategory(name: 'Games', icon: Icons.casino, topics: [
+        _MockTopic(id: '11', name: 'Board Games', events: 7),
+        _MockTopic(id: '12', name: 'Video Games', events: 5),
+        _MockTopic(id: '13', name: 'Trivia Night', events: 6),
+        _MockTopic(id: '14', name: 'Card Games', events: 3),
+      ]),
+      _MockCategory(name: 'Food & Drink', icon: Icons.restaurant, topics: [
+        _MockTopic(id: '15', name: 'Cooking', events: 8),
+        _MockTopic(id: '16', name: 'Wine Tasting', events: 4),
+        _MockTopic(id: '17', name: 'Coffee Meetup', events: 5),
+      ]),
+      _MockCategory(name: 'Arts', icon: Icons.palette, topics: [
+        _MockTopic(id: '18', name: 'Photography', events: 6),
+        _MockTopic(id: '19', name: 'Painting', events: 3),
+        _MockTopic(id: '20', name: 'Live Music', events: 10),
+      ]),
+      _MockCategory(name: 'Social', icon: Icons.people, topics: [
+        _MockTopic(id: '21', name: 'Movie Nights', events: 7),
+        _MockTopic(id: '22', name: 'Book Club', events: 4),
+        _MockTopic(id: '23', name: 'Karaoke', events: 5),
+      ]),
+    ];
+
+    // Pre-subscribe a few
+    _subscribedTopicIds.addAll(['1', '7', '11', '18']);
+  }
+
+  List<_MockCategory> get _filteredCategories {
+    if (_searchQuery.isEmpty) return _categories;
+
+    final query = _searchQuery.toLowerCase();
+    return _categories
+        .map((category) {
+          final matchingTopics = category.topics
+              .where((t) => t.name.toLowerCase().contains(query))
+              .toList();
+          if (matchingTopics.isEmpty) return null;
+          return _MockCategory(
+            name: category.name,
+            icon: category.icon,
+            topics: matchingTopics,
+          );
+        })
+        .whereType<_MockCategory>()
+        .toList();
+  }
+
+  void _toggleTopic(String topicId) {
+    setState(() {
+      if (_subscribedTopicIds.contains(topicId)) {
+        _subscribedTopicIds.remove(topicId);
+      } else {
+        _subscribedTopicIds.add(topicId);
+      }
+    });
+  }
+
+  void _subscribeAll(List<_MockTopic> topics) {
+    setState(() {
+      for (final topic in topics) {
+        _subscribedTopicIds.add(topic.id);
+      }
+    });
+  }
+
+  void _unsubscribeAll(List<_MockTopic> topics) {
+    setState(() {
+      for (final topic in topics) {
+        _subscribedTopicIds.remove(topic.id);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showEmptyState = context.knobs.boolean(
+      label: 'Show empty state',
+      initial: false,
+      description: 'Toggle between empty and populated states',
+    );
+
+    final expandAll = context.knobs.boolean(
+      label: 'Expand all categories',
+      initial: false,
+      description: 'Expand all category sections',
+    );
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final filteredCategories = _filteredCategories;
+
+    if (expandAll) {
+      for (final cat in _categories) {
+        _expandedCategories.add(cat.name);
+      }
+    }
+
+    return AppScaffold(
+      title: 'Topics',
+      body: Column(
+        children: [
+          // Header with search
+          Container(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withAlpha(13),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Browse Topics',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Expand categories to discover and subscribe to topics',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).textTheme.bodySmall?.color,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search topics...',
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: _searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              setState(() => _searchQuery = '');
+                            },
+                          )
+                        : null,
+                  ),
+                  onChanged: (value) {
+                    setState(() {
+                      _searchQuery = value;
+                      if (value.isNotEmpty) {
+                        // Auto-expand all when searching
+                        for (final cat in _categories) {
+                          _expandedCategories.add(cat.name);
+                        }
+                      }
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),
+
+          // Subscription summary
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Icon(Icons.check_circle, size: 16, color: colorScheme.primary),
+                const SizedBox(width: 6),
+                Text(
+                  '${_subscribedTopicIds.length} subscribed',
+                  style: TextStyle(
+                    color: colorScheme.primary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Category tree
+          Expanded(
+            child: showEmptyState || filteredCategories.isEmpty
+                ? _buildEmptyState(context)
+                : ListView.builder(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    itemCount: filteredCategories.length,
+                    itemBuilder: (context, index) {
+                      final category = filteredCategories[index];
+                      final subscribedCount = category.topics
+                          .where((t) => _subscribedTopicIds.contains(t.id))
+                          .length;
+                      final allSubscribed =
+                          subscribedCount == category.topics.length;
+                      final isExpanded =
+                          _expandedCategories.contains(category.name);
+
+                      return Card(
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 4),
+                        clipBehavior: Clip.antiAlias,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Theme(
+                          data: Theme.of(context)
+                              .copyWith(dividerColor: Colors.transparent),
+                          child: ExpansionTile(
+                            key: PageStorageKey(category.name),
+                            initiallyExpanded: isExpanded,
+                            onExpansionChanged: (expanded) {
+                              setState(() {
+                                if (expanded) {
+                                  _expandedCategories.add(category.name);
+                                } else {
+                                  _expandedCategories.remove(category.name);
+                                }
+                              });
+                            },
+                            leading:
+                                Icon(category.icon, color: colorScheme.primary),
+                            title: Row(
+                              children: [
+                                Text(
+                                  category.name,
+                                  style: const TextStyle(
+                                      fontWeight: FontWeight.bold),
+                                ),
+                                const SizedBox(width: 8),
+                                if (subscribedCount > 0)
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 6, vertical: 1),
+                                    decoration: BoxDecoration(
+                                      color: colorScheme.primaryContainer,
+                                      borderRadius: BorderRadius.circular(10),
+                                    ),
+                                    child: Text(
+                                      '$subscribedCount/${category.topics.length}',
+                                      style: TextStyle(
+                                        fontSize: 11,
+                                        color: colorScheme.onPrimaryContainer,
+                                      ),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                TextButton(
+                                  onPressed: () {
+                                    if (allSubscribed) {
+                                      _unsubscribeAll(category.topics);
+                                    } else {
+                                      _subscribeAll(category.topics);
+                                    }
+                                  },
+                                  child: Text(
+                                    allSubscribed ? 'Unsub All' : 'Sub All',
+                                    style: const TextStyle(fontSize: 12),
+                                  ),
+                                ),
+                                Icon(
+                                  isExpanded
+                                      ? Icons.expand_less
+                                      : Icons.expand_more,
+                                ),
+                              ],
+                            ),
+                            children: category.topics.map((topic) {
+                              final isSubscribed =
+                                  _subscribedTopicIds.contains(topic.id);
+                              return ListTile(
+                                contentPadding:
+                                    const EdgeInsets.symmetric(horizontal: 24),
+                                title: Text(topic.name),
+                                subtitle: Text('${topic.events} events'),
+                                trailing: IconButton(
+                                  icon: AnimatedSwitcher(
+                                    duration: const Duration(milliseconds: 200),
+                                    child: isSubscribed
+                                        ? Icon(
+                                            Icons.check_circle,
+                                            key: const ValueKey('sub'),
+                                            color: colorScheme.primary,
+                                          )
+                                        : Icon(
+                                            Icons.add_circle_outline,
+                                            key: const ValueKey('unsub'),
+                                            color: colorScheme.onSurface
+                                                .withAlpha(120),
+                                          ),
+                                  ),
+                                  onPressed: () => _toggleTopic(topic.id),
+                                ),
+                                onTap: () => _toggleTopic(topic.id),
+                              );
+                            }).toList(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No Topics Found',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Try a different search term',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).textTheme.bodySmall?.color,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MockCategory {
+  final String name;
+  final IconData icon;
+  final List<_MockTopic> topics;
+
+  _MockCategory({
+    required this.name,
+    required this.icon,
+    required this.topics,
+  });
+}
+
+class _MockTopic {
+  final String id;
+  final String name;
+  final int events;
+
+  _MockTopic({
+    required this.id,
+    required this.name,
+    required this.events,
+  });
+}

--- a/lib/storybook/screens/topics/topics_list.v4.dart
+++ b/lib/storybook/screens/topics/topics_list.v4.dart
@@ -1,0 +1,414 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storybook_toolkit/storybook_toolkit.dart';
+import 'package:squadquest/app_scaffold.dart';
+
+class TopicsListScreenV4 extends ConsumerStatefulWidget {
+  const TopicsListScreenV4({super.key});
+
+  @override
+  ConsumerState<TopicsListScreenV4> createState() => _TopicsListScreenV4State();
+}
+
+class _TopicsListScreenV4State extends ConsumerState<TopicsListScreenV4> {
+  String _searchQuery = '';
+  final _searchController = TextEditingController();
+  String _selectedMetaTag = 'All';
+  final Set<String> _subscribedTopicIds = {};
+
+  static const _metaTags = [
+    'All',
+    'Active',
+    'Fitness',
+    'Social',
+    'Creative',
+    'Outdoors',
+  ];
+
+  late final List<_MockTopic> _topics;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _topics = [
+      _MockTopic(
+          id: '1',
+          name: 'Basketball',
+          metaTags: ['Active', 'Fitness'],
+          events: 8),
+      _MockTopic(
+          id: '2', name: 'Soccer', metaTags: ['Active', 'Fitness'], events: 12),
+      _MockTopic(
+          id: '3', name: 'Tennis', metaTags: ['Active', 'Fitness'], events: 5),
+      _MockTopic(
+          id: '4',
+          name: 'Trail Running',
+          metaTags: ['Active', 'Fitness', 'Outdoors'],
+          events: 6),
+      _MockTopic(
+          id: '5',
+          name: 'Road Running',
+          metaTags: ['Active', 'Fitness'],
+          events: 4),
+      _MockTopic(
+          id: '6',
+          name: 'Swimming',
+          metaTags: ['Active', 'Fitness'],
+          events: 3),
+      _MockTopic(
+          id: '7', name: 'Hiking', metaTags: ['Active', 'Outdoors'], events: 9),
+      _MockTopic(
+          id: '8',
+          name: 'Rock Climbing',
+          metaTags: ['Active', 'Outdoors'],
+          events: 4),
+      _MockTopic(
+          id: '9',
+          name: 'Camping',
+          metaTags: ['Outdoors', 'Social'],
+          events: 3),
+      _MockTopic(
+          id: '10',
+          name: 'Kayaking',
+          metaTags: ['Active', 'Outdoors'],
+          events: 2),
+      _MockTopic(
+          id: '11', name: 'Board Games', metaTags: ['Social'], events: 7),
+      _MockTopic(
+          id: '12', name: 'Video Games', metaTags: ['Social'], events: 5),
+      _MockTopic(
+          id: '13', name: 'Trivia Night', metaTags: ['Social'], events: 6),
+      _MockTopic(id: '14', name: 'Card Games', metaTags: ['Social'], events: 3),
+      _MockTopic(
+          id: '15',
+          name: 'Cooking',
+          metaTags: ['Social', 'Creative'],
+          events: 8),
+      _MockTopic(
+          id: '16', name: 'Wine Tasting', metaTags: ['Social'], events: 4),
+      _MockTopic(
+          id: '17', name: 'Coffee Meetup', metaTags: ['Social'], events: 5),
+      _MockTopic(
+          id: '18',
+          name: 'Photography',
+          metaTags: ['Creative', 'Outdoors'],
+          events: 6),
+      _MockTopic(id: '19', name: 'Painting', metaTags: ['Creative'], events: 3),
+      _MockTopic(
+          id: '20',
+          name: 'Live Music',
+          metaTags: ['Social', 'Creative'],
+          events: 10),
+      _MockTopic(
+          id: '21', name: 'Movie Nights', metaTags: ['Social'], events: 7),
+      _MockTopic(
+          id: '22',
+          name: 'Book Club',
+          metaTags: ['Social', 'Creative'],
+          events: 4),
+      _MockTopic(
+          id: '23', name: 'Karaoke', metaTags: ['Social', 'Active'], events: 5),
+    ];
+
+    // Pre-subscribe a few
+    _subscribedTopicIds.addAll(['1', '7', '11', '18']);
+  }
+
+  List<_MockTopic> get _filteredTopics {
+    var topics = _topics.toList();
+
+    if (_selectedMetaTag != 'All') {
+      topics =
+          topics.where((t) => t.metaTags.contains(_selectedMetaTag)).toList();
+    }
+
+    if (_searchQuery.isNotEmpty) {
+      final query = _searchQuery.toLowerCase();
+      topics =
+          topics.where((t) => t.name.toLowerCase().contains(query)).toList();
+    }
+
+    return topics;
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showEmptyState = context.knobs.boolean(
+      label: 'Show empty state',
+      initial: false,
+      description: 'Toggle between empty and populated states',
+    );
+
+    final showSubscribedFirst = context.knobs.boolean(
+      label: 'Show subscribed first',
+      initial: true,
+      description: 'Group subscribed topics at the top',
+    );
+
+    final colorScheme = Theme.of(context).colorScheme;
+    var filtered = _filteredTopics;
+
+    if (showSubscribedFirst) {
+      final subscribed =
+          filtered.where((t) => _subscribedTopicIds.contains(t.id)).toList();
+      final unsubscribed =
+          filtered.where((t) => !_subscribedTopicIds.contains(t.id)).toList();
+      filtered = [...subscribed, ...unsubscribed];
+    }
+
+    return AppScaffold(
+      title: 'Topics',
+      body: Column(
+        children: [
+          // Header with search
+          Container(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withAlpha(13),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Your Topics',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Tap chips to subscribe to topics you\'re interested in',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).textTheme.bodySmall?.color,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search topics...',
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: _searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              setState(() => _searchQuery = '');
+                            },
+                          )
+                        : null,
+                  ),
+                  onChanged: (value) => setState(() => _searchQuery = value),
+                ),
+              ],
+            ),
+          ),
+
+          // Meta-tag filter row
+          SizedBox(
+            height: 52,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              separatorBuilder: (_, __) => const SizedBox(width: 8),
+              itemCount: _metaTags.length,
+              itemBuilder: (context, index) {
+                final tag = _metaTags[index];
+                final isSelected = _selectedMetaTag == tag;
+
+                return ChoiceChip(
+                  label: Text(tag),
+                  selected: isSelected,
+                  onSelected: (_) => setState(() => _selectedMetaTag = tag),
+                );
+              },
+            ),
+          ),
+
+          // Subscription count
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Row(
+              children: [
+                Text(
+                  '${filtered.length} topics',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: colorScheme.onSurface.withAlpha(180),
+                      ),
+                ),
+                const Spacer(),
+                Text(
+                  '${_subscribedTopicIds.length} subscribed',
+                  style: TextStyle(
+                    color: colorScheme.primary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Chip cloud
+          Expanded(
+            child: showEmptyState || filtered.isEmpty
+                ? _buildEmptyState(context)
+                : SingleChildScrollView(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (showSubscribedFirst &&
+                            filtered.any(
+                                (t) => _subscribedTopicIds.contains(t.id))) ...[
+                          Text(
+                            'My Topics',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: filtered
+                                .where(
+                                    (t) => _subscribedTopicIds.contains(t.id))
+                                .map((topic) =>
+                                    _buildTopicChip(context, topic, true))
+                                .toList(),
+                          ),
+                          const SizedBox(height: 24),
+                          Text(
+                            'Available Topics',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: filtered
+                                .where(
+                                    (t) => !_subscribedTopicIds.contains(t.id))
+                                .map((topic) =>
+                                    _buildTopicChip(context, topic, false))
+                                .toList(),
+                          ),
+                        ] else
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: filtered
+                                .map((topic) => _buildTopicChip(context, topic,
+                                    _subscribedTopicIds.contains(topic.id)))
+                                .toList(),
+                          ),
+                      ],
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTopicChip(
+    BuildContext context,
+    _MockTopic topic,
+    bool isSubscribed,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return FilterChip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(topic.name),
+          const SizedBox(width: 4),
+          Text(
+            '${topic.events}',
+            style: TextStyle(
+              fontSize: 11,
+              color: isSubscribed
+                  ? colorScheme.onPrimaryContainer.withAlpha(180)
+                  : colorScheme.onSurface.withAlpha(120),
+            ),
+          ),
+        ],
+      ),
+      selected: isSubscribed,
+      onSelected: (_) {
+        setState(() {
+          if (isSubscribed) {
+            _subscribedTopicIds.remove(topic.id);
+          } else {
+            _subscribedTopicIds.add(topic.id);
+          }
+        });
+      },
+      showCheckmark: isSubscribed,
+      avatar: isSubscribed ? null : const Icon(Icons.add, size: 16),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No Topics Found',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Try a different search term or filter',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).textTheme.bodySmall?.color,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MockTopic {
+  final String id;
+  final String name;
+  final List<String> metaTags;
+  final int events;
+
+  _MockTopic({
+    required this.id,
+    required this.name,
+    required this.metaTags,
+    required this.events,
+  });
+}

--- a/lib/storybook/screens/topics/topics_list.v5.dart
+++ b/lib/storybook/screens/topics/topics_list.v5.dart
@@ -1,0 +1,594 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storybook_toolkit/storybook_toolkit.dart';
+import 'package:squadquest/app_scaffold.dart';
+
+class TopicsListScreenV5 extends ConsumerStatefulWidget {
+  const TopicsListScreenV5({super.key});
+
+  @override
+  ConsumerState<TopicsListScreenV5> createState() => _TopicsListScreenV5State();
+}
+
+class _TopicsListScreenV5State extends ConsumerState<TopicsListScreenV5> {
+  String _searchQuery = '';
+  final _searchController = TextEditingController();
+  String _selectedCategory = 'All';
+  final Set<String> _subscribedTopicIds = {};
+
+  late final List<_MockCategory> _categories;
+  late final List<_MockTopic> _topics;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _categories = [
+      _MockCategory(name: 'All', icon: Icons.apps, color: Colors.blueGrey),
+      _MockCategory(
+          name: 'Sports', icon: Icons.sports_basketball, color: Colors.orange),
+      _MockCategory(
+          name: 'Outdoors', icon: Icons.landscape, color: Colors.green),
+      _MockCategory(name: 'Games', icon: Icons.casino, color: Colors.purple),
+      _MockCategory(
+          name: 'Food & Drink', icon: Icons.restaurant, color: Colors.red),
+      _MockCategory(name: 'Arts', icon: Icons.palette, color: Colors.teal),
+      _MockCategory(name: 'Social', icon: Icons.people, color: Colors.indigo),
+    ];
+
+    _topics = [
+      _MockTopic(
+          id: '1',
+          name: 'Basketball',
+          categories: ['Sports'],
+          events: 8,
+          icon: Icons.sports_basketball),
+      _MockTopic(
+          id: '2',
+          name: 'Soccer',
+          categories: ['Sports'],
+          events: 12,
+          icon: Icons.sports_soccer),
+      _MockTopic(
+          id: '3',
+          name: 'Tennis',
+          categories: ['Sports'],
+          events: 5,
+          icon: Icons.sports_tennis),
+      _MockTopic(
+          id: '4',
+          name: 'Trail Running',
+          categories: ['Sports', 'Outdoors'],
+          events: 6,
+          icon: Icons.directions_run),
+      _MockTopic(
+          id: '5',
+          name: 'Road Running',
+          categories: ['Sports'],
+          events: 4,
+          icon: Icons.directions_run),
+      _MockTopic(
+          id: '6',
+          name: 'Swimming',
+          categories: ['Sports'],
+          events: 3,
+          icon: Icons.pool),
+      _MockTopic(
+          id: '7',
+          name: 'Hiking',
+          categories: ['Outdoors'],
+          events: 9,
+          icon: Icons.hiking),
+      _MockTopic(
+          id: '8',
+          name: 'Rock Climbing',
+          categories: ['Sports', 'Outdoors'],
+          events: 4,
+          icon: Icons.terrain),
+      _MockTopic(
+          id: '9',
+          name: 'Camping',
+          categories: ['Outdoors'],
+          events: 3,
+          icon: Icons.cabin),
+      _MockTopic(
+          id: '10',
+          name: 'Kayaking',
+          categories: ['Sports', 'Outdoors'],
+          events: 2,
+          icon: Icons.kayaking),
+      _MockTopic(
+          id: '11',
+          name: 'Board Games',
+          categories: ['Games'],
+          events: 7,
+          icon: Icons.extension),
+      _MockTopic(
+          id: '12',
+          name: 'Video Games',
+          categories: ['Games'],
+          events: 5,
+          icon: Icons.videogame_asset),
+      _MockTopic(
+          id: '13',
+          name: 'Trivia Night',
+          categories: ['Games', 'Social'],
+          events: 6,
+          icon: Icons.quiz),
+      _MockTopic(
+          id: '14',
+          name: 'Card Games',
+          categories: ['Games'],
+          events: 3,
+          icon: Icons.style),
+      _MockTopic(
+          id: '15',
+          name: 'Cooking',
+          categories: ['Food & Drink'],
+          events: 8,
+          icon: Icons.soup_kitchen),
+      _MockTopic(
+          id: '16',
+          name: 'Wine Tasting',
+          categories: ['Food & Drink'],
+          events: 4,
+          icon: Icons.wine_bar),
+      _MockTopic(
+          id: '17',
+          name: 'Coffee Meetup',
+          categories: ['Food & Drink'],
+          events: 5,
+          icon: Icons.coffee),
+      _MockTopic(
+          id: '18',
+          name: 'Photography',
+          categories: ['Arts'],
+          events: 6,
+          icon: Icons.camera_alt),
+      _MockTopic(
+          id: '19',
+          name: 'Painting',
+          categories: ['Arts'],
+          events: 3,
+          icon: Icons.brush),
+      _MockTopic(
+          id: '20',
+          name: 'Live Music',
+          categories: ['Arts', 'Social'],
+          events: 10,
+          icon: Icons.music_note),
+      _MockTopic(
+          id: '21',
+          name: 'Movie Nights',
+          categories: ['Social'],
+          events: 7,
+          icon: Icons.movie),
+      _MockTopic(
+          id: '22',
+          name: 'Book Club',
+          categories: ['Social'],
+          events: 4,
+          icon: Icons.menu_book),
+      _MockTopic(
+          id: '23',
+          name: 'Karaoke',
+          categories: ['Social'],
+          events: 5,
+          icon: Icons.mic),
+    ];
+
+    // Pre-subscribe a few
+    _subscribedTopicIds.addAll(['1', '7', '11', '18']);
+  }
+
+  List<_MockTopic> get _filteredTopics {
+    var topics = _topics.toList();
+
+    if (_selectedCategory != 'All') {
+      topics = topics
+          .where((t) => t.categories.contains(_selectedCategory))
+          .toList();
+    }
+
+    if (_searchQuery.isNotEmpty) {
+      final query = _searchQuery.toLowerCase();
+      topics = topics
+          .where((t) =>
+              t.name.toLowerCase().contains(query) ||
+              t.categories.any((c) => c.toLowerCase().contains(query)))
+          .toList();
+    }
+
+    return topics;
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showEmptyState = context.knobs.boolean(
+      label: 'Show empty state',
+      initial: false,
+      description: 'Toggle between empty and populated states',
+    );
+
+    final showSubscribedOnly = context.knobs.boolean(
+      label: 'Show subscribed only',
+      initial: false,
+      description: 'Only show topics the user has subscribed to',
+    );
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final filtered = showSubscribedOnly
+        ? _filteredTopics
+            .where((t) => _subscribedTopicIds.contains(t.id))
+            .toList()
+        : _filteredTopics;
+
+    return AppScaffold(
+      title: 'Topics',
+      body: Column(
+        children: [
+          // Header with search
+          Container(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withAlpha(13),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Browse Topics',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Explore categories and subscribe to topics you love',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).textTheme.bodySmall?.color,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search topics...',
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: _searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              setState(() => _searchQuery = '');
+                            },
+                          )
+                        : null,
+                  ),
+                  onChanged: (value) => setState(() => _searchQuery = value),
+                ),
+              ],
+            ),
+          ),
+
+          // Category bar
+          SizedBox(
+            height: 100,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              separatorBuilder: (_, __) => const SizedBox(width: 12),
+              itemCount: _categories.length,
+              itemBuilder: (context, index) {
+                final category = _categories[index];
+                final isSelected = _selectedCategory == category.name;
+
+                return GestureDetector(
+                  onTap: () =>
+                      setState(() => _selectedCategory = category.name),
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    width: 76,
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(16),
+                      border: isSelected
+                          ? Border.all(color: colorScheme.primary, width: 2)
+                          : null,
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          category.icon,
+                          color:
+                              isSelected ? colorScheme.primary : category.color,
+                          size: 28,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          category.name,
+                          style: TextStyle(
+                            fontSize: 11,
+                            fontWeight:
+                                isSelected ? FontWeight.bold : FontWeight.w500,
+                            color: isSelected
+                                ? colorScheme.primary
+                                : colorScheme.onSurface,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+
+          // Topic count
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Row(
+              children: [
+                Text(
+                  _selectedCategory == 'All' ? 'All Topics' : _selectedCategory,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    filtered.length.toString(),
+                    style: TextStyle(
+                      color: colorScheme.onPrimaryContainer,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Topic grid
+          Expanded(
+            child: showEmptyState || filtered.isEmpty
+                ? _buildEmptyState(context)
+                : GridView.builder(
+                    padding: const EdgeInsets.all(16),
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      mainAxisSpacing: 12,
+                      crossAxisSpacing: 12,
+                      childAspectRatio: 1.4,
+                    ),
+                    itemCount: filtered.length,
+                    itemBuilder: (context, index) {
+                      final topic = filtered[index];
+                      final isSubscribed =
+                          _subscribedTopicIds.contains(topic.id);
+                      final categoryColor = _categories
+                          .firstWhere((c) => c.name == topic.categories.first,
+                              orElse: () => _categories.first)
+                          .color;
+
+                      return _buildTopicCard(
+                        context,
+                        topic,
+                        isSubscribed: isSubscribed,
+                        categoryColor: categoryColor,
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTopicCard(
+    BuildContext context,
+    _MockTopic topic, {
+    required bool isSubscribed,
+    required Color categoryColor,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      elevation: isSubscribed ? 2 : 0.5,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: isSubscribed
+            ? BorderSide(color: colorScheme.primary, width: 2)
+            : BorderSide.none,
+      ),
+      child: InkWell(
+        onTap: () {
+          setState(() {
+            if (isSubscribed) {
+              _subscribedTopicIds.remove(topic.id);
+            } else {
+              _subscribedTopicIds.add(topic.id);
+            }
+          });
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  if (topic.categories.length == 1)
+                    Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: categoryColor.withAlpha(30),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(topic.icon, size: 20, color: categoryColor),
+                    )
+                  else
+                    SizedBox(
+                      width: 24.0 + (topic.categories.length - 1) * 18.0,
+                      height: 32,
+                      child: Stack(
+                        children: [
+                          for (var i = 0; i < topic.categories.length; i++)
+                            Positioned(
+                              left: i * 18.0,
+                              child: Container(
+                                padding: const EdgeInsets.all(4),
+                                decoration: BoxDecoration(
+                                  color: _categories
+                                      .firstWhere(
+                                          (c) => c.name == topic.categories[i],
+                                          orElse: () => _categories.first)
+                                      .color
+                                      .withAlpha(30),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color:
+                                        Theme.of(context).colorScheme.surface,
+                                    width: 1.5,
+                                  ),
+                                ),
+                                child: Icon(
+                                  _categories
+                                      .firstWhere(
+                                          (c) => c.name == topic.categories[i],
+                                          orElse: () => _categories.first)
+                                      .icon,
+                                  size: 16,
+                                  color: _categories
+                                      .firstWhere(
+                                          (c) => c.name == topic.categories[i],
+                                          orElse: () => _categories.first)
+                                      .color,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  const Spacer(),
+                  if (isSubscribed)
+                    Icon(Icons.check_circle,
+                        size: 22, color: colorScheme.primary)
+                  else
+                    Icon(Icons.add_circle_outline,
+                        size: 22, color: colorScheme.onSurface.withAlpha(120)),
+                ],
+              ),
+              const Spacer(),
+              Text(
+                topic.name,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                '${topic.events} events',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).textTheme.bodySmall?.color,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No Topics Found',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _searchQuery.isNotEmpty
+                  ? 'Try a different search term or category'
+                  : 'Try selecting a different category',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).textTheme.bodySmall?.color,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MockCategory {
+  final String name;
+  final IconData icon;
+  final Color color;
+
+  _MockCategory({
+    required this.name,
+    required this.icon,
+    required this.color,
+  });
+}
+
+class _MockTopic {
+  final String id;
+  final String name;
+  final List<String> categories;
+  final int events;
+  final IconData icon;
+
+  _MockTopic({
+    required this.id,
+    required this.name,
+    required this.categories,
+    required this.events,
+    required this.icon,
+  });
+}

--- a/lib/storybook/screens/topics/topics_list.v6.dart
+++ b/lib/storybook/screens/topics/topics_list.v6.dart
@@ -1,0 +1,670 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storybook_toolkit/storybook_toolkit.dart';
+import 'package:squadquest/app_scaffold.dart';
+
+class TopicsListScreenV6 extends ConsumerStatefulWidget {
+  const TopicsListScreenV6({super.key});
+
+  @override
+  ConsumerState<TopicsListScreenV6> createState() => _TopicsListScreenV6State();
+}
+
+class _TopicsListScreenV6State extends ConsumerState<TopicsListScreenV6> {
+  String _searchQuery = '';
+  final _searchController = TextEditingController();
+  final Set<String> _subscribedTopicIds = {};
+
+  // Active facet selections
+  String? _selectedActivityType;
+  String? _selectedSetting;
+  String? _selectedGroupSize;
+
+  static const _activityTypes = [
+    'Physical',
+    'Creative',
+    'Intellectual',
+    'Social',
+  ];
+
+  static const _settings = [
+    'Indoor',
+    'Outdoor',
+    'Either',
+  ];
+
+  static const _groupSizes = [
+    'Small (2-5)',
+    'Medium (6-15)',
+    'Large (15+)',
+  ];
+
+  late final List<_MockTopic> _topics;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _topics = [
+      _MockTopic(
+          id: '1',
+          name: 'Basketball',
+          activityType: 'Physical',
+          setting: 'Either',
+          groupSize: 'Medium (6-15)',
+          events: 8,
+          icon: Icons.sports_basketball),
+      _MockTopic(
+          id: '2',
+          name: 'Soccer',
+          activityType: 'Physical',
+          setting: 'Outdoor',
+          groupSize: 'Large (15+)',
+          events: 12,
+          icon: Icons.sports_soccer),
+      _MockTopic(
+          id: '3',
+          name: 'Tennis',
+          activityType: 'Physical',
+          setting: 'Either',
+          groupSize: 'Small (2-5)',
+          events: 5,
+          icon: Icons.sports_tennis),
+      _MockTopic(
+          id: '4',
+          name: 'Trail Running',
+          activityType: 'Physical',
+          setting: 'Outdoor',
+          groupSize: 'Small (2-5)',
+          events: 6,
+          icon: Icons.directions_run),
+      _MockTopic(
+          id: '5',
+          name: 'Road Running',
+          activityType: 'Physical',
+          setting: 'Outdoor',
+          groupSize: 'Small (2-5)',
+          events: 4,
+          icon: Icons.directions_run),
+      _MockTopic(
+          id: '6',
+          name: 'Swimming',
+          activityType: 'Physical',
+          setting: 'Either',
+          groupSize: 'Small (2-5)',
+          events: 3,
+          icon: Icons.pool),
+      _MockTopic(
+          id: '7',
+          name: 'Hiking',
+          activityType: 'Physical',
+          setting: 'Outdoor',
+          groupSize: 'Medium (6-15)',
+          events: 9,
+          icon: Icons.hiking),
+      _MockTopic(
+          id: '8',
+          name: 'Rock Climbing',
+          activityType: 'Physical',
+          setting: 'Either',
+          groupSize: 'Small (2-5)',
+          events: 4,
+          icon: Icons.terrain),
+      _MockTopic(
+          id: '9',
+          name: 'Camping',
+          activityType: 'Social',
+          setting: 'Outdoor',
+          groupSize: 'Medium (6-15)',
+          events: 3,
+          icon: Icons.cabin),
+      _MockTopic(
+          id: '10',
+          name: 'Kayaking',
+          activityType: 'Physical',
+          setting: 'Outdoor',
+          groupSize: 'Small (2-5)',
+          events: 2,
+          icon: Icons.kayaking),
+      _MockTopic(
+          id: '11',
+          name: 'Board Games',
+          activityType: 'Intellectual',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 7,
+          icon: Icons.extension),
+      _MockTopic(
+          id: '12',
+          name: 'Video Games',
+          activityType: 'Social',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 5,
+          icon: Icons.videogame_asset),
+      _MockTopic(
+          id: '13',
+          name: 'Trivia Night',
+          activityType: 'Intellectual',
+          setting: 'Indoor',
+          groupSize: 'Medium (6-15)',
+          events: 6,
+          icon: Icons.quiz),
+      _MockTopic(
+          id: '14',
+          name: 'Card Games',
+          activityType: 'Intellectual',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 3,
+          icon: Icons.style),
+      _MockTopic(
+          id: '15',
+          name: 'Cooking',
+          activityType: 'Creative',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 8,
+          icon: Icons.soup_kitchen),
+      _MockTopic(
+          id: '16',
+          name: 'Wine Tasting',
+          activityType: 'Social',
+          setting: 'Indoor',
+          groupSize: 'Medium (6-15)',
+          events: 4,
+          icon: Icons.wine_bar),
+      _MockTopic(
+          id: '17',
+          name: 'Coffee Meetup',
+          activityType: 'Social',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 5,
+          icon: Icons.coffee),
+      _MockTopic(
+          id: '18',
+          name: 'Photography',
+          activityType: 'Creative',
+          setting: 'Either',
+          groupSize: 'Small (2-5)',
+          events: 6,
+          icon: Icons.camera_alt),
+      _MockTopic(
+          id: '19',
+          name: 'Painting',
+          activityType: 'Creative',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 3,
+          icon: Icons.brush),
+      _MockTopic(
+          id: '20',
+          name: 'Live Music',
+          activityType: 'Social',
+          setting: 'Either',
+          groupSize: 'Large (15+)',
+          events: 10,
+          icon: Icons.music_note),
+      _MockTopic(
+          id: '21',
+          name: 'Movie Nights',
+          activityType: 'Social',
+          setting: 'Indoor',
+          groupSize: 'Medium (6-15)',
+          events: 7,
+          icon: Icons.movie),
+      _MockTopic(
+          id: '22',
+          name: 'Book Club',
+          activityType: 'Intellectual',
+          setting: 'Indoor',
+          groupSize: 'Small (2-5)',
+          events: 4,
+          icon: Icons.menu_book),
+      _MockTopic(
+          id: '23',
+          name: 'Karaoke',
+          activityType: 'Social',
+          setting: 'Indoor',
+          groupSize: 'Medium (6-15)',
+          events: 5,
+          icon: Icons.mic),
+    ];
+
+    // Pre-subscribe a few
+    _subscribedTopicIds.addAll(['1', '7', '11', '18']);
+  }
+
+  List<_MockTopic> get _filteredTopics {
+    var topics = _topics.toList();
+
+    if (_selectedActivityType != null) {
+      topics =
+          topics.where((t) => t.activityType == _selectedActivityType).toList();
+    }
+    if (_selectedSetting != null) {
+      topics = topics.where((t) => t.setting == _selectedSetting).toList();
+    }
+    if (_selectedGroupSize != null) {
+      topics = topics.where((t) => t.groupSize == _selectedGroupSize).toList();
+    }
+
+    if (_searchQuery.isNotEmpty) {
+      final query = _searchQuery.toLowerCase();
+      topics =
+          topics.where((t) => t.name.toLowerCase().contains(query)).toList();
+    }
+
+    return topics;
+  }
+
+  bool get _hasActiveFilters =>
+      _selectedActivityType != null ||
+      _selectedSetting != null ||
+      _selectedGroupSize != null;
+
+  void _clearFilters() {
+    setState(() {
+      _selectedActivityType = null;
+      _selectedSetting = null;
+      _selectedGroupSize = null;
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showEmptyState = context.knobs.boolean(
+      label: 'Show empty state',
+      initial: false,
+      description: 'Toggle between empty and populated states',
+    );
+
+    final compactFilters = context.knobs.boolean(
+      label: 'Compact filters',
+      initial: false,
+      description: 'Use a more compact filter layout',
+    );
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final filtered = _filteredTopics;
+
+    return AppScaffold(
+      title: 'Topics',
+      body: Column(
+        children: [
+          // Header with search
+          Container(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withAlpha(13),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Discover Topics',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Use filters to find exactly what you\'re looking for',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).textTheme.bodySmall?.color,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search topics...',
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: _searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              setState(() => _searchQuery = '');
+                            },
+                          )
+                        : null,
+                  ),
+                  onChanged: (value) => setState(() => _searchQuery = value),
+                ),
+              ],
+            ),
+          ),
+
+          // Facet filters
+          Container(
+            padding: EdgeInsets.all(compactFilters ? 8 : 12),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerLow,
+              border: Border(
+                bottom: BorderSide(
+                  color: colorScheme.outlineVariant,
+                  width: 0.5,
+                ),
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Activity Type
+                _buildFacetRow(
+                  context,
+                  label: 'Activity',
+                  options: _activityTypes,
+                  selected: _selectedActivityType,
+                  compact: compactFilters,
+                  onSelected: (value) =>
+                      setState(() => _selectedActivityType = value),
+                ),
+                SizedBox(height: compactFilters ? 6 : 10),
+
+                // Setting
+                _buildFacetRow(
+                  context,
+                  label: 'Setting',
+                  options: _settings,
+                  selected: _selectedSetting,
+                  compact: compactFilters,
+                  onSelected: (value) =>
+                      setState(() => _selectedSetting = value),
+                ),
+                SizedBox(height: compactFilters ? 6 : 10),
+
+                // Group Size
+                _buildFacetRow(
+                  context,
+                  label: 'Group Size',
+                  options: _groupSizes,
+                  selected: _selectedGroupSize,
+                  compact: compactFilters,
+                  onSelected: (value) =>
+                      setState(() => _selectedGroupSize = value),
+                ),
+
+                if (_hasActiveFilters) ...[
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Text(
+                        '${filtered.length} results',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: colorScheme.onSurface.withAlpha(150),
+                        ),
+                      ),
+                      const Spacer(),
+                      TextButton.icon(
+                        onPressed: _clearFilters,
+                        icon: const Icon(Icons.clear_all, size: 16),
+                        label: const Text('Clear filters'),
+                        style: TextButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          visualDensity: VisualDensity.compact,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+
+          // Results list
+          Expanded(
+            child: showEmptyState || filtered.isEmpty
+                ? _buildEmptyState(context)
+                : ListView.separated(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: filtered.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final topic = filtered[index];
+                      final isSubscribed =
+                          _subscribedTopicIds.contains(topic.id);
+
+                      return _buildTopicTile(
+                        context,
+                        topic,
+                        isSubscribed: isSubscribed,
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFacetRow(
+    BuildContext context, {
+    required String label,
+    required List<String> options,
+    required String? selected,
+    required bool compact,
+    required ValueChanged<String?> onSelected,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: compact ? 60 : 76,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: compact ? 11 : 12,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(180),
+            ),
+          ),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: options.map((option) {
+                final isSelected = selected == option;
+                return Padding(
+                  padding: const EdgeInsets.only(right: 6),
+                  child: ChoiceChip(
+                    label: Text(
+                      option,
+                      style: TextStyle(fontSize: compact ? 11 : 12),
+                    ),
+                    selected: isSelected,
+                    onSelected: (_) {
+                      onSelected(isSelected ? null : option);
+                    },
+                    visualDensity: compact
+                        ? VisualDensity.compact
+                        : VisualDensity.standard,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTopicTile(
+    BuildContext context,
+    _MockTopic topic, {
+    required bool isSubscribed,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return ListTile(
+      leading: Container(
+        width: 44,
+        height: 44,
+        decoration: BoxDecoration(
+          color: isSubscribed
+              ? colorScheme.primaryContainer
+              : colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(
+          topic.icon,
+          color: isSubscribed
+              ? colorScheme.onPrimaryContainer
+              : colorScheme.onSurface.withAlpha(180),
+        ),
+      ),
+      title: Text(
+        topic.name,
+        style: const TextStyle(fontWeight: FontWeight.w600),
+      ),
+      subtitle: Row(
+        children: [
+          _buildBadge(context, topic.activityType),
+          const SizedBox(width: 4),
+          _buildBadge(context, topic.setting),
+          const SizedBox(width: 4),
+          _buildBadge(context, topic.groupSize.split(' ').first),
+          const Spacer(),
+          Text(
+            '${topic.events} events',
+            style: TextStyle(
+              fontSize: 11,
+              color: colorScheme.onSurface.withAlpha(120),
+            ),
+          ),
+        ],
+      ),
+      trailing: IconButton(
+        icon: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: isSubscribed
+              ? Icon(Icons.check_circle,
+                  key: const ValueKey('sub'), color: colorScheme.primary)
+              : Icon(Icons.add_circle_outline,
+                  key: const ValueKey('unsub'),
+                  color: colorScheme.onSurface.withAlpha(120)),
+        ),
+        onPressed: () {
+          setState(() {
+            if (isSubscribed) {
+              _subscribedTopicIds.remove(topic.id);
+            } else {
+              _subscribedTopicIds.add(topic.id);
+            }
+          });
+        },
+      ),
+      onTap: () {
+        setState(() {
+          if (isSubscribed) {
+            _subscribedTopicIds.remove(topic.id);
+          } else {
+            _subscribedTopicIds.add(topic.id);
+          }
+        });
+      },
+    );
+  }
+
+  Widget _buildBadge(BuildContext context, String text) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 10,
+          color: colorScheme.onSurface.withAlpha(160),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.filter_list_off,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No Matching Topics',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _hasActiveFilters
+                  ? 'Try adjusting your filters or search term'
+                  : 'Try a different search term',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).textTheme.bodySmall?.color,
+                  ),
+            ),
+            if (_hasActiveFilters) ...[
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: _clearFilters,
+                icon: const Icon(Icons.clear_all),
+                label: const Text('Clear all filters'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MockTopic {
+  final String id;
+  final String name;
+  final String activityType;
+  final String setting;
+  final String groupSize;
+  final int events;
+  final IconData icon;
+
+  _MockTopic({
+    required this.id,
+    required this.name,
+    required this.activityType,
+    required this.setting,
+    required this.groupSize,
+    required this.events,
+    required this.icon,
+  });
+}

--- a/lib/storybook/screens/topics/topics_list.v7.dart
+++ b/lib/storybook/screens/topics/topics_list.v7.dart
@@ -1,0 +1,1238 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storybook_toolkit/storybook_toolkit.dart';
+
+import 'package:squadquest/app_scaffold.dart';
+import 'package:squadquest/controllers/topics.dart';
+
+// Mock data models
+class _MockCategory {
+  final String name;
+  final IconData icon;
+  final Color color;
+
+  _MockCategory({
+    required this.name,
+    required this.icon,
+    required this.color,
+  });
+}
+
+class _MockTopic {
+  final String id;
+  final String slug;
+  final String displayName;
+  final List<String> categories;
+  final int events;
+  final IconData icon;
+
+  _MockTopic({
+    required this.id,
+    required this.slug,
+    required this.displayName,
+    required this.categories,
+    required this.events,
+    required this.icon,
+  });
+}
+
+// Semantic similarity map: query substring → [(topicId, similarity)]
+const _semanticMap = <String, List<(String, double)>>{
+  'jog': [('5', 0.87), ('4', 0.82)],
+  'jogging': [('5', 0.92), ('4', 0.88)],
+  'hike': [('7', 0.90), ('4', 0.68)],
+  'climb': [('8', 0.88), ('7', 0.62)],
+  'bike': [('10', 0.85)],
+  'exercise': [('4', 0.75), ('5', 0.72), ('6', 0.70), ('10', 0.68)],
+  'outdoor': [('7', 0.80), ('4', 0.78), ('8', 0.75), ('9', 0.73), ('10', 0.70)],
+  'games': [('11', 0.90), ('12', 0.85), ('14', 0.82), ('13', 0.75)],
+  'food': [('15', 0.82), ('16', 0.70), ('17', 0.68)],
+  'fitness': [('4', 0.80), ('5', 0.78), ('6', 0.75)],
+  'music': [('20', 0.90), ('23', 0.72)],
+  'art': [('18', 0.80), ('19', 0.85)],
+};
+
+// Related topics map (neighborhoods): topicId → [related topicIds]
+const _relatedMap = <String, List<String>>{
+  '1': ['2', '3', '6'], // Basketball → Soccer, Tennis, Swimming (Sports)
+  '2': ['1', '3'], // Soccer → Basketball, Tennis
+  '3': ['1', '2'], // Tennis → Basketball, Soccer
+  '4': ['5', '7', '8'], // Trail Running → Road Running, Hiking, Rock Climbing
+  '5': ['4', '6'], // Road Running → Trail Running, Swimming
+  '6': ['5', '10'], // Swimming → Road Running, Kayaking
+  '7': ['8', '9', '4'], // Hiking → Rock Climbing, Camping, Trail Running
+  '8': ['7', '4'], // Rock Climbing → Hiking, Trail Running
+  '9': ['7', '10'], // Camping → Hiking, Kayaking
+  '10': ['9', '7', '6'], // Kayaking → Camping, Hiking, Swimming
+  '11': ['12', '14', '13'], // Board Games → Video Games, Card Games, Trivia
+  '12': ['11', '14'], // Video Games → Board Games, Card Games
+  '13': ['11', '23', '22'], // Trivia Night → Board Games, Karaoke, Book Club
+  '14': ['11', '12'], // Card Games → Board Games, Video Games
+  '15': ['16', '17'], // Cooking → Wine Tasting, Coffee Meetup
+  '16': ['15', '17'], // Wine Tasting → Cooking, Coffee Meetup
+  '17': ['15', '16'], // Coffee Meetup → Cooking, Wine Tasting
+  '18': ['19'], // Photography → Painting
+  '19': ['18', '20'], // Painting → Photography, Live Music
+  '20': ['23', '21'], // Live Music → Karaoke, Movie Nights
+  '21': ['22', '20'], // Movie Nights → Book Club, Live Music
+  '22': ['21', '13'], // Book Club → Movie Nights, Trivia Night
+  '23': ['20', '13'], // Karaoke → Live Music, Trivia Night
+};
+
+class TopicsListScreenV7 extends ConsumerStatefulWidget {
+  const TopicsListScreenV7({super.key});
+
+  @override
+  ConsumerState<TopicsListScreenV7> createState() => _TopicsListScreenV7State();
+}
+
+class _TopicsListScreenV7State extends ConsumerState<TopicsListScreenV7> {
+  String _searchQuery = '';
+  final _searchController = TextEditingController();
+  String _selectedCategory = 'All';
+  final Set<String> _subscribedTopicIds = {'1', '7', '11', '18'};
+
+  // Search state
+  List<TopicSuggestion> _trigramResults = [];
+  List<TopicSuggestion> _semanticResults = [];
+  bool _isSearching = false;
+  bool _hasSearched = false;
+  Timer? _trigramDebounce;
+  Timer? _semanticDebounce;
+
+  // Neighborhoods
+  String? _expandedTopicId;
+  List<_MockTopic> _relatedTopics = [];
+  bool _loadingRelated = false;
+
+  // Knob state
+  bool _simulateSemanticDelay = false;
+
+  late final List<_MockCategory> _categories;
+  late final List<_MockTopic> _topics;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _categories = [
+      _MockCategory(name: 'All', icon: Icons.apps, color: Colors.blueGrey),
+      _MockCategory(
+          name: 'Sports', icon: Icons.sports_basketball, color: Colors.orange),
+      _MockCategory(
+          name: 'Outdoors', icon: Icons.landscape, color: Colors.green),
+      _MockCategory(name: 'Games', icon: Icons.casino, color: Colors.purple),
+      _MockCategory(
+          name: 'Food & Drink', icon: Icons.restaurant, color: Colors.red),
+      _MockCategory(name: 'Arts', icon: Icons.palette, color: Colors.teal),
+      _MockCategory(name: 'Social', icon: Icons.people, color: Colors.indigo),
+    ];
+
+    _topics = [
+      _MockTopic(
+          id: '1',
+          slug: 'basketball',
+          displayName: 'Basketball',
+          categories: ['Sports'],
+          events: 8,
+          icon: Icons.sports_basketball),
+      _MockTopic(
+          id: '2',
+          slug: 'soccer',
+          displayName: 'Soccer',
+          categories: ['Sports'],
+          events: 12,
+          icon: Icons.sports_soccer),
+      _MockTopic(
+          id: '3',
+          slug: 'tennis',
+          displayName: 'Tennis',
+          categories: ['Sports'],
+          events: 5,
+          icon: Icons.sports_tennis),
+      _MockTopic(
+          id: '4',
+          slug: 'trail-running',
+          displayName: 'Trail Running',
+          categories: ['Sports', 'Outdoors'],
+          events: 6,
+          icon: Icons.directions_run),
+      _MockTopic(
+          id: '5',
+          slug: 'road-running',
+          displayName: 'Road Running',
+          categories: ['Sports'],
+          events: 4,
+          icon: Icons.directions_run),
+      _MockTopic(
+          id: '6',
+          slug: 'swimming',
+          displayName: 'Swimming',
+          categories: ['Sports'],
+          events: 3,
+          icon: Icons.pool),
+      _MockTopic(
+          id: '7',
+          slug: 'hiking',
+          displayName: 'Hiking',
+          categories: ['Outdoors'],
+          events: 9,
+          icon: Icons.hiking),
+      _MockTopic(
+          id: '8',
+          slug: 'rock-climbing',
+          displayName: 'Rock Climbing',
+          categories: ['Sports', 'Outdoors'],
+          events: 4,
+          icon: Icons.terrain),
+      _MockTopic(
+          id: '9',
+          slug: 'camping',
+          displayName: 'Camping',
+          categories: ['Outdoors'],
+          events: 3,
+          icon: Icons.cabin),
+      _MockTopic(
+          id: '10',
+          slug: 'kayaking',
+          displayName: 'Kayaking',
+          categories: ['Sports', 'Outdoors'],
+          events: 2,
+          icon: Icons.kayaking),
+      _MockTopic(
+          id: '11',
+          slug: 'board-games',
+          displayName: 'Board Games',
+          categories: ['Games'],
+          events: 7,
+          icon: Icons.extension),
+      _MockTopic(
+          id: '12',
+          slug: 'video-games',
+          displayName: 'Video Games',
+          categories: ['Games'],
+          events: 5,
+          icon: Icons.videogame_asset),
+      _MockTopic(
+          id: '13',
+          slug: 'trivia-night',
+          displayName: 'Trivia Night',
+          categories: ['Games', 'Social'],
+          events: 6,
+          icon: Icons.quiz),
+      _MockTopic(
+          id: '14',
+          slug: 'card-games',
+          displayName: 'Card Games',
+          categories: ['Games'],
+          events: 3,
+          icon: Icons.style),
+      _MockTopic(
+          id: '15',
+          slug: 'cooking',
+          displayName: 'Cooking',
+          categories: ['Food & Drink'],
+          events: 8,
+          icon: Icons.soup_kitchen),
+      _MockTopic(
+          id: '16',
+          slug: 'wine-tasting',
+          displayName: 'Wine Tasting',
+          categories: ['Food & Drink'],
+          events: 4,
+          icon: Icons.wine_bar),
+      _MockTopic(
+          id: '17',
+          slug: 'coffee-meetup',
+          displayName: 'Coffee Meetup',
+          categories: ['Food & Drink'],
+          events: 5,
+          icon: Icons.coffee),
+      _MockTopic(
+          id: '18',
+          slug: 'photography',
+          displayName: 'Photography',
+          categories: ['Arts'],
+          events: 6,
+          icon: Icons.camera_alt),
+      _MockTopic(
+          id: '19',
+          slug: 'painting',
+          displayName: 'Painting',
+          categories: ['Arts'],
+          events: 3,
+          icon: Icons.brush),
+      _MockTopic(
+          id: '20',
+          slug: 'live-music',
+          displayName: 'Live Music',
+          categories: ['Arts', 'Social'],
+          events: 10,
+          icon: Icons.music_note),
+      _MockTopic(
+          id: '21',
+          slug: 'movie-nights',
+          displayName: 'Movie Nights',
+          categories: ['Social'],
+          events: 7,
+          icon: Icons.movie),
+      _MockTopic(
+          id: '22',
+          slug: 'book-club',
+          displayName: 'Book Club',
+          categories: ['Social'],
+          events: 4,
+          icon: Icons.menu_book),
+      _MockTopic(
+          id: '23',
+          slug: 'karaoke',
+          displayName: 'Karaoke',
+          categories: ['Social'],
+          events: 5,
+          icon: Icons.mic),
+    ];
+  }
+
+  @override
+  void dispose() {
+    _trigramDebounce?.cancel();
+    _semanticDebounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  bool get _isSearchActive => _searchQuery.isNotEmpty;
+
+  _MockTopic? _topicById(String id) {
+    return _topics.where((t) => t.id == id).firstOrNull;
+  }
+
+  List<_MockTopic> get _filteredTopics {
+    var topics = _topics.toList();
+    if (_selectedCategory != 'All') {
+      topics = topics
+          .where((t) => t.categories.contains(_selectedCategory))
+          .toList();
+    }
+    return topics;
+  }
+
+  // --- Search logic ---
+
+  void _onSearchChanged(String value) {
+    final query = value.trim();
+    setState(() => _searchQuery = query);
+
+    if (query.isEmpty) {
+      setState(() {
+        _trigramResults = [];
+        _semanticResults = [];
+        _hasSearched = false;
+        _isSearching = false;
+      });
+      return;
+    }
+
+    _trigramDebounce?.cancel();
+    _trigramDebounce = Timer(const Duration(milliseconds: 200), () {
+      _runTrigramSearch(query);
+    });
+
+    _semanticDebounce?.cancel();
+    if (query.length >= 3) {
+      _semanticDebounce = Timer(const Duration(milliseconds: 500), () {
+        _runSemanticSearch(query);
+      });
+    }
+  }
+
+  void _runTrigramSearch(String query) {
+    final lowerQuery = query.toLowerCase();
+
+    // Filter by selected category too
+    var searchPool = _topics.toList();
+    if (_selectedCategory != 'All') {
+      searchPool = searchPool
+          .where((t) => t.categories.contains(_selectedCategory))
+          .toList();
+    }
+
+    final results = searchPool
+        .where((t) =>
+            t.displayName.toLowerCase().contains(lowerQuery) ||
+            t.slug.contains(lowerQuery))
+        .map((t) => TopicSuggestion(
+              id: t.id,
+              name: t.slug,
+              displayName: t.displayName,
+              similarity:
+                  _trigramSimilarity(t.displayName.toLowerCase(), lowerQuery),
+            ))
+        .toList()
+      ..sort((a, b) => b.similarity.compareTo(a.similarity));
+
+    if (mounted && _searchQuery == query) {
+      setState(() {
+        _trigramResults = results;
+        _hasSearched = true;
+      });
+    }
+  }
+
+  double _trigramSimilarity(String text, String query) {
+    if (text == query) return 1.0;
+    if (text.startsWith(query)) return 0.9;
+    if (text.contains(query)) return 0.7;
+    return 0.5;
+  }
+
+  Future<void> _runSemanticSearch(String query) async {
+    if (_trigramResults.length >= 3) return;
+
+    setState(() => _isSearching = true);
+
+    if (_simulateSemanticDelay) {
+      await Future.delayed(const Duration(milliseconds: 500));
+    }
+
+    if (!mounted || _searchQuery != query) return;
+
+    final lowerQuery = query.toLowerCase();
+    final List<TopicSuggestion> results = [];
+
+    for (final entry in _semanticMap.entries) {
+      if (lowerQuery.contains(entry.key) || entry.key.contains(lowerQuery)) {
+        for (final (topicId, similarity) in entry.value) {
+          // Filter by category if one is selected
+          if (_selectedCategory != 'All') {
+            final topic = _topicById(topicId);
+            if (topic == null ||
+                !topic.categories.contains(_selectedCategory)) {
+              continue;
+            }
+          }
+          final topic = _topicById(topicId);
+          if (topic != null && !results.any((r) => r.id == topicId)) {
+            results.add(TopicSuggestion(
+              id: topicId,
+              name: topic.slug,
+              displayName: topic.displayName,
+              similarity: similarity,
+            ));
+          }
+        }
+      }
+    }
+
+    results.sort((a, b) => b.similarity.compareTo(a.similarity));
+
+    setState(() {
+      _semanticResults = results;
+      _isSearching = false;
+    });
+  }
+
+  // --- Neighborhoods ---
+
+  Future<void> _loadRelatedTopics(String topicId) async {
+    if (_expandedTopicId == topicId) {
+      setState(() {
+        _expandedTopicId = null;
+        _relatedTopics = [];
+      });
+      return;
+    }
+
+    setState(() {
+      _expandedTopicId = topicId;
+      _loadingRelated = true;
+      _relatedTopics = [];
+    });
+
+    await Future.delayed(const Duration(milliseconds: 200));
+
+    if (!mounted || _expandedTopicId != topicId) return;
+
+    final relatedIds = _relatedMap[topicId] ?? [];
+    final results = relatedIds
+        .map((id) => _topicById(id))
+        .where((t) => t != null)
+        .cast<_MockTopic>()
+        .toList();
+
+    setState(() {
+      _relatedTopics = results;
+      _loadingRelated = false;
+    });
+  }
+
+  // --- Actions ---
+
+  void _toggleSubscription(String topicId) {
+    setState(() {
+      if (_subscribedTopicIds.contains(topicId)) {
+        _subscribedTopicIds.remove(topicId);
+      } else {
+        _subscribedTopicIds.add(topicId);
+      }
+    });
+  }
+
+  void _showCreateDialog() {
+    final displayName = _searchController.text.trim();
+    if (displayName.isEmpty) return;
+
+    final highMatches = <TopicSuggestion>[
+      ..._trigramResults.where((s) => s.similarity > 0.7),
+      ..._semanticResults.where((s) => s.similarity > 0.7),
+    ];
+
+    if (highMatches.isNotEmpty) {
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Similar topic exists'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                  'This looks similar to existing ${highMatches.length == 1 ? 'topic' : 'topics'}:'),
+              const SizedBox(height: 8),
+              ...highMatches.map((m) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Text('• ${m.label}',
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
+                  )),
+              const SizedBox(height: 12),
+              const Text('Create a new topic anyway?'),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context, true);
+                _createTopic(displayName);
+              },
+              child: const Text('Create anyway'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      _createTopic(displayName);
+    }
+  }
+
+  void _createTopic(String displayName) {
+    final slug = displayName
+        .toLowerCase()
+        .trim()
+        .replaceAll(RegExp(r'[^a-z0-9\s\-]'), '')
+        .replaceAll(RegExp(r'\s+'), '-');
+
+    final newId = 'new-${DateTime.now().millisecondsSinceEpoch}';
+    final newTopic = _MockTopic(
+      id: newId,
+      slug: slug,
+      displayName: displayName,
+      categories: [_selectedCategory == 'All' ? 'Social' : _selectedCategory],
+      events: 0,
+      icon: Icons.tag,
+    );
+
+    setState(() {
+      _topics.add(newTopic);
+      _subscribedTopicIds.add(newId);
+      _searchController.clear();
+      _searchQuery = '';
+      _trigramResults = [];
+      _semanticResults = [];
+      _hasSearched = false;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Created and subscribed to "$displayName"')),
+    );
+  }
+
+  // --- Build ---
+
+  @override
+  Widget build(BuildContext context) {
+    final showSubscribedOnly = context.knobs.boolean(
+      label: 'Show subscribed only',
+      initial: false,
+      description: 'Filter to subscribed topics in grid mode',
+    );
+
+    _simulateSemanticDelay = context.knobs.boolean(
+      label: 'Simulate semantic delay',
+      initial: false,
+      description: '500ms delay on semantic search results',
+    );
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    var gridTopics = _filteredTopics;
+    if (showSubscribedOnly) {
+      gridTopics =
+          gridTopics.where((t) => _subscribedTopicIds.contains(t.id)).toList();
+    }
+
+    // Deduplicate search results
+    final allSuggestionIds = <String>{};
+    final trigramOnly = <TopicSuggestion>[];
+    final semanticOnly = <TopicSuggestion>[];
+
+    for (final result in _trigramResults) {
+      if (allSuggestionIds.add(result.id)) {
+        trigramOnly.add(result);
+      }
+    }
+    for (final result in _semanticResults) {
+      if (allSuggestionIds.add(result.id)) {
+        semanticOnly.add(result);
+      }
+    }
+
+    final showCreateButton =
+        _hasSearched && _searchController.text.trim().isNotEmpty;
+
+    return AppScaffold(
+      title: 'Topics',
+      body: Column(
+        children: [
+          // Header with search
+          Container(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withAlpha(13),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Browse Topics',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Explore categories and subscribe to topics you love',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).textTheme.bodySmall?.color,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search topics...',
+                    filled: true,
+                    fillColor: colorScheme.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: _isSearching
+                        ? const Padding(
+                            padding: EdgeInsets.all(12),
+                            child: SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                          )
+                        : _searchQuery.isNotEmpty
+                            ? IconButton(
+                                icon: const Icon(Icons.clear),
+                                onPressed: () {
+                                  _searchController.clear();
+                                  _onSearchChanged('');
+                                },
+                              )
+                            : null,
+                  ),
+                  onChanged: _onSearchChanged,
+                ),
+              ],
+            ),
+          ),
+
+          // Category bar — always visible but visually secondary during search
+          AnimatedOpacity(
+            opacity: _isSearchActive ? 0.6 : 1.0,
+            duration: const Duration(milliseconds: 200),
+            child: SizedBox(
+              height: 100,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                separatorBuilder: (_, __) => const SizedBox(width: 12),
+                itemCount: _categories.length,
+                itemBuilder: (context, index) {
+                  final category = _categories[index];
+                  final isSelected = _selectedCategory == category.name;
+
+                  return GestureDetector(
+                    onTap: () {
+                      setState(() => _selectedCategory = category.name);
+                      // Re-run search if active
+                      if (_isSearchActive) {
+                        _trigramDebounce?.cancel();
+                        _semanticDebounce?.cancel();
+                        _runTrigramSearch(_searchQuery);
+                        if (_searchQuery.length >= 3) {
+                          _runSemanticSearch(_searchQuery);
+                        }
+                      }
+                    },
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      width: 76,
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? colorScheme.primaryContainer
+                            : colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(16),
+                        border: isSelected
+                            ? Border.all(color: colorScheme.primary, width: 2)
+                            : null,
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            category.icon,
+                            color: isSelected
+                                ? colorScheme.primary
+                                : category.color,
+                            size: 28,
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            category.name,
+                            style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: isSelected
+                                  ? FontWeight.bold
+                                  : FontWeight.w500,
+                              color: isSelected
+                                  ? colorScheme.primary
+                                  : colorScheme.onSurface,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+
+          // Main content area
+          Expanded(
+            child: _isSearchActive
+                ? _buildSearchResults(
+                    trigramOnly, semanticOnly, showCreateButton)
+                : _buildCategoryGrid(gridTopics),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // --- Grid mode (no search) ---
+
+  Widget _buildCategoryGrid(List<_MockTopic> topics) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (topics.isEmpty) {
+      return _buildEmptyState();
+    }
+
+    return Column(
+      children: [
+        // Topic count header
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Row(
+            children: [
+              Text(
+                _selectedCategory == 'All' ? 'All Topics' : _selectedCategory,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  topics.length.toString(),
+                  style: TextStyle(
+                    color: colorScheme.onPrimaryContainer,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Grid
+        Expanded(
+          child: GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              mainAxisSpacing: 12,
+              crossAxisSpacing: 12,
+              childAspectRatio: 1.3,
+            ),
+            itemCount: topics.length,
+            itemBuilder: (context, index) {
+              final topic = topics[index];
+              final isSubscribed = _subscribedTopicIds.contains(topic.id);
+              final isExpanded = _expandedTopicId == topic.id;
+              final categoryColor = _categories
+                  .firstWhere((c) => c.name == topic.categories.first,
+                      orElse: () => _categories.first)
+                  .color;
+
+              return _buildTopicCard(
+                topic,
+                isSubscribed: isSubscribed,
+                isExpanded: isExpanded,
+                categoryColor: categoryColor,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTopicCard(
+    _MockTopic topic, {
+    required bool isSubscribed,
+    required bool isExpanded,
+    required Color categoryColor,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      elevation: isSubscribed ? 2 : 0.5,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: isSubscribed
+            ? BorderSide(color: colorScheme.primary, width: 2)
+            : BorderSide.none,
+      ),
+      child: InkWell(
+        onTap: () => _toggleSubscription(topic.id),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  // Category icons
+                  if (topic.categories.length == 1)
+                    Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: categoryColor.withAlpha(30),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(topic.icon, size: 20, color: categoryColor),
+                    )
+                  else
+                    SizedBox(
+                      width: 24.0 + (topic.categories.length - 1) * 18.0,
+                      height: 32,
+                      child: Stack(
+                        children: [
+                          for (var i = 0; i < topic.categories.length; i++)
+                            Positioned(
+                              left: i * 18.0,
+                              child: Container(
+                                padding: const EdgeInsets.all(4),
+                                decoration: BoxDecoration(
+                                  color: _categories
+                                      .firstWhere(
+                                          (c) => c.name == topic.categories[i],
+                                          orElse: () => _categories.first)
+                                      .color
+                                      .withAlpha(30),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color: colorScheme.surface,
+                                    width: 1.5,
+                                  ),
+                                ),
+                                child: Icon(
+                                  _categories
+                                      .firstWhere(
+                                          (c) => c.name == topic.categories[i],
+                                          orElse: () => _categories.first)
+                                      .icon,
+                                  size: 16,
+                                  color: _categories
+                                      .firstWhere(
+                                          (c) => c.name == topic.categories[i],
+                                          orElse: () => _categories.first)
+                                      .color,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  const Spacer(),
+                  // Explore icon
+                  InkWell(
+                    onTap: () => _showNeighborhoodSheet(topic.id),
+                    borderRadius: BorderRadius.circular(12),
+                    child: Icon(
+                      Icons.explore,
+                      size: 20,
+                      color: colorScheme.onSurface.withAlpha(120),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  if (isSubscribed)
+                    Icon(Icons.check_circle,
+                        size: 22, color: colorScheme.primary)
+                  else
+                    Icon(Icons.add_circle_outline,
+                        size: 22, color: colorScheme.onSurface.withAlpha(120)),
+                ],
+              ),
+              const Spacer(),
+              Text(
+                topic.displayName,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                '${topic.events} events',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).textTheme.bodySmall?.color,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showNeighborhoodSheet(String topicId) {
+    final topic = _topicById(topicId);
+    if (topic == null) return;
+
+    final relatedIds = _relatedMap[topicId] ?? [];
+    final relatedTopics = relatedIds
+        .map((id) => _topicById(id))
+        .where((t) => t != null)
+        .cast<_MockTopic>()
+        .toList();
+
+    showModalBottomSheet(
+      context: context,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.explore,
+                          color: Theme.of(context).colorScheme.primary),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Related to ${topic.displayName}',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (relatedTopics.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Text('No related topics found',
+                          style: TextStyle(fontStyle: FontStyle.italic)),
+                    )
+                  else
+                    ...relatedTopics.map((related) {
+                      final isSubscribed =
+                          _subscribedTopicIds.contains(related.id);
+                      final relatedCategoryColor = _categories
+                          .firstWhere((c) => c.name == related.categories.first,
+                              orElse: () => _categories.first)
+                          .color;
+
+                      return ListTile(
+                        leading: Container(
+                          padding: const EdgeInsets.all(6),
+                          decoration: BoxDecoration(
+                            color: relatedCategoryColor.withAlpha(30),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Icon(related.icon,
+                              size: 20, color: relatedCategoryColor),
+                        ),
+                        title: Text(related.displayName),
+                        subtitle: Text('${related.events} events'),
+                        trailing: Switch(
+                          value: isSubscribed,
+                          onChanged: (_) {
+                            _toggleSubscription(related.id);
+                            setSheetState(() {});
+                          },
+                        ),
+                      );
+                    }),
+                  const SizedBox(height: 8),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  // --- Search mode ---
+
+  Widget _buildSearchResults(List<TopicSuggestion> trigramOnly,
+      List<TopicSuggestion> semanticOnly, bool showCreateButton) {
+    return ListView(
+      children: [
+        // Trigram results
+        if (_hasSearched && trigramOnly.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'Search Results',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+          ),
+          ...trigramOnly.map((s) => _buildSearchResultTile(s)),
+        ],
+
+        // Semantic results
+        if (semanticOnly.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'Similar Topics',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          ...semanticOnly.map((s) => _buildSearchResultTile(s)),
+        ],
+
+        // No results
+        if (_hasSearched &&
+            trigramOnly.isEmpty &&
+            semanticOnly.isEmpty &&
+            !_isSearching)
+          const Padding(
+            padding: EdgeInsets.all(24),
+            child: Text(
+              'No topics found. Try different search terms.',
+              textAlign: TextAlign.center,
+            ),
+          ),
+
+        // Create button
+        if (showCreateButton)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: OutlinedButton.icon(
+              onPressed: _showCreateDialog,
+              icon: const Icon(Icons.add, size: 18),
+              label: Text('Create "${_searchController.text.trim()}"'),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildSearchResultTile(TopicSuggestion suggestion) {
+    final isSubscribed = _subscribedTopicIds.contains(suggestion.id);
+    final isExpanded = _expandedTopicId == suggestion.id;
+    final topic = _topicById(suggestion.id);
+    final eventCount = topic?.events ?? 0;
+
+    // Similarity indicator
+    final TextStyle? subtitleStyle;
+    final String? subtitleText;
+    if (suggestion.similarity > 0.85) {
+      subtitleStyle = TextStyle(
+        color: Theme.of(context).colorScheme.error,
+        fontSize: 12,
+      );
+      subtitleText = 'Very similar match';
+    } else if (suggestion.similarity > 0.7) {
+      subtitleStyle = TextStyle(
+        color: Theme.of(context).colorScheme.tertiary,
+        fontSize: 12,
+      );
+      subtitleText = 'Similar match';
+    } else {
+      subtitleStyle = null;
+      subtitleText = null;
+    }
+
+    final subtitle = subtitleText != null
+        ? subtitleText + (eventCount > 0 ? ' · $eventCount events' : '')
+        : (eventCount > 0 ? '$eventCount events' : null);
+
+    return Column(
+      children: [
+        ListTile(
+          title: Text(suggestion.label),
+          subtitle:
+              subtitle != null ? Text(subtitle, style: subtitleStyle) : null,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(
+                  isExpanded ? Icons.expand_less : Icons.explore,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                tooltip: 'Related topics',
+                onPressed: () => _loadRelatedTopics(suggestion.id),
+              ),
+              Switch(
+                value: isSubscribed,
+                onChanged: (_) => _toggleSubscription(suggestion.id),
+              ),
+            ],
+          ),
+        ),
+        if (isExpanded) _buildRelatedTopicsPanel(),
+      ],
+    );
+  }
+
+  Widget _buildRelatedTopicsPanel() {
+    if (_loadingRelated) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+
+    if (_relatedTopics.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32, vertical: 8),
+        child: Text(
+          'No related topics found',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(left: 24, right: 16, bottom: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+            child: Text(
+              'Related Topics',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          ..._relatedTopics.map((related) {
+            final isSubscribed = _subscribedTopicIds.contains(related.id);
+
+            return ListTile(
+              dense: true,
+              title: Text(related.displayName),
+              trailing: Switch(
+                value: isSubscribed,
+                onChanged: (_) => _toggleSubscription(related.id),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No Topics Found',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Try selecting a different category',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).textTheme.bodySmall?.color,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/storybook/screens/topics/topics_search.dart
+++ b/lib/storybook/screens/topics/topics_search.dart
@@ -1,0 +1,686 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storybook_toolkit/storybook_toolkit.dart';
+
+import 'package:squadquest/app_scaffold.dart';
+import 'package:squadquest/controllers/topics.dart';
+
+// Mock topic data with display names and slugs
+class _MockTopic {
+  final String id;
+  final String slug;
+  final String displayName;
+  final int events;
+  bool subscribed;
+
+  _MockTopic({
+    required this.id,
+    required this.slug,
+    required this.displayName,
+    required this.events,
+    this.subscribed = false,
+  });
+
+  String get label => displayName;
+}
+
+// Pre-built mock data
+final _allMockTopics = <_MockTopic>[
+  _MockTopic(id: 't1', slug: 'running', displayName: 'Running', events: 8),
+  _MockTopic(
+      id: 't2', slug: 'trail-running', displayName: 'Trail Running', events: 3),
+  _MockTopic(id: 't3', slug: 'hiking', displayName: 'Hiking', events: 12),
+  _MockTopic(
+      id: 't4', slug: 'rock-climbing', displayName: 'Rock Climbing', events: 5),
+  _MockTopic(
+      id: 't5', slug: 'board-games', displayName: 'Board Games', events: 7),
+  _MockTopic(
+      id: 't6', slug: 'photography', displayName: 'Photography', events: 4),
+  _MockTopic(id: 't7', slug: 'cycling', displayName: 'Cycling', events: 6),
+  _MockTopic(
+      id: 't8', slug: 'cross-country', displayName: 'Cross Country', events: 2),
+  _MockTopic(id: 't9', slug: 'yoga', displayName: 'Yoga', events: 9),
+  _MockTopic(id: 't10', slug: 'cooking', displayName: 'Cooking', events: 3),
+  _MockTopic(
+      id: 't11', slug: 'movie-nights', displayName: 'Movie Nights', events: 5),
+  _MockTopic(id: 't12', slug: 'swimming', displayName: 'Swimming', events: 4),
+];
+
+// Semantic similarity map: query substring → [(topicId, similarity)]
+const _semanticMap = <String, List<(String, double)>>{
+  'jog': [('t1', 0.87), ('t2', 0.72)],
+  'jogging': [('t1', 0.92), ('t2', 0.78), ('t8', 0.65)],
+  'hike': [('t3', 0.90), ('t2', 0.68)],
+  'climb': [('t4', 0.88), ('t3', 0.62)],
+  'bike': [('t7', 0.85)],
+  'exercise': [('t1', 0.75), ('t7', 0.72), ('t9', 0.70), ('t12', 0.68)],
+  'outdoor': [('t3', 0.80), ('t2', 0.78), ('t4', 0.75), ('t7', 0.70)],
+  'games': [('t5', 0.90), ('t11', 0.60)],
+  'food': [('t10', 0.82)],
+  'fitness': [('t1', 0.80), ('t9', 0.78), ('t7', 0.75), ('t12', 0.72)],
+};
+
+// Related topics (neighborhoods) map: topicId → [topicIds]
+const _relatedMap = <String, List<String>>{
+  't1': ['t2', 't8', 't7'], // Running → Trail Running, Cross Country, Cycling
+  't2': ['t1', 't3', 't8'], // Trail Running → Running, Hiking, Cross Country
+  't3': ['t2', 't4'], // Hiking → Trail Running, Rock Climbing
+  't4': ['t3', 't2'], // Rock Climbing → Hiking, Trail Running
+  't5': ['t11'], // Board Games → Movie Nights
+  't7': ['t1', 't12'], // Cycling → Running, Swimming
+  't9': ['t1', 't12'], // Yoga → Running, Swimming
+};
+
+class TopicsSearchScreen extends ConsumerStatefulWidget {
+  const TopicsSearchScreen({super.key});
+
+  @override
+  ConsumerState<TopicsSearchScreen> createState() => _TopicsSearchScreenState();
+}
+
+class _TopicsSearchScreenState extends ConsumerState<TopicsSearchScreen> {
+  final _searchController = TextEditingController();
+  String _searchQuery = '';
+
+  // Search results
+  List<TopicSuggestion> _trigramResults = [];
+  List<TopicSuggestion> _semanticResults = [];
+  bool _isSearching = false;
+  bool _hasSearched = false;
+  Timer? _trigramDebounce;
+  Timer? _semanticDebounce;
+
+  // Neighborhoods
+  String? _expandedTopicId;
+  List<TopicSuggestion> _relatedTopics = [];
+  bool _loadingRelated = false;
+
+  // Local subscription state
+  final Set<String> _subscribedIds = {'t1', 't3', 't5'};
+
+  // Knob state (read during build, used in async methods)
+  bool _simulateSemanticDelay = false;
+
+  // Local copy of topics
+  late List<_MockTopic> _topics;
+
+  @override
+  void initState() {
+    super.initState();
+    _topics = _allMockTopics.map((t) {
+      final copy = _MockTopic(
+        id: t.id,
+        slug: t.slug,
+        displayName: t.displayName,
+        events: t.events,
+        subscribed: _subscribedIds.contains(t.id),
+      );
+      return copy;
+    }).toList();
+  }
+
+  @override
+  void dispose() {
+    _trigramDebounce?.cancel();
+    _semanticDebounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  _MockTopic? _topicById(String id) {
+    return _topics.where((t) => t.id == id).firstOrNull;
+  }
+
+  void _onSearchChanged(String value) {
+    final query = value.trim();
+    setState(() => _searchQuery = query);
+
+    if (query.isEmpty) {
+      setState(() {
+        _trigramResults = [];
+        _semanticResults = [];
+        _hasSearched = false;
+        _isSearching = false;
+      });
+      return;
+    }
+
+    // Trigram with 200ms debounce
+    _trigramDebounce?.cancel();
+    _trigramDebounce = Timer(const Duration(milliseconds: 200), () {
+      _runTrigramSearch(query);
+    });
+
+    // Semantic with 500ms debounce
+    _semanticDebounce?.cancel();
+    if (query.length >= 3) {
+      _semanticDebounce = Timer(const Duration(milliseconds: 500), () {
+        _runSemanticSearch(query);
+      });
+    }
+  }
+
+  void _runTrigramSearch(String query) {
+    final lowerQuery = query.toLowerCase();
+    final results = _topics
+        .where((t) =>
+            t.displayName.toLowerCase().contains(lowerQuery) ||
+            t.slug.contains(lowerQuery))
+        .map((t) => TopicSuggestion(
+              id: t.id,
+              name: t.slug,
+              displayName: t.displayName,
+              similarity:
+                  _trigramSimilarity(t.displayName.toLowerCase(), lowerQuery),
+            ))
+        .toList()
+      ..sort((a, b) => b.similarity.compareTo(a.similarity));
+
+    if (mounted && _searchQuery == query) {
+      setState(() {
+        _trigramResults = results;
+        _hasSearched = true;
+      });
+    }
+  }
+
+  double _trigramSimilarity(String text, String query) {
+    if (text == query) return 1.0;
+    if (text.startsWith(query)) return 0.9;
+    if (text.contains(query)) return 0.7;
+    return 0.5;
+  }
+
+  Future<void> _runSemanticSearch(String query) async {
+    if (_trigramResults.length >= 3) return;
+
+    setState(() => _isSearching = true);
+
+    if (_simulateSemanticDelay) {
+      await Future.delayed(const Duration(milliseconds: 500));
+    }
+
+    if (!mounted || _searchQuery != query) return;
+
+    final lowerQuery = query.toLowerCase();
+    final List<TopicSuggestion> results = [];
+
+    // Check each key in semantic map for substring match
+    for (final entry in _semanticMap.entries) {
+      if (lowerQuery.contains(entry.key) || entry.key.contains(lowerQuery)) {
+        for (final (topicId, similarity) in entry.value) {
+          final topic = _topicById(topicId);
+          if (topic != null && !results.any((r) => r.id == topicId)) {
+            results.add(TopicSuggestion(
+              id: topicId,
+              name: topic.slug,
+              displayName: topic.displayName,
+              similarity: similarity,
+            ));
+          }
+        }
+      }
+    }
+
+    results.sort((a, b) => b.similarity.compareTo(a.similarity));
+
+    setState(() {
+      _semanticResults = results;
+      _isSearching = false;
+    });
+  }
+
+  Future<void> _loadRelatedTopics(String topicId) async {
+    if (_expandedTopicId == topicId) {
+      setState(() {
+        _expandedTopicId = null;
+        _relatedTopics = [];
+      });
+      return;
+    }
+
+    setState(() {
+      _expandedTopicId = topicId;
+      _loadingRelated = true;
+      _relatedTopics = [];
+    });
+
+    // Brief delay for realism
+    await Future.delayed(const Duration(milliseconds: 200));
+
+    if (!mounted || _expandedTopicId != topicId) return;
+
+    final relatedIds = _relatedMap[topicId] ?? [];
+    final results = relatedIds
+        .map((id) => _topicById(id))
+        .where((t) => t != null)
+        .map((t) => TopicSuggestion(
+              id: t!.id,
+              name: t.slug,
+              displayName: t.displayName,
+              similarity: 0.75,
+            ))
+        .toList();
+
+    setState(() {
+      _relatedTopics = results;
+      _loadingRelated = false;
+    });
+  }
+
+  void _toggleSubscription(String topicId) {
+    setState(() {
+      if (_subscribedIds.contains(topicId)) {
+        _subscribedIds.remove(topicId);
+      } else {
+        _subscribedIds.add(topicId);
+      }
+      final topic = _topicById(topicId);
+      if (topic != null) {
+        topic.subscribed = _subscribedIds.contains(topicId);
+      }
+    });
+  }
+
+  void _showCreateDialog() {
+    final displayName = _searchController.text.trim();
+    if (displayName.isEmpty) return;
+
+    // Check for high-similarity matches
+    final highMatches = <TopicSuggestion>[
+      ..._trigramResults.where((s) => s.similarity > 0.7),
+      ..._semanticResults.where((s) => s.similarity > 0.7),
+    ];
+
+    if (highMatches.isNotEmpty) {
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Similar topic exists'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                  'This looks similar to existing ${highMatches.length == 1 ? 'topic' : 'topics'}:'),
+              const SizedBox(height: 8),
+              ...highMatches.map((m) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Text('• ${m.label}',
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
+                  )),
+              const SizedBox(height: 12),
+              const Text('Create a new topic anyway?'),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context, true);
+                _createTopic(displayName);
+              },
+              child: const Text('Create anyway'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      _createTopic(displayName);
+    }
+  }
+
+  void _createTopic(String displayName) {
+    final slug = displayName
+        .toLowerCase()
+        .trim()
+        .replaceAll(RegExp(r'[^a-z0-9\s\-]'), '')
+        .replaceAll(RegExp(r'\s+'), '-');
+
+    final newId = 'new-${DateTime.now().millisecondsSinceEpoch}';
+    final newTopic = _MockTopic(
+      id: newId,
+      slug: slug,
+      displayName: displayName,
+      events: 0,
+      subscribed: true,
+    );
+
+    setState(() {
+      _topics.add(newTopic);
+      _subscribedIds.add(newId);
+      _searchController.clear();
+      _searchQuery = '';
+      _trigramResults = [];
+      _semanticResults = [];
+      _hasSearched = false;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Created and subscribed to "$displayName"')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showSubscribed = context.knobs.boolean(
+      label: 'Show subscribed topics',
+      initial: true,
+    );
+
+    _simulateSemanticDelay = context.knobs.boolean(
+      label: 'Simulate semantic delay',
+      initial: false,
+    );
+
+    // Deduplicate combined results
+    final allSuggestionIds = <String>{};
+    final trigramOnly = <TopicSuggestion>[];
+    final semanticOnly = <TopicSuggestion>[];
+
+    for (final result in _trigramResults) {
+      if (allSuggestionIds.add(result.id)) {
+        trigramOnly.add(result);
+      }
+    }
+    for (final result in _semanticResults) {
+      if (allSuggestionIds.add(result.id)) {
+        semanticOnly.add(result);
+      }
+    }
+
+    final subscribedTopics =
+        _topics.where((t) => _subscribedIds.contains(t.id)).toList();
+
+    final showCreateButton =
+        _hasSearched && _searchController.text.trim().isNotEmpty;
+
+    return AppScaffold(
+      title: 'Topics',
+      body: Column(
+        children: [
+          // Search bar
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _searchController,
+              textInputAction: TextInputAction.search,
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search),
+                hintText: 'What are you interested in?',
+                suffixIcon: _isSearching
+                    ? const Padding(
+                        padding: EdgeInsets.all(12),
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : _searchController.text.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              _onSearchChanged('');
+                            },
+                          )
+                        : null,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(28),
+                ),
+              ),
+              onChanged: _onSearchChanged,
+            ),
+          ),
+
+          Expanded(
+            child: ListView(
+              children: [
+                // Trigram search results
+                if (_hasSearched && trigramOnly.isNotEmpty) ...[
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Text(
+                      'Search Results',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  ...trigramOnly.map((s) => _buildSearchResultTile(s)),
+                ],
+
+                // Semantic results
+                if (semanticOnly.isNotEmpty) ...[
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Text(
+                      'Similar Topics',
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                  ),
+                  ...semanticOnly.map((s) => _buildSearchResultTile(s)),
+                ],
+
+                // No results
+                if (_hasSearched && trigramOnly.isEmpty && semanticOnly.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Text(
+                      'No topics found. Try different search terms.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+
+                // Create button
+                if (showCreateButton)
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    child: OutlinedButton.icon(
+                      onPressed: _showCreateDialog,
+                      icon: const Icon(Icons.add, size: 18),
+                      label: Text('Create "${_searchController.text.trim()}"'),
+                    ),
+                  ),
+
+                // My Topics section
+                if (showSubscribed && subscribedTopics.isNotEmpty) ...[
+                  const Divider(),
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Text(
+                      'My Topics',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  ...subscribedTopics.map((t) => _buildSubscribedTile(t)),
+                ],
+
+                // Empty state
+                if (!_hasSearched && subscribedTopics.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.search,
+                          size: 64,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurfaceVariant
+                              .withAlpha(128),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          'Search for topics you\'re interested in to subscribe and get notified about new events',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchResultTile(TopicSuggestion suggestion) {
+    final isSubscribed = _subscribedIds.contains(suggestion.id);
+    final isExpanded = _expandedTopicId == suggestion.id;
+
+    // Similarity indicator
+    final TextStyle? subtitleStyle;
+    final String? subtitleText;
+    if (suggestion.similarity > 0.85) {
+      subtitleStyle = TextStyle(
+        color: Theme.of(context).colorScheme.error,
+        fontSize: 12,
+      );
+      subtitleText = 'Very similar match';
+    } else if (suggestion.similarity > 0.7) {
+      subtitleStyle = TextStyle(
+        color: Theme.of(context).colorScheme.tertiary,
+        fontSize: 12,
+      );
+      subtitleText = 'Similar match';
+    } else {
+      subtitleStyle = null;
+      subtitleText = null;
+    }
+
+    final topic = _topicById(suggestion.id);
+    final eventCount = topic?.events ?? 0;
+    final subtitle = subtitleText != null
+        ? subtitleText + (eventCount > 0 ? ' · $eventCount events' : '')
+        : (eventCount > 0 ? '$eventCount events' : null);
+
+    return Column(
+      children: [
+        ListTile(
+          title: Text(suggestion.label),
+          subtitle:
+              subtitle != null ? Text(subtitle, style: subtitleStyle) : null,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(
+                  isExpanded ? Icons.expand_less : Icons.explore,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                tooltip: 'Related topics',
+                onPressed: () => _loadRelatedTopics(suggestion.id),
+              ),
+              Switch(
+                value: isSubscribed,
+                onChanged: (_) => _toggleSubscription(suggestion.id),
+              ),
+            ],
+          ),
+        ),
+        if (isExpanded) _buildRelatedTopicsPanel(),
+      ],
+    );
+  }
+
+  Widget _buildSubscribedTile(_MockTopic topic) {
+    final isExpanded = _expandedTopicId == topic.id;
+
+    return Column(
+      children: [
+        ListTile(
+          title: Text(topic.label),
+          subtitle: topic.events > 0 ? Text('${topic.events} events') : null,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(
+                  isExpanded ? Icons.expand_less : Icons.explore,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                tooltip: 'Related topics',
+                onPressed: () => _loadRelatedTopics(topic.id),
+              ),
+              Switch(
+                value: true,
+                onChanged: (_) => _toggleSubscription(topic.id),
+              ),
+            ],
+          ),
+        ),
+        if (isExpanded) _buildRelatedTopicsPanel(),
+      ],
+    );
+  }
+
+  Widget _buildRelatedTopicsPanel() {
+    if (_loadingRelated) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+
+    if (_relatedTopics.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32, vertical: 8),
+        child: Text(
+          'No related topics found',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(left: 24, right: 16, bottom: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+            child: Text(
+              'Related Topics',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          ..._relatedTopics.map((related) {
+            final isSubscribed = _subscribedIds.contains(related.id);
+
+            return ListTile(
+              dense: true,
+              title: Text(related.label),
+              trailing: Switch(
+                value: isSubscribed,
+                onChanged: (_) => _toggleSubscription(related.id),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/topics/topics_screen.dart
+++ b/lib/ui/topics/topics_screen.dart
@@ -1,14 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:squadquest/logger.dart';
 import 'package:squadquest/app_scaffold.dart';
 import 'package:squadquest/controllers/auth.dart';
+import 'package:squadquest/controllers/topics.dart';
 import 'package:squadquest/controllers/topic_memberships.dart';
 import 'package:squadquest/models/topic.dart';
 import 'package:squadquest/models/topic_member.dart';
-
-import 'widgets/topic_list_section.dart';
 
 class TopicsScreen extends ConsumerStatefulWidget {
   const TopicsScreen({super.key});
@@ -18,8 +19,144 @@ class TopicsScreen extends ConsumerStatefulWidget {
 }
 
 class _TopicsScreenState extends ConsumerState<TopicsScreen> {
+  final _searchController = TextEditingController();
   String _searchQuery = '';
   final Map<TopicID, bool> pendingChanges = {};
+
+  // Search results
+  List<TopicSuggestion> _searchResults = [];
+  bool _isSearching = false;
+  bool _hasSearched = false;
+  Timer? _searchDebounce;
+
+  // Expanded topic for neighborhoods
+  String? _expandedTopicId;
+  List<TopicSuggestion> _relatedTopics = [];
+  bool _loadingRelated = false;
+
+  @override
+  void dispose() {
+    _searchDebounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    setState(() => _searchQuery = value.trim());
+
+    if (_searchQuery.isEmpty) {
+      setState(() {
+        _searchResults = [];
+        _hasSearched = false;
+        _isSearching = false;
+      });
+      return;
+    }
+
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(const Duration(milliseconds: 300), () {
+      _runSearch(_searchQuery);
+    });
+  }
+
+  Future<void> _runSearch(String query) async {
+    setState(() => _isSearching = true);
+
+    try {
+      // Run trigram search first
+      final trigramResults =
+          await ref.read(topicsProvider.notifier).searchTrigram(query);
+
+      if (!mounted || _searchQuery != query) return;
+
+      setState(() {
+        _searchResults = trigramResults;
+        _hasSearched = true;
+      });
+
+      // If trigram didn't find much, run semantic search
+      if (trigramResults.length < 3 && query.length >= 3) {
+        try {
+          final semanticResult =
+              await ref.read(topicsProvider.notifier).suggestTopics(query);
+
+          if (!mounted || _searchQuery != query) return;
+
+          // Merge results, deduplicating
+          final existingIds = _searchResults.map((s) => s.id).toSet();
+          final newResults = semanticResult.suggestions
+              .where((s) => !existingIds.contains(s.id))
+              .toList();
+
+          setState(() {
+            _searchResults = [..._searchResults, ...newResults];
+          });
+        } catch (_) {
+          // Semantic search is optional enhancement
+        }
+      }
+    } catch (_) {
+      // Fall back to client-side filtering
+      _fallbackSearch(query);
+    } finally {
+      if (mounted) {
+        setState(() => _isSearching = false);
+      }
+    }
+  }
+
+  void _fallbackSearch(String query) {
+    final topicMemberships = ref.read(topicMembershipsProvider).valueOrNull;
+    if (topicMemberships == null) return;
+
+    final lowerQuery = query.toLowerCase();
+    setState(() {
+      _searchResults = topicMemberships
+          .where((tm) =>
+              tm.topic.name.toLowerCase().contains(lowerQuery) ||
+              (tm.topic.displayName?.toLowerCase().contains(lowerQuery) ??
+                  false))
+          .map((tm) => TopicSuggestion(
+                id: tm.topic.id!,
+                name: tm.topic.name,
+                displayName: tm.topic.displayName,
+                similarity: 1.0,
+              ))
+          .toList();
+      _hasSearched = true;
+    });
+  }
+
+  Future<void> _loadRelatedTopics(String topicId) async {
+    if (_expandedTopicId == topicId) {
+      setState(() {
+        _expandedTopicId = null;
+        _relatedTopics = [];
+      });
+      return;
+    }
+
+    setState(() {
+      _expandedTopicId = topicId;
+      _loadingRelated = true;
+      _relatedTopics = [];
+    });
+
+    try {
+      final related =
+          await ref.read(topicsProvider.notifier).getRelatedTopics(topicId);
+      if (mounted && _expandedTopicId == topicId) {
+        setState(() {
+          _relatedTopics = related;
+          _loadingRelated = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() => _loadingRelated = false);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,47 +168,310 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     }
 
     return AppScaffold(
-      title: 'Topic Subscriptions',
+      title: 'Topics',
       body: Column(
         children: [
-          const Padding(
-            padding: EdgeInsets.all(16),
-            child: Text(
-              'Select topics you are interested in to receive notifications when new events are posted',
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 16, fontStyle: FontStyle.italic),
-            ),
-          ),
-          TextFormField(
-            textInputAction: TextInputAction.done,
-            decoration: const InputDecoration(
-              prefixIcon: Icon(Icons.search),
-              labelText: 'Search topics',
-            ),
-            onChanged: (String searchQuery) {
-              setState(() {
-                _searchQuery = searchQuery.toLowerCase();
-              });
-            },
-          ),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                return ref.read(topicMembershipsProvider.notifier).refresh();
-              },
-              child: topicMembershipsList.when(
-                data: (topicMemberships) => TopicListSection(
-                  topicMemberships: topicMemberships,
-                  pendingChanges: pendingChanges,
-                  searchQuery: _searchQuery,
-                  onTopicChanged: _onTopicCheckboxChanged,
+          // Search bar
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _searchController,
+              textInputAction: TextInputAction.search,
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search),
+                hintText: 'What are you interested in?',
+                suffixIcon: _isSearching
+                    ? const Padding(
+                        padding: EdgeInsets.all(12),
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : _searchController.text.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              _onSearchChanged('');
+                            },
+                          )
+                        : null,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(28),
                 ),
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, stackTrace) =>
-                    Center(child: Text('Error: $error')),
               ),
+              onChanged: _onSearchChanged,
             ),
           ),
+
+          Expanded(
+            child: topicMembershipsList.when(
+              data: (topicMemberships) {
+                // Build subscribed topics list
+                final subscribedTopics = topicMemberships
+                    .where((tm) => pendingChanges.containsKey(tm.topic.id)
+                        ? pendingChanges[tm.topic.id]!
+                        : tm.subscribed)
+                    .toList();
+
+                return ListView(
+                  children: [
+                    // Search results
+                    if (_hasSearched && _searchResults.isNotEmpty) ...[
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        child: Text(
+                          'Search Results',
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                      ),
+                      ..._searchResults.map(
+                          (s) => _buildSearchResultTile(s, topicMemberships)),
+                    ],
+
+                    if (_hasSearched && _searchResults.isEmpty)
+                      const Padding(
+                        padding: EdgeInsets.all(24),
+                        child: Text(
+                          'No topics found. Try different search terms.',
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+
+                    // My Topics section
+                    if (subscribedTopics.isNotEmpty) ...[
+                      const Divider(),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        child: Text(
+                          'My Topics',
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                      ),
+                      ...subscribedTopics.map(
+                          (tm) => _buildSubscribedTile(tm, topicMemberships)),
+                    ],
+
+                    // Empty state when no search and no subscriptions
+                    if (!_hasSearched && subscribedTopics.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.all(32),
+                        child: Column(
+                          children: [
+                            Icon(
+                              Icons.search,
+                              size: 64,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant
+                                  .withAlpha(128),
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              'Search for topics you\'re interested in to subscribe and get notified about new events',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, stackTrace) =>
+                  Center(child: Text('Error: $error')),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchResultTile(
+      TopicSuggestion suggestion, List<MyTopicMembership> allMemberships) {
+    // Find if user is subscribed to this topic
+    final membership =
+        allMemberships.where((tm) => tm.topic.id == suggestion.id).firstOrNull;
+    final isSubscribed = pendingChanges.containsKey(suggestion.id)
+        ? pendingChanges[suggestion.id]!
+        : (membership?.subscribed ?? false);
+    final isPending = pendingChanges.containsKey(suggestion.id);
+    final isExpanded = _expandedTopicId == suggestion.id;
+
+    return Column(
+      children: [
+        ListTile(
+          title: Text(suggestion.label),
+          subtitle: membership?.events != null && membership!.events! > 0
+              ? Text('${membership.events} events')
+              : null,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(
+                  isExpanded ? Icons.expand_less : Icons.explore,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                tooltip: 'Related topics',
+                onPressed: () => _loadRelatedTopics(suggestion.id),
+              ),
+              Switch(
+                value: isSubscribed,
+                onChanged: isPending
+                    ? null
+                    : (value) {
+                        if (membership != null) {
+                          _onTopicCheckboxChanged(membership, value);
+                        } else {
+                          // Create a temporary membership for subscribing
+                          _onTopicCheckboxChanged(
+                            MyTopicMembership(
+                              topic: Topic(
+                                id: suggestion.id,
+                                name: suggestion.name,
+                                displayName: suggestion.displayName,
+                              ),
+                              subscribed: false,
+                              events: 0,
+                            ),
+                            value,
+                          );
+                        }
+                      },
+              ),
+            ],
+          ),
+        ),
+
+        // Related topics panel
+        if (isExpanded) _buildRelatedTopicsPanel(allMemberships),
+      ],
+    );
+  }
+
+  Widget _buildSubscribedTile(
+      MyTopicMembership membership, List<MyTopicMembership> allMemberships) {
+    final isSubscribed = pendingChanges.containsKey(membership.topic.id)
+        ? pendingChanges[membership.topic.id]!
+        : membership.subscribed;
+    final isPending = pendingChanges.containsKey(membership.topic.id);
+    final isExpanded = _expandedTopicId == membership.topic.id;
+
+    return Column(
+      children: [
+        ListTile(
+          title: Text(membership.topic.label),
+          subtitle: membership.events != null && membership.events! > 0
+              ? Text('${membership.events} events')
+              : null,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(
+                  isExpanded ? Icons.expand_less : Icons.explore,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                tooltip: 'Related topics',
+                onPressed: () => _loadRelatedTopics(membership.topic.id!),
+              ),
+              Switch(
+                value: isSubscribed,
+                onChanged: isPending
+                    ? null
+                    : (value) => _onTopicCheckboxChanged(membership, value),
+              ),
+            ],
+          ),
+        ),
+        if (isExpanded) _buildRelatedTopicsPanel(allMemberships),
+      ],
+    );
+  }
+
+  Widget _buildRelatedTopicsPanel(List<MyTopicMembership> allMemberships) {
+    if (_loadingRelated) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+
+    if (_relatedTopics.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32, vertical: 8),
+        child: Text(
+          'No related topics found',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+      );
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(left: 24, right: 16, bottom: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+            child: Text(
+              'Related Topics',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          ..._relatedTopics.map((related) {
+            final membership = allMemberships
+                .where((tm) => tm.topic.id == related.id)
+                .firstOrNull;
+            final isSubscribed = pendingChanges.containsKey(related.id)
+                ? pendingChanges[related.id]!
+                : (membership?.subscribed ?? false);
+            final isPending = pendingChanges.containsKey(related.id);
+
+            return ListTile(
+              dense: true,
+              title: Text(related.label),
+              trailing: Switch(
+                value: isSubscribed,
+                onChanged: isPending
+                    ? null
+                    : (value) {
+                        if (membership != null) {
+                          _onTopicCheckboxChanged(membership, value);
+                        } else {
+                          _onTopicCheckboxChanged(
+                            MyTopicMembership(
+                              topic: Topic(
+                                id: related.id,
+                                name: related.name,
+                                displayName: related.displayName,
+                              ),
+                              subscribed: false,
+                              events: 0,
+                            ),
+                            value,
+                          );
+                        }
+                      },
+              ),
+            );
+          }),
         ],
       ),
     );

--- a/lib/ui/topics/widgets/topic_list_section.dart
+++ b/lib/ui/topics/widgets/topic_list_section.dart
@@ -20,7 +20,7 @@ class TopicListSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final filteredTopicMemberships = topicMemberships.where((topicMembership) {
       return searchQuery.isEmpty ||
-          topicMembership.topic.name.toLowerCase().contains(searchQuery);
+          topicMembership.topic.label.toLowerCase().contains(searchQuery);
     }).toList();
 
     return GroupedListView(
@@ -45,7 +45,7 @@ class TopicListSection extends StatelessWidget {
         ),
       ),
       itemBuilder: (context, topicMembership) {
-        final topicName = topicMembership.topic.name;
+        final topicName = topicMembership.topic.label;
         int? matchIndex;
 
         if (searchQuery.isNotEmpty) {

--- a/supabase/functions/suggest-topics/index.ts
+++ b/supabase/functions/suggest-topics/index.ts
@@ -1,0 +1,63 @@
+import { assertPost, getRequiredJsonParameters, serve } from "../_shared/http.ts";
+import { getServiceRoleSupabaseClient } from "../_shared/supabase.ts";
+
+// deno-lint-ignore no-explicit-any
+let pipeline: any = null;
+
+async function getEmbeddingPipeline() {
+  if (pipeline) return pipeline;
+
+  const { pipeline: createPipeline } = await import(
+    "https://esm.sh/@xenova/transformers@2.17.2"
+  );
+
+  pipeline = await createPipeline(
+    "feature-extraction",
+    "Xenova/all-MiniLM-L6-v2",
+    { quantized: true },
+  );
+
+  return pipeline;
+}
+
+serve(async (request) => {
+  assertPost(request);
+
+  const { query } = await getRequiredJsonParameters(request, ["query"]);
+
+  // Compute embedding for the query
+  const extractor = await getEmbeddingPipeline();
+  const output = await extractor(query, {
+    pooling: "mean",
+    normalize: true,
+  });
+
+  const embedding = Array.from(output.data) as number[];
+
+  // Search for similar topics using the embedding
+  const supabase = getServiceRoleSupabaseClient();
+
+  const { data: suggestions, error } = await supabase.rpc(
+    "search_similar_topics",
+    {
+      query_embedding: JSON.stringify(embedding),
+      similarity_threshold: 0.4,
+      max_results: 10,
+    },
+  );
+
+  if (error) {
+    throw new Error(`Failed to search similar topics: ${error.message}`);
+  }
+
+  return new Response(
+    JSON.stringify({
+      suggestions: suggestions ?? [],
+      embedding,
+    }),
+    {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    },
+  );
+});

--- a/supabase/tables/topics.sql
+++ b/supabase/tables/topics.sql
@@ -1,12 +1,118 @@
+-- Enable required extensions
+create extension if not exists vector;
+create extension if not exists pg_trgm;
+
 create table
   public.topics (
     id uuid not null default gen_random_uuid (),
     created_at timestamp with time zone not null default now(),
     created_by uuid null default auth.uid (),
     name character varying null,
+    display_name character varying null,
+    embedding vector(384) null,
     constraint topics_pkey primary key (id),
     constraint topics_name_key unique (name),
     constraint topics_created_by_fkey foreign key (created_by) references profiles (id)
   );
 
 alter table public.topics enable row level security;
+
+-- Trigram indexes for fast typeahead
+create index topics_name_trgm_idx on public.topics using gin (name gin_trgm_ops);
+create index topics_display_name_trgm_idx on public.topics using gin (display_name gin_trgm_ops);
+
+-- Vector index for semantic search
+create index topics_embedding_idx on public.topics
+  using ivfflat (embedding vector_cosine_ops) with (lists = 10);
+
+-- Trigram search function for fast typeahead
+create or replace function search_topics_trigram(query text, max_results int default 10)
+returns table (id uuid, name varchar, display_name varchar, similarity real)
+language sql stable
+as $$
+  select
+    t.id,
+    t.name,
+    t.display_name,
+    greatest(
+      similarity(t.name, query),
+      similarity(coalesce(t.display_name, ''), query)
+    ) as similarity
+  from public.topics t
+  where
+    t.name % query
+    or t.display_name % query
+  order by similarity desc
+  limit max_results;
+$$;
+
+-- Semantic search function using pgvector
+create or replace function search_similar_topics(
+  query_embedding vector(384),
+  similarity_threshold float default 0.5,
+  max_results int default 5
+)
+returns table (id uuid, name varchar, display_name varchar, similarity float)
+language sql stable
+as $$
+  select
+    t.id,
+    t.name,
+    t.display_name,
+    1 - (t.embedding <=> query_embedding) as similarity
+  from public.topics t
+  where
+    t.embedding is not null
+    and 1 - (t.embedding <=> query_embedding) > similarity_threshold
+  order by t.embedding <=> query_embedding
+  limit max_results;
+$$;
+
+-- Topic neighborhoods: find related topics for a given topic
+create or replace function get_related_topics(topic_id uuid, max_results int default 5)
+returns table (id uuid, name varchar, display_name varchar, similarity float)
+language sql stable
+as $$
+  select
+    t.id,
+    t.name,
+    t.display_name,
+    1 - (t.embedding <=> ref.embedding) as similarity
+  from public.topics t
+  cross join public.topics ref
+  where
+    ref.id = topic_id
+    and t.id != topic_id
+    and t.embedding is not null
+    and ref.embedding is not null
+  order by t.embedding <=> ref.embedding
+  limit max_results;
+$$;
+
+-- Merge topics: move all references from one topic to another, then delete the duplicate
+create or replace function merge_topics(keep_id uuid, remove_id uuid)
+returns void
+language plpgsql
+as $$
+begin
+  -- Move topic_members
+  update public.topic_members
+  set topic = keep_id
+  where topic = remove_id
+  and not exists (
+    select 1 from public.topic_members
+    where topic = keep_id and member = topic_members.member
+  );
+
+  -- Delete remaining duplicate topic_members
+  delete from public.topic_members where topic = remove_id;
+
+  -- Move instances (events)
+  update public.instances
+  set topic = keep_id
+  where topic = remove_id;
+
+  -- Delete the duplicate topic
+  delete from public.topics where id = remove_id;
+end;
+$$;


### PR DESCRIPTION
  Summary                                                                                                                                        
                                                                                                                                                 
  - Add a dual-layer topic search system combining trigram similarity (PostgreSQL's pg_trgm extension, which finds matches by comparing  overlapping 3-character substrings between the search query and stored topic names — e.g. searching "bask" matches "basketball" because they  share trigrams like "bas", "ask") for fast typeahead with vector similarity (pgvector cosine distance on 384-dimensional embeddings from  all-MiniLM-L6-v2) for semantic matching — so searching "hoops" can find "basketball" even with no shared characters
  - Add display_name and embedding columns to the topics table, with GIN trigram indexes and IVFFlat vector indexes
  - Add Supabase edge function suggest-topics that computes query embeddings on-the-fly and returns semantically similar topics
  - Add database functions for trigram search (search_topics_trigram), semantic search (search_similar_topics), topic neighborhoods
  (get_related_topics), and topic merging (merge_topics)
  - Add TopicsController methods exposing trigram search, semantic suggestions, and related topic lookups to the Flutter app
  - Redesign topic picker with combined trigram + semantic search and duplicate detection
  - Redesign topics screen with search-first UX and related topic exploration
  - Include storybook iterations (v3–v7) exploring different topic browsing patterns

## To Do
The new semantic functionality requires additional testing and verification. The primary purpose of this pull request was to create possible topic screen solutions. Work is ongoing. 