### PR TITLE
v2 backend Stage 1: API foundation + auth + identity

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,6 +36,21 @@ jobs:
 
   server:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: squadquest
+          POSTGRES_PASSWORD: squadquest
+          POSTGRES_DB: squadquest_v2
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U squadquest -d squadquest_v2"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgres://squadquest:squadquest@localhost:5432/squadquest_v2
+      JWT_SECRET: ci-secret-min-32-chars-aaaaaaaaaaaaaaaa
     defaults:
       run:
         working-directory: server
@@ -48,3 +63,5 @@ jobs:
 
       - run: bun install --frozen-lockfile
       - run: bun run type-check
+      - run: bun run db:migrate
+      - run: bun test

--- a/plans/v2-backend-stage1-auth.md
+++ b/plans/v2-backend-stage1-auth.md
@@ -6,7 +6,7 @@ specs:
   - specs/api/auth.md
   - specs/data-model.md
 issues: []
-pr: 407
+pr: 408
 ---
 
 # Plan: v2 backend Stage 1 — API foundation + auth + identity
@@ -53,7 +53,7 @@ communities; squads/messages; SSE realtime; real SMS provider; storage/signed UR
       "not on v2 yet" row (hand-seeded shell + friendship).
 - [x] below-floor `X-SquadQuest-Client` → `426` with upgrade envelope; unauthed `/v1/me` →
       `401`.
-- [x] `bun test` green (9 tests); `pr-test` server job → verified on PR #407.
+- [x] `bun test` green (9 tests); `pr-test` server job → verified on PR #408.
 
 ## Risks / unknowns
 
@@ -64,7 +64,7 @@ communities; squads/messages; SSE realtime; real SMS provider; storage/signed UR
 
 ## Notes
 
-Shipped as PR #407 (5 commits: deps, schema+plumbing, conventions middleware, auth+identity,
+Shipped as PR #408 (5 commits: deps, schema+plumbing, conventions middleware, auth+identity,
 tests+CI). Drizzle/Bun/postgres-js + drizzle-kit generate/migrate work cleanly (risk
 cleared). Dev Postgres runs on host port **5532** (5432 is commonly taken by other projects).
 Access tokens are JWT (15m); refresh tokens are opaque, hashed, rotating, DB-backed. CI: the

--- a/plans/v2-backend-stage1-auth.md
+++ b/plans/v2-backend-stage1-auth.md
@@ -1,0 +1,83 @@
+---
+status: done
+depends: [v2-repo-reset]
+specs:
+  - specs/api/conventions.md
+  - specs/api/auth.md
+  - specs/data-model.md
+issues: []
+pr: 407
+---
+
+# Plan: v2 backend Stage 1 — API foundation + auth + identity
+
+## Scope
+
+The foundational backend layer in `server/`: Postgres + Drizzle, the `/v1` conventions
+middleware (build header → `426` floor, error envelope, JWT auth), the identity schema
+(profile / friendship / topic / topic_subscription), the auth endpoints (OTP → JWT +
+claim-on-login, dev-stub OTP), and `GET /v1/me` + `GET /v1/friends` to prove the authed
+stack. First slice of the `v2-backend-and-migration` umbrella.
+
+Out (later staged plans): the bulk v1→v2 pre-migration job; ideas/activities + timeline;
+communities; squads/messages; SSE realtime; real SMS provider; storage/signed URLs.
+
+## Implements
+
+`specs/api/conventions.md`, `specs/api/auth.md`, and the identity slice of
+`specs/data-model.md`.
+
+## Approach
+
+- **DB:** Drizzle ORM + drizzle-kit + `postgres` driver; `src/db` client plugin
+  (`fastify.db`), `src/db/schema/*`, `drizzle.config.ts` → `migrations/`, `db:generate` /
+  `db:migrate` scripts; local `docker-compose.yml`; `.env.example` (DATABASE_URL, JWT_SECRET,
+  MIN_SUPPORTED_BUILD).
+- **Conventions:** build-header parse + `426` floor hook; `sendError` + `ApiError` + global
+  error handler emitting the spec envelope; JWT bearer auth preHandler. Wired into `/v1`.
+- **Auth:** OTP store + `OtpProvider` interface + `ConsoleOtpProvider`; JWT issue/refresh/
+  revoke; claim-on-login by normalized (E.164) phone (bind shell + set `claimed_at`, else
+  create). `routes/v1/auth.ts`.
+- **Identity reads:** `routes/v1/me.ts`, `routes/v1/friends.ts` + serializers in
+  `src/contracts/`.
+- **Tests:** Bun integration (otp→verify→/me→/friends) + 426 unit; wire into `pr-test`
+  server job if a Postgres service is easy, else local-only (note the gap).
+
+## Validation
+
+- [x] `docker compose up -d && bun run db:migrate` applies; tables exist (6).
+- [x] `bun run dev` boots; `bun run type-check` clean.
+- [x] `POST /v1/auth/otp/request` → 200, code logged; `/otp/verify` → access+refresh +
+      profile (`claimed_v1` correct).
+- [x] authed `GET /v1/me` → profile; `GET /v1/friends` → accepted graph incl. an unclaimed
+      "not on v2 yet" row (hand-seeded shell + friendship).
+- [x] below-floor `X-SquadQuest-Client` → `426` with upgrade envelope; unauthed `/v1/me` →
+      `401`.
+- [x] `bun test` green (9 tests); `pr-test` server job → verified on PR #407.
+
+## Risks / unknowns
+
+- Drizzle + Bun + postgres.js / drizzle-kit edge cases — validate generate/migrate early.
+- Postgres service in `pr-test` CI — straightforward on ubuntu; fall back to local-only +
+  type-check in CI if flaky (flag it).
+- OTP TTL/rate-limit kept simple in Stage 1.
+
+## Notes
+
+Shipped as PR #407 (5 commits: deps, schema+plumbing, conventions middleware, auth+identity,
+tests+CI). Drizzle/Bun/postgres-js + drizzle-kit generate/migrate work cleanly (risk
+cleared). Dev Postgres runs on host port **5532** (5432 is commonly taken by other projects).
+Access tokens are JWT (15m); refresh tokens are opaque, hashed, rotating, DB-backed. CI: the
+`pr-test` server job runs a `postgres:17` service + `db:migrate` + `bun test`.
+
+Stage-1 simplifications (intentional): the client-build header is not hard-required when
+absent (spec says required); phone normalization is US-centric best-effort (no
+libphonenumber); OTP rate-limiting is minimal.
+
+## Follow-ups
+
+- **Deferred to plan:** bulk v1→v2 pre-migration job (reads v1 Supabase); ideas/activities +
+  timeline; communities; squads/messages; SSE realtime; real SMS provider; storage/signed
+  URLs. (Tracked under the `v2-backend-and-migration` umbrella.)
+- **Tighten later:** hard-require the client-build header; libphonenumber-grade phone
+  normalization; OTP request rate-limiting.

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,5 +4,12 @@ HOST=0.0.0.0
 NODE_ENV=development
 LOG_LEVEL=info
 
-# Postgres (not yet used — see the v2-backend-and-migration plan)
-DATABASE_URL=postgres://localhost:5432/squadquest_v2
+# Postgres (local dev via docker-compose.yml)
+DATABASE_URL=postgres://squadquest:squadquest@localhost:5532/squadquest_v2
+
+# Auth — JWT signing secret (>= 32 chars). Generate a strong value per environment.
+JWT_SECRET=dev-secret-change-me-min-32-chars-long
+
+# Lowest client build allowed; requests below it get 426 Upgrade Required.
+# 0 disables the floor (default for dev).
+MIN_SUPPORTED_BUILD=0

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -10,10 +10,12 @@
         "drizzle-orm": "^0.45.2",
         "fastify": "^5.2.0",
         "fastify-plugin": "^5.0.0",
+        "jsonwebtoken": "^9.0.3",
         "postgres": "^3.4.9",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/jsonwebtoken": "^9.0.10",
         "drizzle-kit": "^0.31.10",
         "typescript": "^5.7.0",
       },
@@ -98,6 +100,10 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
@@ -109,6 +115,8 @@
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -125,6 +133,8 @@
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "env-schema": ["env-schema@6.1.0", "", { "dependencies": { "ajv": "^8.12.0", "dotenv": "^17.0.0", "dotenv-expand": "10.0.0" } }, "sha512-TWtYV2jKe7bd/19kzvNGa8GRRrSwmIMarhcWBzuZYPbHtdlUdjYhnaFvxrO4+GvcwF10sEeVGzf9b/wqLIyf9A=="],
 
@@ -158,7 +168,29 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
+
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
@@ -185,6 +217,8 @@
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-regex2": ["safe-regex2@5.1.1", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA=="],
 

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -7,16 +7,77 @@
       "dependencies": {
         "@fastify/cors": "^11.0.0",
         "@fastify/env": "^5.0.0",
+        "drizzle-orm": "^0.45.2",
         "fastify": "^5.2.0",
         "fastify-plugin": "^5.0.0",
+        "postgres": "^3.4.9",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "drizzle-kit": "^0.31.10",
         "typescript": "^5.7.0",
       },
     },
   },
   "packages": {
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
     "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
 
     "@fastify/cors": ["@fastify/cors@11.2.0", "", { "dependencies": { "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw=="],
@@ -49,6 +110,8 @@
 
     "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
@@ -59,7 +122,13 @@
 
     "dotenv-expand": ["dotenv-expand@10.0.0", "", {}, "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="],
 
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
     "env-schema": ["env-schema@6.1.0", "", { "dependencies": { "ajv": "^8.12.0", "dotenv": "^17.0.0", "dotenv-expand": "10.0.0" } }, "sha512-TWtYV2jKe7bd/19kzvNGa8GRRrSwmIMarhcWBzuZYPbHtdlUdjYhnaFvxrO4+GvcwF10sEeVGzf9b/wqLIyf9A=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -79,6 +148,10 @@
 
     "find-my-way": ["find-my-way@9.6.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ=="],
 
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
     "ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
@@ -95,6 +168,8 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
+
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
@@ -102,6 +177,8 @@
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
 
@@ -121,18 +198,124 @@
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "toad-cache": ["toad-cache@3.7.1", "", {}, "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ=="],
 
+    "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "tsx/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
   }
 }

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,24 @@
+# Local Postgres for development. Matches the default DATABASE_URL in .env.example.
+#   docker compose up -d
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: squadquest-v2-postgres
+    environment:
+      POSTGRES_USER: squadquest
+      POSTGRES_PASSWORD: squadquest
+      POSTGRES_DB: squadquest_v2
+    # Host port 5532 (not the default 5432) to avoid colliding with other
+    # local Postgres instances. Matches DATABASE_URL in .env.example.
+    ports:
+      - '5532:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U squadquest -d squadquest_v2']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/server/drizzle.config.ts
+++ b/server/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: './src/db/schema/index.ts',
+  out: './migrations',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url:
+      process.env.DATABASE_URL ??
+      'postgres://squadquest:squadquest@localhost:5532/squadquest_v2',
+  },
+  casing: 'snake_case',
+})

--- a/server/migrations/0000_minor_rage.sql
+++ b/server/migrations/0000_minor_rage.sql
@@ -1,0 +1,57 @@
+CREATE TYPE "public"."friendship_status" AS ENUM('requested', 'accepted', 'declined');--> statement-breakpoint
+CREATE TABLE "friendship" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"requester" uuid NOT NULL,
+	"requestee" uuid NOT NULL,
+	"status" "friendship_status" DEFAULT 'requested' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "friendship_pair" UNIQUE("requester","requestee")
+);
+--> statement-breakpoint
+CREATE TABLE "profile" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"phone" text NOT NULL,
+	"first_name" text,
+	"last_name" text,
+	"photo" text,
+	"claimed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "profile_phone_unique" UNIQUE("phone")
+);
+--> statement-breakpoint
+CREATE TABLE "topic" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"noun" text NOT NULL,
+	"verb" text NOT NULL,
+	"label" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "topic_subscription" (
+	"topic_id" uuid NOT NULL,
+	"profile_id" uuid NOT NULL,
+	CONSTRAINT "topic_subscription_topic_id_profile_id_pk" PRIMARY KEY("topic_id","profile_id")
+);
+--> statement-breakpoint
+CREATE TABLE "otp_code" (
+	"phone" text PRIMARY KEY NOT NULL,
+	"code_hash" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "refresh_token" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"profile_id" uuid NOT NULL,
+	"token_hash" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "refresh_token_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "friendship" ADD CONSTRAINT "friendship_requester_profile_id_fk" FOREIGN KEY ("requester") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "friendship" ADD CONSTRAINT "friendship_requestee_profile_id_fk" FOREIGN KEY ("requestee") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "topic_subscription" ADD CONSTRAINT "topic_subscription_topic_id_topic_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topic"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "topic_subscription" ADD CONSTRAINT "topic_subscription_profile_id_profile_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "refresh_token" ADD CONSTRAINT "refresh_token_profile_id_profile_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/migrations/meta/0000_snapshot.json
+++ b/server/migrations/meta/0000_snapshot.json
@@ -1,0 +1,393 @@
+{
+  "id": "b4ce033e-d00b-4b6f-a434-17de7de7da8d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester": {
+          "name": "requester",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestee": {
+          "name": "requestee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_requester_profile_id_fk": {
+          "name": "friendship_requester_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requester"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_requestee_profile_id_fk": {
+          "name": "friendship_requestee_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requestee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "friendship_pair": {
+          "name": "friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "requester",
+            "requestee"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_phone_unique": {
+          "name": "profile_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "noun": {
+          "name": "noun",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_subscription": {
+      "name": "topic_subscription",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_subscription_topic_id_topic_id_fk": {
+          "name": "topic_subscription_topic_id_topic_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_subscription_profile_id_profile_id_fk": {
+          "name": "topic_subscription_profile_id_profile_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_subscription_topic_id_profile_id_pk": {
+          "name": "topic_subscription_topic_id_profile_id_pk",
+          "columns": [
+            "topic_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_code": {
+      "name": "otp_code",
+      "schema": "",
+      "columns": {
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_token": {
+      "name": "refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_token_profile_id_profile_id_fk": {
+          "name": "refresh_token_profile_id_profile_id_fk",
+          "tableFrom": "refresh_token",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_token_token_hash_unique": {
+          "name": "refresh_token_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted",
+        "declined"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1780963135162,
+      "tag": "0000_minor_rage",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/package.json
+++ b/server/package.json
@@ -20,10 +20,12 @@
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.2.0",
     "fastify-plugin": "^5.0.0",
+    "jsonwebtoken": "^9.0.3",
     "postgres": "^3.4.9"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/jsonwebtoken": "^9.0.10",
     "drizzle-kit": "^0.31.10",
     "typescript": "^5.7.0"
   }

--- a/server/package.json
+++ b/server/package.json
@@ -8,16 +8,23 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "bun test",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@fastify/cors": "^11.0.0",
     "@fastify/env": "^5.0.0",
+    "drizzle-orm": "^0.45.2",
     "fastify": "^5.2.0",
-    "fastify-plugin": "^5.0.0"
+    "fastify-plugin": "^5.0.0",
+    "postgres": "^3.4.9"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "drizzle-kit": "^0.31.10",
     "typescript": "^5.7.0"
   }
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,12 +3,16 @@ import fp from 'fastify-plugin'
 import cors from '@fastify/cors'
 
 import envPlugin from './plugins/env.ts'
+import dbPlugin from './db/index.ts'
 import v1Routes from './routes/v1/index.ts'
 
 export const app: FastifyPluginAsync = async (fastify) => {
   // Environment config must load first (validates + decorates fastify.config).
   await fastify.register(envPlugin)
   fastify.log.level = fastify.config.LOG_LEVEL
+
+  // Database (decorates fastify.db + fastify.sql).
+  await fastify.register(dbPlugin)
 
   await fastify.register(cors, {
     origin: fastify.config.NODE_ENV === 'production' ? false : true,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,9 @@ import cors from '@fastify/cors'
 
 import envPlugin from './plugins/env.ts'
 import dbPlugin from './db/index.ts'
+import clientVersionPlugin from './plugins/client-version.ts'
+import authPlugin from './plugins/auth.ts'
+import { ApiError, sendError } from './contracts/errors.ts'
 import v1Routes from './routes/v1/index.ts'
 
 export const app: FastifyPluginAsync = async (fastify) => {
@@ -14,9 +17,37 @@ export const app: FastifyPluginAsync = async (fastify) => {
   // Database (decorates fastify.db + fastify.sql).
   await fastify.register(dbPlugin)
 
+  // Conventions: client-build header + 426 floor, JWT auth (see
+  // specs/api/conventions.md).
+  await fastify.register(clientVersionPlugin)
+  await fastify.register(authPlugin)
+
   await fastify.register(cors, {
     origin: fastify.config.NODE_ENV === 'production' ? false : true,
     credentials: true,
+  })
+
+  // Map thrown ApiErrors to the standard error envelope; everything else is a
+  // generic 500 (logged) so internals never leak to the client.
+  fastify.setErrorHandler((error, request, reply) => {
+    if (error instanceof ApiError) {
+      sendError(reply, error)
+      return
+    }
+    // Fastify validation errors → 400 with a stable code.
+    if ((error as { validation?: unknown }).validation) {
+      reply.code(400).send({
+        error: {
+          code: 'bad_request',
+          message: error instanceof Error ? error.message : 'Bad request',
+        },
+      })
+      return
+    }
+    request.log.error(error)
+    reply.code(500).send({
+      error: { code: 'internal', message: 'Internal server error' },
+    })
   })
 
   // The versioned API surface.

--- a/server/src/contracts/errors.ts
+++ b/server/src/contracts/errors.ts
@@ -1,0 +1,48 @@
+import type { FastifyReply } from 'fastify'
+
+// The standard error envelope from specs/api/conventions.md. Clients branch on
+// `error.code` (stable), never on `message`. `upgrade` is present only on 426.
+export interface ErrorEnvelope {
+  error: {
+    code: string
+    message: string
+    details?: Record<string, unknown>
+  }
+  upgrade?: {
+    min_build: number
+    store_url: string
+  }
+}
+
+// A thrown error that maps to the envelope. The global error handler (app.ts)
+// turns these into the right status + body.
+export class ApiError extends Error {
+  constructor(
+    readonly statusCode: number,
+    readonly code: string,
+    message: string,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+// Common constructors (codes match specs/api/*).
+export const errors = {
+  unauthorized: (message = 'Authentication required') =>
+    new ApiError(401, 'unauthorized', message),
+  forbidden: (code: string, message: string) =>
+    new ApiError(403, code, message),
+  rateLimited: (message = 'Too many requests') =>
+    new ApiError(429, 'rate_limited', message),
+  badRequest: (code: string, message: string, details?: Record<string, unknown>) =>
+    new ApiError(400, code, message, details),
+}
+
+export function sendError(reply: FastifyReply, err: ApiError): void {
+  const body: ErrorEnvelope = {
+    error: { code: err.code, message: err.message, details: err.details },
+  }
+  reply.code(err.statusCode).send(body)
+}

--- a/server/src/contracts/friend.ts
+++ b/server/src/contracts/friend.ts
@@ -1,0 +1,16 @@
+import type { profile } from '../db/schema/index.ts'
+
+type ProfileRow = typeof profile.$inferSelect
+
+// A friend as seen in lists. `on_v2` false = a carried friendship whose other
+// party hasn't claimed their v2 profile yet ("not on v2 yet · invite"). See
+// specs/behaviors/v1-migration.md.
+export function serializeFriend(row: ProfileRow) {
+  return {
+    id: row.id,
+    first_name: row.firstName,
+    last_name: row.lastName,
+    photo: row.photo,
+    on_v2: row.claimedAt !== null,
+  }
+}

--- a/server/src/contracts/profile.ts
+++ b/server/src/contracts/profile.ts
@@ -1,0 +1,16 @@
+import type { profile } from '../db/schema/index.ts'
+
+type ProfileRow = typeof profile.$inferSelect
+
+// Serialized profile wire shape (specs/api/auth.md). `photo` is a URL/key;
+// signed-URL handling arrives with storage in a later stage.
+export function serializeProfile(row: ProfileRow) {
+  return {
+    id: row.id,
+    first_name: row.firstName,
+    last_name: row.lastName,
+    photo: row.photo,
+    phone: row.phone,
+    claimed_at: row.claimedAt ? row.claimedAt.toISOString() : null,
+  }
+}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -1,0 +1,28 @@
+import fp from 'fastify-plugin'
+import postgres from 'postgres'
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+
+import * as schema from './schema/index.ts'
+
+export type Database = PostgresJsDatabase<typeof schema>
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    db: Database
+    sql: ReturnType<typeof postgres>
+  }
+}
+
+// Decorates `fastify.db` (Drizzle) + `fastify.sql` (raw postgres-js client) and
+// closes the pool on shutdown. DATABASE_URL is validated by the env plugin.
+export default fp(async (fastify) => {
+  const sql = postgres(fastify.config.DATABASE_URL, { max: 10 })
+  const db = drizzle(sql, { schema })
+
+  fastify.decorate('db', db)
+  fastify.decorate('sql', sql)
+
+  fastify.addHook('onClose', async () => {
+    await sql.end({ timeout: 5 })
+  })
+})

--- a/server/src/db/schema/auth.ts
+++ b/server/src/db/schema/auth.ts
@@ -1,0 +1,29 @@
+import { pgTable, uuid, text, timestamp, integer } from 'drizzle-orm/pg-core'
+
+import { profile } from './identity.ts'
+
+// Short-lived OTP challenges, keyed by normalized (E.164) phone. The code is
+// stored hashed; `attempts` supports basic rate limiting.
+export const otpCode = pgTable('otp_code', {
+  phone: text('phone').primaryKey(),
+  codeHash: text('code_hash').notNull(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  attempts: integer('attempts').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})
+
+// Rotating refresh tokens (stored hashed). `revokedAt` set on logout/rotation.
+export const refreshToken = pgTable('refresh_token', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  profileId: uuid('profile_id')
+    .notNull()
+    .references(() => profile.id, { onDelete: 'cascade' }),
+  tokenHash: text('token_hash').notNull().unique(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})

--- a/server/src/db/schema/identity.ts
+++ b/server/src/db/schema/identity.ts
@@ -1,0 +1,71 @@
+import {
+  pgTable,
+  pgEnum,
+  uuid,
+  text,
+  timestamp,
+  unique,
+  primaryKey,
+} from 'drizzle-orm/pg-core'
+
+// A person. `phone` is the identity bridge from v1 (see
+// specs/behaviors/v1-migration.md); `claimed_at` null = a pre-migrated shell
+// not yet logged into v2.
+export const profile = pgTable('profile', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  phone: text('phone').notNull().unique(),
+  firstName: text('first_name'),
+  lastName: text('last_name'),
+  photo: text('photo'),
+  claimedAt: timestamp('claimed_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})
+
+export const friendshipStatus = pgEnum('friendship_status', [
+  'requested',
+  'accepted',
+  'declined',
+])
+
+// The double-opt-in graph. A pair is "friends" when status = accepted.
+export const friendship = pgTable(
+  'friendship',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    requester: uuid('requester')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+    requestee: uuid('requestee')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+    status: friendshipStatus('status').notNull().default('requested'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [unique('friendship_pair').on(t.requester, t.requestee)],
+)
+
+// The interest taxonomy (noun-verb, e.g. "Go Hiking").
+export const topic = pgTable('topic', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  noun: text('noun').notNull(),
+  verb: text('verb').notNull(),
+  label: text('label').notNull(),
+})
+
+// Per-user interest subscriptions.
+export const topicSubscription = pgTable(
+  'topic_subscription',
+  {
+    topicId: uuid('topic_id')
+      .notNull()
+      .references(() => topic.id, { onDelete: 'cascade' }),
+    profileId: uuid('profile_id')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+  },
+  (t) => [primaryKey({ columns: [t.topicId, t.profileId] })],
+)

--- a/server/src/db/schema/index.ts
+++ b/server/src/db/schema/index.ts
@@ -1,0 +1,2 @@
+export * from './identity.ts'
+export * from './auth.ts'

--- a/server/src/domain/auth/otp-provider.ts
+++ b/server/src/domain/auth/otp-provider.ts
@@ -1,0 +1,16 @@
+import type { FastifyBaseLogger } from 'fastify'
+
+// Swappable OTP delivery. Stage 1 ships ConsoleOtpProvider (logs the code); a
+// real SMS provider (Twilio Verify-class) is a later-stage follow-up. See
+// specs/api/auth.md and specs/architecture.md.
+export interface OtpProvider {
+  send(phone: string, code: string): Promise<void>
+}
+
+export class ConsoleOtpProvider implements OtpProvider {
+  constructor(private readonly log: FastifyBaseLogger) {}
+
+  async send(phone: string, code: string): Promise<void> {
+    this.log.info({ phone, code }, `[dev OTP] code for ${phone}: ${code}`)
+  }
+}

--- a/server/src/domain/auth/phone.ts
+++ b/server/src/domain/auth/phone.ts
@@ -1,0 +1,18 @@
+import { errors } from '../../contracts/errors.ts'
+
+// Best-effort E.164 normalization. US-centric default (bare 10-digit → +1).
+// Stage 1 keeps this simple; a real libphonenumber pass is a later follow-up.
+export function normalizePhone(raw: string): string {
+  const trimmed = (raw ?? '').trim()
+  const hasPlus = trimmed.startsWith('+')
+  let digits = trimmed.replace(/\D/g, '')
+
+  if (!hasPlus) {
+    if (digits.length === 10) digits = '1' + digits // assume US/NANP
+  }
+
+  if (digits.length < 8 || digits.length > 15) {
+    throw errors.badRequest('phone_invalid', 'Invalid phone number')
+  }
+  return '+' + digits
+}

--- a/server/src/domain/auth/service.ts
+++ b/server/src/domain/auth/service.ts
@@ -1,0 +1,138 @@
+import { createHash, randomBytes, randomInt } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+
+import type { Database } from '../../db/index.ts'
+import { profile, otpCode, refreshToken } from '../../db/schema/index.ts'
+import { ApiError, errors } from '../../contracts/errors.ts'
+import { normalizePhone } from './phone.ts'
+import type { OtpProvider } from './otp-provider.ts'
+
+const OTP_TTL_MS = 5 * 60 * 1000
+const OTP_MAX_ATTEMPTS = 5
+const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex')
+
+export interface VerifyResult {
+  profileId: string
+  accessToken: string
+  refreshToken: string
+  claimedV1: boolean
+}
+
+export class AuthService {
+  constructor(
+    private readonly db: Database,
+    private readonly otp: OtpProvider,
+    private readonly signAccessToken: (profileId: string) => string,
+  ) {}
+
+  // Start verification: generate + store a hashed code, deliver via the provider.
+  // Always succeeds for a valid-format number (don't reveal whether it's known).
+  async requestOtp(rawPhone: string): Promise<{ expiresIn: number }> {
+    const phone = normalizePhone(rawPhone)
+    const code = String(randomInt(0, 1_000_000)).padStart(6, '0')
+    const expiresAt = new Date(Date.now() + OTP_TTL_MS)
+
+    await this.db
+      .insert(otpCode)
+      .values({ phone, codeHash: sha256(`${phone}:${code}`), expiresAt, attempts: 0 })
+      .onConflictDoUpdate({
+        target: otpCode.phone,
+        set: { codeHash: sha256(`${phone}:${code}`), expiresAt, attempts: 0 },
+      })
+
+    await this.otp.send(phone, code)
+    return { expiresIn: Math.floor(OTP_TTL_MS / 1000) }
+  }
+
+  // Verify the code, then claim a pre-migrated shell or create a fresh profile,
+  // and issue tokens. See specs/behaviors/v1-migration.md (claim-on-login).
+  async verifyOtp(rawPhone: string, code: string): Promise<VerifyResult> {
+    const phone = normalizePhone(rawPhone)
+
+    const [row] = await this.db.select().from(otpCode).where(eq(otpCode.phone, phone))
+    if (!row || row.expiresAt.getTime() < Date.now()) {
+      throw new ApiError(400, 'otp_expired', 'Code expired or not found')
+    }
+    if (row.attempts >= OTP_MAX_ATTEMPTS) {
+      throw errors.rateLimited('Too many attempts; request a new code')
+    }
+    if (row.codeHash !== sha256(`${phone}:${code}`)) {
+      await this.db
+        .update(otpCode)
+        .set({ attempts: row.attempts + 1 })
+        .where(eq(otpCode.phone, phone))
+      throw new ApiError(400, 'otp_invalid', 'Incorrect code')
+    }
+
+    // Consume the code.
+    await this.db.delete(otpCode).where(eq(otpCode.phone, phone))
+
+    // Claim shell or create fresh.
+    const [existing] = await this.db.select().from(profile).where(eq(profile.phone, phone))
+    let profileId: string
+    let claimedV1 = false
+    if (existing) {
+      profileId = existing.id
+      if (existing.claimedAt === null) {
+        await this.db
+          .update(profile)
+          .set({ claimedAt: new Date() })
+          .where(eq(profile.id, existing.id))
+        claimedV1 = true // an unclaimed (pre-migrated) shell became active
+      }
+    } else {
+      const [created] = await this.db
+        .insert(profile)
+        .values({ phone, claimedAt: new Date() })
+        .returning({ id: profile.id })
+      profileId = created!.id
+    }
+
+    const tokens = await this.issueTokens(profileId)
+    return { profileId, ...tokens, claimedV1 }
+  }
+
+  // Rotate a refresh token: revoke the presented one, issue a fresh pair.
+  async refresh(rawToken: string): Promise<{ accessToken: string; refreshToken: string }> {
+    const hash = sha256(rawToken)
+    const [row] = await this.db
+      .select()
+      .from(refreshToken)
+      .where(eq(refreshToken.tokenHash, hash))
+
+    if (!row || row.revokedAt !== null) {
+      throw new ApiError(401, 'refresh_invalid', 'Invalid refresh token')
+    }
+    if (row.expiresAt.getTime() < Date.now()) {
+      throw new ApiError(401, 'refresh_invalid', 'Refresh token expired')
+    }
+
+    await this.revoke(hash)
+    return this.issueTokens(row.profileId)
+  }
+
+  async logout(rawToken: string): Promise<void> {
+    await this.revoke(sha256(rawToken))
+  }
+
+  private async revoke(tokenHash: string): Promise<void> {
+    await this.db
+      .update(refreshToken)
+      .set({ revokedAt: new Date() })
+      .where(eq(refreshToken.tokenHash, tokenHash))
+  }
+
+  private async issueTokens(
+    profileId: string,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const raw = randomBytes(32).toString('base64url')
+    await this.db.insert(refreshToken).values({
+      profileId,
+      tokenHash: sha256(raw),
+      expiresAt: new Date(Date.now() + REFRESH_TTL_MS),
+    })
+    return { accessToken: this.signAccessToken(profileId), refreshToken: raw }
+  }
+}

--- a/server/src/plugins/auth.ts
+++ b/server/src/plugins/auth.ts
@@ -1,0 +1,56 @@
+import fp from 'fastify-plugin'
+import type { FastifyRequest } from 'fastify'
+import jwt from 'jsonwebtoken'
+
+import { errors } from '../contracts/errors.ts'
+
+const ACCESS_TTL = '15m'
+
+interface AccessClaims {
+  sub: string // profile id
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    // Signs a short-lived access token for a profile.
+    signAccessToken(profileId: string): string
+    // preHandler that requires a valid bearer token; sets request.profileId.
+    authenticate(request: FastifyRequest): Promise<void>
+  }
+  interface FastifyRequest {
+    profileId: string | null
+  }
+}
+
+function extractBearer(request: FastifyRequest): string | null {
+  const header = request.headers.authorization
+  if (!header) return null
+  const [scheme, token] = header.split(' ')
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return null
+  return token
+}
+
+// JWT bearer auth (access tokens). Refresh tokens are opaque + DB-backed (see
+// domain/auth). See specs/api/conventions.md (Auth).
+export default fp(async (fastify) => {
+  const secret = fastify.config.JWT_SECRET
+
+  fastify.decorate('signAccessToken', (profileId: string) =>
+    jwt.sign({ sub: profileId } satisfies AccessClaims, secret, {
+      expiresIn: ACCESS_TTL,
+    }),
+  )
+
+  fastify.decorateRequest('profileId', null)
+
+  fastify.decorate('authenticate', async (request: FastifyRequest) => {
+    const token = extractBearer(request)
+    if (!token) throw errors.unauthorized()
+    try {
+      const claims = jwt.verify(token, secret) as AccessClaims
+      request.profileId = claims.sub
+    } catch {
+      throw errors.unauthorized('Invalid or expired token')
+    }
+  })
+})

--- a/server/src/plugins/client-version.ts
+++ b/server/src/plugins/client-version.ts
@@ -1,0 +1,53 @@
+import fp from 'fastify-plugin'
+
+import { type ErrorEnvelope } from '../contracts/errors.ts'
+
+// Parsed `X-SquadQuest-Client: <platform>/<version>+<build>` (e.g. ios/1.4.2+312).
+export interface ClientBuild {
+  platform: string
+  version: string
+  build: number
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    clientBuild: ClientBuild | null
+  }
+}
+
+const HEADER = 'x-squadquest-client'
+
+export function parseClientHeader(value: string | undefined): ClientBuild | null {
+  if (!value) return null
+  const m = /^([^/]+)\/(.+)\+(\d+)$/.exec(value.trim())
+  if (!m) return null
+  return { platform: m[1]!, version: m[2]!, build: Number(m[3]) }
+}
+
+// Parses the client-build header onto request.clientBuild (telemetry) and
+// enforces the upgrade floor: a present build below MIN_SUPPORTED_BUILD gets a
+// 426 with the upgrade envelope. See specs/api/conventions.md.
+//
+// Stage 1 simplification: the header is not hard-required (the spec says it is);
+// when absent we allow the request. Tightening that is a later-stage follow-up.
+export default fp(async (fastify) => {
+  const floor = fastify.config.MIN_SUPPORTED_BUILD
+
+  fastify.decorateRequest('clientBuild', null)
+
+  fastify.addHook('onRequest', async (request, reply) => {
+    const build = parseClientHeader(request.headers[HEADER] as string | undefined)
+    request.clientBuild = build
+
+    if (floor > 0 && build && build.build < floor) {
+      const body: ErrorEnvelope = {
+        error: {
+          code: 'upgrade_required',
+          message: 'This app version is no longer supported. Please update.',
+        },
+        upgrade: { min_build: floor, store_url: 'https://squadquest.app' },
+      }
+      reply.code(426).send(body)
+    }
+  })
+})

--- a/server/src/plugins/client-version.ts
+++ b/server/src/plugins/client-version.ts
@@ -47,7 +47,8 @@ export default fp(async (fastify) => {
         },
         upgrade: { min_build: floor, store_url: 'https://squadquest.app' },
       }
-      reply.code(426).send(body)
+      // Return the reply to halt the request lifecycle (don't run the route).
+      return reply.code(426).send(body)
     }
   })
 })

--- a/server/src/plugins/env.ts
+++ b/server/src/plugins/env.ts
@@ -3,7 +3,7 @@ import fastifyEnv from '@fastify/env'
 
 const schema = {
   type: 'object',
-  required: [],
+  required: ['DATABASE_URL', 'JWT_SECRET'],
   properties: {
     PORT: { type: 'number', default: 4000 },
     HOST: { type: 'string', default: '0.0.0.0' },
@@ -17,6 +17,11 @@ const schema = {
       enum: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
       default: 'info',
     },
+    DATABASE_URL: { type: 'string' },
+    JWT_SECRET: { type: 'string', minLength: 32 },
+    // Lowest client build allowed; requests below it get 426 (see
+    // specs/api/conventions.md). 0 = no floor.
+    MIN_SUPPORTED_BUILD: { type: 'number', default: 0 },
   },
 }
 
@@ -27,6 +32,9 @@ declare module 'fastify' {
       HOST: string
       NODE_ENV: 'development' | 'production' | 'test'
       LOG_LEVEL: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
+      DATABASE_URL: string
+      JWT_SECRET: string
+      MIN_SUPPORTED_BUILD: number
     }
   }
 }

--- a/server/src/routes/v1/auth.ts
+++ b/server/src/routes/v1/auth.ts
@@ -1,0 +1,97 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { eq } from 'drizzle-orm'
+
+import { profile } from '../../db/schema/index.ts'
+import { serializeProfile } from '../../contracts/profile.ts'
+import { AuthService } from '../../domain/auth/service.ts'
+import { ConsoleOtpProvider } from '../../domain/auth/otp-provider.ts'
+
+// POST /v1/auth/otp/{request,verify}, /refresh, /logout. See specs/api/auth.md.
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  // Dev-stub OTP delivery for now (logs the code); swap for a real SMS provider
+  // in a later stage.
+  const auth = new AuthService(
+    fastify.db,
+    new ConsoleOtpProvider(fastify.log),
+    (profileId) => fastify.signAccessToken(profileId),
+  )
+
+  fastify.post<{ Body: { phone: string } }>(
+    '/auth/otp/request',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          required: ['phone'],
+          properties: { phone: { type: 'string' } },
+        },
+      },
+    },
+    async (request) => {
+      const { expiresIn } = await auth.requestOtp(request.body.phone)
+      return { expires_in: expiresIn }
+    },
+  )
+
+  fastify.post<{ Body: { phone: string; code: string } }>(
+    '/auth/otp/verify',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          required: ['phone', 'code'],
+          properties: { phone: { type: 'string' }, code: { type: 'string' } },
+        },
+      },
+    },
+    async (request) => {
+      const result = await auth.verifyOtp(request.body.phone, request.body.code)
+      const [row] = await fastify.db
+        .select()
+        .from(profile)
+        .where(eq(profile.id, result.profileId))
+      return {
+        access_token: result.accessToken,
+        refresh_token: result.refreshToken,
+        profile: serializeProfile(row!),
+        claimed_v1: result.claimedV1,
+      }
+    },
+  )
+
+  fastify.post<{ Body: { refresh_token: string } }>(
+    '/auth/refresh',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          required: ['refresh_token'],
+          properties: { refresh_token: { type: 'string' } },
+        },
+      },
+    },
+    async (request) => {
+      const t = await auth.refresh(request.body.refresh_token)
+      return { access_token: t.accessToken, refresh_token: t.refreshToken }
+    },
+  )
+
+  fastify.post<{ Body: { refresh_token: string } }>(
+    '/auth/logout',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          required: ['refresh_token'],
+          properties: { refresh_token: { type: 'string' } },
+        },
+      },
+    },
+    async (request, reply) => {
+      await auth.logout(request.body.refresh_token)
+      reply.code(204)
+    },
+  )
+}
+
+export default authRoutes

--- a/server/src/routes/v1/friends.ts
+++ b/server/src/routes/v1/friends.ts
@@ -1,0 +1,35 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { and, eq, or, inArray } from 'drizzle-orm'
+
+import { profile, friendship } from '../../db/schema/index.ts'
+import { serializeFriend } from '../../contracts/friend.ts'
+
+// GET /v1/friends — the authenticated user's accepted friend graph (includes
+// not-yet-claimed friends, flagged on_v2:false). See specs/behaviors/v1-migration.md.
+const friendsRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/friends', { preHandler: fastify.authenticate }, async (request) => {
+    const me = request.profileId!
+
+    const edges = await fastify.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          eq(friendship.status, 'accepted'),
+          or(eq(friendship.requester, me), eq(friendship.requestee, me)),
+        ),
+      )
+
+    const friendIds = edges.map((e) => (e.requester === me ? e.requestee : e.requester))
+    if (friendIds.length === 0) return { items: [] }
+
+    const rows = await fastify.db
+      .select()
+      .from(profile)
+      .where(inArray(profile.id, friendIds))
+
+    return { items: rows.map(serializeFriend) }
+  })
+}
+
+export default friendsRoutes

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -1,12 +1,18 @@
 import type { FastifyPluginAsync } from 'fastify'
 
 import healthRoutes from './health.ts'
+import authRoutes from './auth.ts'
+import meRoutes from './me.ts'
+import friendsRoutes from './friends.ts'
 
 // The /v1 contract surface. All client-facing endpoints register under here so
 // the URL major version is the coarse contract boundary (see
 // specs/api/conventions.md). New endpoints are additive; break by superseding.
 const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(healthRoutes)
+  await fastify.register(authRoutes)
+  await fastify.register(meRoutes)
+  await fastify.register(friendsRoutes)
 }
 
 export default v1Routes

--- a/server/src/routes/v1/me.ts
+++ b/server/src/routes/v1/me.ts
@@ -1,0 +1,20 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { eq } from 'drizzle-orm'
+
+import { profile } from '../../db/schema/index.ts'
+import { serializeProfile } from '../../contracts/profile.ts'
+import { errors } from '../../contracts/errors.ts'
+
+// GET /v1/me — the authenticated user's profile.
+const meRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/me', { preHandler: fastify.authenticate }, async (request) => {
+    const [row] = await fastify.db
+      .select()
+      .from(profile)
+      .where(eq(profile.id, request.profileId!))
+    if (!row) throw errors.unauthorized()
+    return serializeProfile(row)
+  })
+}
+
+export default meRoutes

--- a/server/test/auth.test.ts
+++ b/server/test/auth.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// Test env defaults (CI provides a Postgres service; locally use docker-compose
+// on 5532). Set before importing the app so @fastify/env picks them up.
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '500'
+
+const { app } = await import('../src/app.ts')
+
+const logs: Array<Record<string, unknown>> = []
+let server: FastifyInstance
+
+beforeAll(async () => {
+  server = Fastify({
+    logger: {
+      level: 'info',
+      stream: {
+        write: (s: string) => {
+          try {
+            logs.push(JSON.parse(s))
+          } catch {
+            /* ignore */
+          }
+        },
+      },
+    },
+  })
+  await server.register(app)
+  await server.ready()
+  await server.sql`truncate profile, friendship, topic, topic_subscription, otp_code, refresh_token cascade`
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+function lastOtp(): string {
+  const entry = [...logs].reverse().find((l) => typeof l.code === 'string')
+  if (!entry) throw new Error('no OTP code logged')
+  return entry.code as string
+}
+
+async function login(phone: string) {
+  await server.inject({
+    method: 'POST',
+    url: '/v1/auth/otp/request',
+    payload: { phone },
+  })
+  const verify = await server.inject({
+    method: 'POST',
+    url: '/v1/auth/otp/verify',
+    payload: { phone, code: lastOtp() },
+  })
+  return verify
+}
+
+test('otp → verify creates a fresh profile and issues tokens', async () => {
+  const res = await login('215-555-0100')
+  expect(res.statusCode).toBe(200)
+  const body = res.json()
+  expect(body.access_token).toBeString()
+  expect(body.refresh_token).toBeString()
+  expect(body.claimed_v1).toBe(false) // brand-new user, no shell
+  expect(body.profile.phone).toBe('+12155550100') // normalized to E.164
+})
+
+test('GET /v1/me requires auth and returns the profile', async () => {
+  const { access_token } = (await login('215-555-0101')).json()
+
+  const unauth = await server.inject({ method: 'GET', url: '/v1/me' })
+  expect(unauth.statusCode).toBe(401)
+  expect(unauth.json().error.code).toBe('unauthorized')
+
+  const me = await server.inject({
+    method: 'GET',
+    url: '/v1/me',
+    headers: { authorization: `Bearer ${access_token}` },
+  })
+  expect(me.statusCode).toBe(200)
+  expect(me.json().phone).toBe('+12155550101')
+})
+
+test('claim-on-login: verifying an unclaimed shell sets claimed_v1', async () => {
+  await server.sql`insert into profile (phone, first_name, claimed_at) values ('+12155559999', 'Dana', null)`
+  const body = (await login('+12155559999')).json()
+  expect(body.claimed_v1).toBe(true)
+  expect(body.profile.first_name).toBe('Dana')
+})
+
+test('GET /v1/friends returns the accepted graph, flagging unclaimed friends', async () => {
+  const me = (await login('215-555-0102')).json()
+  const meId = me.profile.id
+  const [shell] = await server.sql`
+    insert into profile (phone, first_name, claimed_at)
+    values ('+12155558888', 'Unclaimed', null) returning id`
+  await server.sql`
+    insert into friendship (requester, requestee, status)
+    values (${meId}, ${shell.id}, 'accepted')`
+
+  const res = await server.inject({
+    method: 'GET',
+    url: '/v1/friends',
+    headers: { authorization: `Bearer ${me.access_token}` },
+  })
+  expect(res.statusCode).toBe(200)
+  const items = res.json().items
+  expect(items).toHaveLength(1)
+  expect(items[0].first_name).toBe('Unclaimed')
+  expect(items[0].on_v2).toBe(false)
+})
+
+test('426 below the supported build floor (MIN_SUPPORTED_BUILD=500)', async () => {
+  const below = await server.inject({
+    method: 'GET',
+    url: '/v1/health',
+    headers: { 'x-squadquest-client': 'ios/1.0.0+100' },
+  })
+  expect(below.statusCode).toBe(426)
+  expect(below.json().upgrade.min_build).toBe(500)
+
+  const ok = await server.inject({
+    method: 'GET',
+    url: '/v1/health',
+    headers: { 'x-squadquest-client': 'ios/2.0.0+600' },
+  })
+  expect(ok.statusCode).toBe(200)
+})
+
+test('refresh rotates and logout revokes', async () => {
+  const { refresh_token } = (await login('215-555-0103')).json()
+
+  const refreshed = await server.inject({
+    method: 'POST',
+    url: '/v1/auth/refresh',
+    payload: { refresh_token },
+  })
+  expect(refreshed.statusCode).toBe(200)
+  expect(refreshed.json().refresh_token).not.toBe(refresh_token) // rotated
+
+  // old token is now revoked
+  const reuse = await server.inject({
+    method: 'POST',
+    url: '/v1/auth/refresh',
+    payload: { refresh_token },
+  })
+  expect(reuse.statusCode).toBe(401)
+})

--- a/server/test/client-version.test.ts
+++ b/server/test/client-version.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test'
+
+import { parseClientHeader } from '../src/plugins/client-version.ts'
+
+test('parses a well-formed client header', () => {
+  expect(parseClientHeader('ios/1.4.2+312')).toEqual({
+    platform: 'ios',
+    version: '1.4.2',
+    build: 312,
+  })
+})
+
+test('handles android + multi-dot versions', () => {
+  expect(parseClientHeader('android/2.0.0-beta.1+1099')).toEqual({
+    platform: 'android',
+    version: '2.0.0-beta.1',
+    build: 1099,
+  })
+})
+
+test('returns null for missing or malformed headers', () => {
+  expect(parseClientHeader(undefined)).toBeNull()
+  expect(parseClientHeader('')).toBeNull()
+  expect(parseClientHeader('garbage')).toBeNull()
+  expect(parseClientHeader('ios/1.0.0')).toBeNull() // no build
+})


### PR DESCRIPTION
First slice of the v2 backend (`server/`) — the foundation everything else builds on. Delivers a verifiable end state: **a user can request an OTP, verify it, get JWTs, claim/create their profile, and read their profile + friend graph through the versioned `/v1` API.**

Implements `specs/api/conventions.md`, `specs/api/auth.md`, and the identity slice of `specs/data-model.md`. (First stage of the `v2-backend-and-migration` umbrella.)

## What's here

- **DB:** Drizzle ORM + drizzle-kit + postgres.js. Identity schema (`profile`, `friendship`, `topic`, `topic_subscription`) + auth tables (`otp_code`, `refresh_token`). `fastify.db` plugin, first migration, local `docker-compose.yml` (Postgres on host **5532**).
- **`/v1` conventions:** the standard error envelope + `ApiError` + global handler; `X-SquadQuest-Client` parsing + `MIN_SUPPORTED_BUILD` → `426` upgrade envelope; JWT bearer auth (`fastify.authenticate`).
- **Auth (`specs/api/auth.md`):** `POST /v1/auth/otp/request`, `/otp/verify`, `/refresh`, `/logout`. OTP behind a swappable `OtpProvider` (dev-stub `ConsoleOtpProvider` logs the code); access = JWT (15m), refresh = opaque, hashed, rotating. **Claim-on-login by phone** (binds a pre-migrated shell → `claimed_v1`, else creates fresh).
- **Identity reads:** `GET /v1/me`, `GET /v1/friends` (accepted graph; unclaimed friends flagged `on_v2:false`).
- **Tests + CI:** 9 tests (header-parser unit + full auth/identity integration via `fastify.inject`); `pr-test` server job gains a `postgres:17` service + `db:migrate` + `bun test`.

## Verification (local, against docker-compose Postgres)

`bun run type-check` clean; `bun test` 9/9 green. Manual: otp→verify (phone normalized to E.164, fresh user `claimed_v1:false`), shell claim → `claimed_v1:true`, `/friends` shows `on_v2:false` for an unclaimed friend, `/me` 200 authed / 401 unauthed, `426` below the build floor.

## Stage-1 simplifications (intentional; follow-ups)

- Client-build header not hard-required when absent (spec says required).
- US-centric best-effort phone normalization (no libphonenumber).
- Minimal OTP rate-limiting.

## Next stages (umbrella `v2-backend-and-migration`)

Bulk v1→v2 pre-migration job; ideas/activities + timeline; communities; squads/messages; SSE realtime; real SMS provider; storage/signed URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)