### PR TITLE
v2 backend Stage 2: ideas/activities + friends timeline

### DIFF
--- a/plans/v2-backend-and-migration.md
+++ b/plans/v2-backend-and-migration.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: cancelled
 depends: [specops-foundation]
 specs:
   - specs/architecture.md
@@ -16,6 +16,16 @@ pr:
 ---
 
 # Plan: Stand up the v2 backend + v1 migration
+
+> **Cancelled — superseded by staged plans.** This was the original "build the whole
+> backend" umbrella. It proved too big for one unit and was decomposed into incremental,
+> independently-shippable stages (below). Kept for history; do not implement directly. The
+> spec ownership now lives on the stage plans, not here.
+>
+> - `v2-backend-stage1-auth` — API foundation + auth + identity ✅ (#408)
+> - `v2-backend-stage2-activities` — ideas/activities + friends timeline (in progress)
+> - *future stages:* communities; squads + messages; SSE realtime; bulk v1→v2 pre-migration
+>   job; real SMS provider; storage/signed URLs.
 
 ## Scope
 
@@ -59,4 +69,10 @@ populated friends timeline.)
 
 ## Notes
 
+Cancelled and decomposed into staged plans (see the banner above) once it was clear the full
+backend wouldn't land as one PR. Each stage carries its own specs/validation; this file
+remains only as the roadmap breadcrumb.
+
 ## Follow-ups
+
+Tracked by the stage plans listed in the banner.

--- a/plans/v2-backend-stage2-activities.md
+++ b/plans/v2-backend-stage2-activities.md
@@ -1,0 +1,73 @@
+---
+status: in-progress
+depends: [v2-backend-stage1-auth]
+specs:
+  - specs/api/ideas-activities.md
+  - specs/api/timeline.md
+  - specs/data-model.md
+  - specs/behaviors/ideas-activities-lifecycle.md
+  - specs/behaviors/response-system.md
+issues: []
+pr:
+---
+
+# Plan: v2 backend Stage 2 — ideas/activities + friends timeline
+
+## Scope
+
+The core social loop on top of Stage 1: the idea↔activity lifecycle and the My Friends
+timeline. Backend only. Friends-scoped only (squad scope, community link / event_ref /
+bring-friends, threads/messages, and SSE realtime are deferred to their own stages).
+
+Audience: both `all_friends` and `people`-targeted (adds `activity_audience` + per-viewer
+visibility filtering).
+
+## Implements
+
+`specs/api/ideas-activities.md`, friends section of `specs/api/timeline.md`, activity slice
+of `specs/data-model.md`, `behaviors/{ideas-activities-lifecycle,response-system}.md`.
+
+## Approach
+
+- **Schema** (`src/db/schema/activity.ts` + migration): `activity` (captain, activity_type→
+  topic, state idea|confirmed, scope friends|squad default friends, audience_kind
+  all_friends|people, allow_suggestions, confirmed_time/location_option FKs, created/confirmed
+  timestamps; squad_id + community_event_id nullable/unused), `activity_option` (kind
+  time|location, label, created_by), `option_vote` (option,profile), `response`
+  (activity,profile,value), `activity_audience` (activity,profile).
+- **Domain** (`src/domain/activity/`): createIdea (friends-only, transactional, options +
+  people-audience rows), set/clear response, add option (allow_suggestions + visibility),
+  toggle vote, confirm (captain-only). **Visibility predicate** reused by reads + write authz:
+  viewer sees an activity iff captain ∈ {viewer} ∪ accepted-friends(viewer) AND
+  (audience_kind=all_friends OR viewer ∈ activity_audience).
+- **Serializer** (`src/contracts/activity.ts`): batched wire-shape assembler (options w/ vote
+  counts + you_voted, your_response, counts, confirmed_time/location labels, audience.summary;
+  thread_count:0, event_ref:null, squad_id:null this stage).
+- **Routes** (`src/routes/v1/{ideas,timeline}.ts`, authed): POST /v1/ideas; PUT/DELETE
+  /v1/ideas/:id/response; POST /v1/ideas/:id/options; PUT /v1/ideas/:id/votes; POST
+  /v1/ideas/:id/confirm; GET /v1/timeline/friends (cursor created_at,id).
+
+## Validation
+
+- [ ] migration applies; `bun run type-check` clean.
+- [ ] create idea (all_friends + people) → appears on `GET /v1/timeline/friends` for an
+      in-audience friend; hidden from a non-friend and an out-of-audience user.
+- [ ] response set/clear updates your_response + counts; option suggest gated by
+      allow_suggestions; vote toggle updates votes/you_voted.
+- [ ] confirm as captain → state=confirmed + confirmed_time/location; non-captain → 403
+      not_captain.
+- [ ] cursor pagination walks history; `bun test` + `pr-test` server job green.
+
+## Risks / unknowns
+
+- Visibility query (friend graph × audience) correctness + avoiding N+1 in the page serializer.
+- Stable cursor over (created_at, id).
+- `activity_option` single-table-with-kind is an impl choice vs the spec's two named concepts.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-backend-stage2-activities.md
+++ b/plans/v2-backend-stage2-activities.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-backend-stage1-auth]
 specs:
   - specs/api/ideas-activities.md
@@ -8,7 +8,7 @@ specs:
   - specs/behaviors/ideas-activities-lifecycle.md
   - specs/behaviors/response-system.md
 issues: []
-pr:
+pr: 409
 ---
 
 # Plan: v2 backend Stage 2 — ideas/activities + friends timeline
@@ -49,14 +49,14 @@ of `specs/data-model.md`, `behaviors/{ideas-activities-lifecycle,response-system
 
 ## Validation
 
-- [ ] migration applies; `bun run type-check` clean.
-- [ ] create idea (all_friends + people) → appears on `GET /v1/timeline/friends` for an
+- [x] migration applies; `bun run type-check` clean.
+- [x] create idea (all_friends + people) → appears on `GET /v1/timeline/friends` for an
       in-audience friend; hidden from a non-friend and an out-of-audience user.
-- [ ] response set/clear updates your_response + counts; option suggest gated by
+- [x] response set/clear updates your_response + counts; option suggest gated by
       allow_suggestions; vote toggle updates votes/you_voted.
-- [ ] confirm as captain → state=confirmed + confirmed_time/location; non-captain → 403
+- [x] confirm as captain → state=confirmed + confirmed_time/location; non-captain → 403
       not_captain.
-- [ ] cursor pagination walks history; `bun test` + `pr-test` server job green.
+- [x] cursor pagination walks history; `bun test` + `pr-test` server job green.
 
 ## Risks / unknowns
 

--- a/server/migrations/0001_glorious_selene.sql
+++ b/server/migrations/0001_glorious_selene.sql
@@ -1,0 +1,58 @@
+CREATE TYPE "public"."activity_scope" AS ENUM('friends', 'squad');--> statement-breakpoint
+CREATE TYPE "public"."activity_state" AS ENUM('idea', 'confirmed');--> statement-breakpoint
+CREATE TYPE "public"."audience_kind" AS ENUM('all_friends', 'people');--> statement-breakpoint
+CREATE TYPE "public"."option_kind" AS ENUM('time', 'location');--> statement-breakpoint
+CREATE TYPE "public"."response_value" AS ENUM('in', 'interested', 'next_time');--> statement-breakpoint
+CREATE TABLE "activity" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"captain_id" uuid NOT NULL,
+	"activity_type_id" uuid NOT NULL,
+	"state" "activity_state" DEFAULT 'idea' NOT NULL,
+	"scope" "activity_scope" DEFAULT 'friends' NOT NULL,
+	"squad_id" uuid,
+	"audience_kind" "audience_kind" DEFAULT 'all_friends' NOT NULL,
+	"allow_suggestions" boolean DEFAULT false NOT NULL,
+	"confirmed_time_option_id" uuid,
+	"confirmed_location_option_id" uuid,
+	"community_event_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"confirmed_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "activity_audience" (
+	"activity_id" uuid NOT NULL,
+	"profile_id" uuid NOT NULL,
+	CONSTRAINT "activity_audience_activity_id_profile_id_pk" PRIMARY KEY("activity_id","profile_id")
+);
+--> statement-breakpoint
+CREATE TABLE "activity_option" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"activity_id" uuid NOT NULL,
+	"kind" "option_kind" NOT NULL,
+	"label" text NOT NULL,
+	"created_by" uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "option_vote" (
+	"option_id" uuid NOT NULL,
+	"profile_id" uuid NOT NULL,
+	CONSTRAINT "option_vote_option_id_profile_id_pk" PRIMARY KEY("option_id","profile_id")
+);
+--> statement-breakpoint
+CREATE TABLE "response" (
+	"activity_id" uuid NOT NULL,
+	"profile_id" uuid NOT NULL,
+	"value" "response_value" NOT NULL,
+	CONSTRAINT "response_activity_id_profile_id_pk" PRIMARY KEY("activity_id","profile_id")
+);
+--> statement-breakpoint
+ALTER TABLE "activity" ADD CONSTRAINT "activity_captain_id_profile_id_fk" FOREIGN KEY ("captain_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity" ADD CONSTRAINT "activity_activity_type_id_topic_id_fk" FOREIGN KEY ("activity_type_id") REFERENCES "public"."topic"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_audience" ADD CONSTRAINT "activity_audience_activity_id_activity_id_fk" FOREIGN KEY ("activity_id") REFERENCES "public"."activity"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_audience" ADD CONSTRAINT "activity_audience_profile_id_profile_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_option" ADD CONSTRAINT "activity_option_activity_id_activity_id_fk" FOREIGN KEY ("activity_id") REFERENCES "public"."activity"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_option" ADD CONSTRAINT "activity_option_created_by_profile_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "option_vote" ADD CONSTRAINT "option_vote_option_id_activity_option_id_fk" FOREIGN KEY ("option_id") REFERENCES "public"."activity_option"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "option_vote" ADD CONSTRAINT "option_vote_profile_id_profile_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "response" ADD CONSTRAINT "response_activity_id_activity_id_fk" FOREIGN KEY ("activity_id") REFERENCES "public"."activity"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "response" ADD CONSTRAINT "response_profile_id_profile_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/migrations/meta/0001_snapshot.json
+++ b/server/migrations/meta/0001_snapshot.json
@@ -1,0 +1,820 @@
+{
+  "id": "671aa870-52d0-4cdd-8639-48363e3e4917",
+  "prevId": "b4ce033e-d00b-4b6f-a434-17de7de7da8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester": {
+          "name": "requester",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestee": {
+          "name": "requestee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_requester_profile_id_fk": {
+          "name": "friendship_requester_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requester"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_requestee_profile_id_fk": {
+          "name": "friendship_requestee_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requestee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "friendship_pair": {
+          "name": "friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "requester",
+            "requestee"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_phone_unique": {
+          "name": "profile_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "noun": {
+          "name": "noun",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_subscription": {
+      "name": "topic_subscription",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_subscription_topic_id_topic_id_fk": {
+          "name": "topic_subscription_topic_id_topic_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_subscription_profile_id_profile_id_fk": {
+          "name": "topic_subscription_profile_id_profile_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_subscription_topic_id_profile_id_pk": {
+          "name": "topic_subscription_topic_id_profile_id_pk",
+          "columns": [
+            "topic_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_code": {
+      "name": "otp_code",
+      "schema": "",
+      "columns": {
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_token": {
+      "name": "refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_token_profile_id_profile_id_fk": {
+          "name": "refresh_token_profile_id_profile_id_fk",
+          "tableFrom": "refresh_token",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_token_token_hash_unique": {
+          "name": "refresh_token_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "activity_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "activity_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_kind": {
+          "name": "audience_kind",
+          "type": "audience_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_friends'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmed_time_option_id": {
+          "name": "confirmed_time_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_location_option_id": {
+          "name": "confirmed_location_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_event_id": {
+          "name": "community_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_captain_id_profile_id_fk": {
+          "name": "activity_captain_id_profile_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_activity_type_id_topic_id_fk": {
+          "name": "activity_activity_type_id_topic_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_audience": {
+      "name": "activity_audience",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_audience_activity_id_activity_id_fk": {
+          "name": "activity_audience_activity_id_activity_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_audience_profile_id_profile_id_fk": {
+          "name": "activity_audience_profile_id_profile_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_audience_activity_id_profile_id_pk": {
+          "name": "activity_audience_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_option": {
+      "name": "activity_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "option_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_option_activity_id_activity_id_fk": {
+          "name": "activity_option_activity_id_activity_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_option_created_by_profile_id_fk": {
+          "name": "activity_option_created_by_profile_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.option_vote": {
+      "name": "option_vote",
+      "schema": "",
+      "columns": {
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "option_vote_option_id_activity_option_id_fk": {
+          "name": "option_vote_option_id_activity_option_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "activity_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "option_vote_profile_id_profile_id_fk": {
+          "name": "option_vote_profile_id_profile_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "option_vote_option_id_profile_id_pk": {
+          "name": "option_vote_option_id_profile_id_pk",
+          "columns": [
+            "option_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response": {
+      "name": "response",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "response_activity_id_activity_id_fk": {
+          "name": "response_activity_id_activity_id_fk",
+          "tableFrom": "response",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "response_profile_id_profile_id_fk": {
+          "name": "response_profile_id_profile_id_fk",
+          "tableFrom": "response",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "response_activity_id_profile_id_pk": {
+          "name": "response_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.activity_scope": {
+      "name": "activity_scope",
+      "schema": "public",
+      "values": [
+        "friends",
+        "squad"
+      ]
+    },
+    "public.activity_state": {
+      "name": "activity_state",
+      "schema": "public",
+      "values": [
+        "idea",
+        "confirmed"
+      ]
+    },
+    "public.audience_kind": {
+      "name": "audience_kind",
+      "schema": "public",
+      "values": [
+        "all_friends",
+        "people"
+      ]
+    },
+    "public.option_kind": {
+      "name": "option_kind",
+      "schema": "public",
+      "values": [
+        "time",
+        "location"
+      ]
+    },
+    "public.response_value": {
+      "name": "response_value",
+      "schema": "public",
+      "values": [
+        "in",
+        "interested",
+        "next_time"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780963135162,
       "tag": "0000_minor_rage",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1780972500889,
+      "tag": "0001_glorious_selene",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/contracts/activity.ts
+++ b/server/src/contracts/activity.ts
@@ -1,0 +1,134 @@
+import { inArray } from 'drizzle-orm'
+
+import type { Database } from '../db/index.ts'
+import {
+  activity,
+  activityOption,
+  activityAudience,
+  optionVote,
+  response,
+  profile,
+  topic,
+} from '../db/schema/index.ts'
+
+type ActivityRow = typeof activity.$inferSelect
+
+// Batched assembler: serialize a page of activity rows into the wire shape
+// (specs/api/ideas-activities.md) for `viewer`, loading options/votes/responses/
+// captains/types in one pass each to avoid N+1. Output preserves input order.
+export async function serializeActivities(
+  db: Database,
+  viewerId: string,
+  rows: ActivityRow[],
+) {
+  if (rows.length === 0) return []
+
+  const ids = rows.map((r) => r.id)
+  const captainIds = [...new Set(rows.map((r) => r.captainId))]
+  const typeIds = [...new Set(rows.map((r) => r.activityTypeId))]
+
+  const [captains, types, options, audienceRows, responses] = await Promise.all([
+    db.select().from(profile).where(inArray(profile.id, captainIds)),
+    db.select().from(topic).where(inArray(topic.id, typeIds)),
+    db.select().from(activityOption).where(inArray(activityOption.activityId, ids)),
+    db.select().from(activityAudience).where(inArray(activityAudience.activityId, ids)),
+    db.select().from(response).where(inArray(response.activityId, ids)),
+  ])
+
+  const optionIds = options.map((o) => o.id)
+  const votes = optionIds.length
+    ? await db.select().from(optionVote).where(inArray(optionVote.optionId, optionIds))
+    : []
+
+  const captainById = new Map(captains.map((c) => [c.id, c]))
+  const typeById = new Map(types.map((t) => [t.id, t]))
+  const optionById = new Map(options.map((o) => [o.id, o]))
+
+  // votes per option + whether viewer voted
+  const voteCount = new Map<string, number>()
+  const youVoted = new Set<string>()
+  for (const v of votes) {
+    voteCount.set(v.optionId, (voteCount.get(v.optionId) ?? 0) + 1)
+    if (v.profileId === viewerId) youVoted.add(v.optionId)
+  }
+
+  // responses per activity
+  const respCounts = new Map<string, { in: number; interested: number }>()
+  const yourResponse = new Map<string, string>()
+  for (const r of responses) {
+    const c = respCounts.get(r.activityId) ?? { in: 0, interested: 0 }
+    if (r.value === 'in') c.in += 1
+    else if (r.value === 'interested') c.interested += 1
+    respCounts.set(r.activityId, c)
+    if (r.profileId === viewerId) yourResponse.set(r.activityId, r.value)
+  }
+
+  // people-audience counts per activity
+  const audienceCount = new Map<string, number>()
+  for (const a of audienceRows) {
+    audienceCount.set(a.activityId, (audienceCount.get(a.activityId) ?? 0) + 1)
+  }
+
+  const optionsByActivity = new Map<string, typeof options>()
+  for (const o of options) {
+    const list = optionsByActivity.get(o.activityId) ?? []
+    list.push(o)
+    optionsByActivity.set(o.activityId, list)
+  }
+
+  const serializeOption = (o: (typeof options)[number]) => ({
+    id: o.id,
+    label: o.label,
+    votes: voteCount.get(o.id) ?? 0,
+    you_voted: youVoted.has(o.id),
+  })
+
+  return rows.map((r) => {
+    const captain = captainById.get(r.captainId)
+    const type = typeById.get(r.activityTypeId)
+    const opts = optionsByActivity.get(r.id) ?? []
+    const counts = respCounts.get(r.id) ?? { in: 0, interested: 0 }
+
+    const audienceSummary =
+      r.audienceKind === 'all_friends'
+        ? 'all friends'
+        : `${audienceCount.get(r.id) ?? 0} ${
+            (audienceCount.get(r.id) ?? 0) === 1 ? 'person' : 'people'
+          }`
+
+    return {
+      id: r.id,
+      state: r.state,
+      captain: captain
+        ? { id: captain.id, first_name: captain.firstName, photo: captain.photo }
+        : null,
+      activity_type: type ? { id: type.id, label: type.label } : null,
+      scope: r.scope,
+      squad_id: r.squadId,
+      audience: { kind: r.audienceKind, summary: audienceSummary },
+      allow_suggestions: r.allowSuggestions,
+      time_options: opts.filter((o) => o.kind === 'time').map(serializeOption),
+      location_options: opts.filter((o) => o.kind === 'location').map(serializeOption),
+      confirmed_time: r.confirmedTimeOptionId
+        ? (optionById.get(r.confirmedTimeOptionId)?.label ?? null)
+        : null,
+      confirmed_location: r.confirmedLocationOptionId
+        ? (optionById.get(r.confirmedLocationOptionId)?.label ?? null)
+        : null,
+      your_response: yourResponse.get(r.id) ?? null,
+      counts,
+      thread_count: 0, // threads/messages arrive in a later stage
+      event_ref: null, // bring-friends/community link arrives in a later stage
+      created_at: r.createdAt.toISOString(),
+    }
+  })
+}
+
+export async function serializeActivity(
+  db: Database,
+  viewerId: string,
+  row: ActivityRow,
+) {
+  const [one] = await serializeActivities(db, viewerId, [row])
+  return one
+}

--- a/server/src/db/schema/activity.ts
+++ b/server/src/db/schema/activity.ts
@@ -1,0 +1,108 @@
+import {
+  pgTable,
+  pgEnum,
+  uuid,
+  text,
+  boolean,
+  timestamp,
+  primaryKey,
+} from 'drizzle-orm/pg-core'
+
+import { profile, topic } from './identity.ts'
+
+export const activityState = pgEnum('activity_state', ['idea', 'confirmed'])
+export const activityScope = pgEnum('activity_scope', ['friends', 'squad'])
+export const audienceKind = pgEnum('audience_kind', ['all_friends', 'people'])
+export const optionKind = pgEnum('option_kind', ['time', 'location'])
+export const responseValue = pgEnum('response_value', [
+  'in',
+  'interested',
+  'next_time',
+])
+
+// The central two-state record: an `idea` while tentative, a `confirmed` activity
+// once the captain locks a time + place — two states of one row. See
+// specs/behaviors/ideas-activities-lifecycle.md.
+//
+// Stage 2 wires friends scope + all_friends/people audience. `squad_id` and
+// `community_event_id` columns exist for later stages but are unused (no FK yet —
+// the squad/community tables don't exist). `confirmed_*_option_id` are plain uuids
+// (no FK) to avoid a circular activity↔activity_option constraint; integrity is
+// enforced in the domain layer.
+export const activity = pgTable('activity', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  captainId: uuid('captain_id')
+    .notNull()
+    .references(() => profile.id, { onDelete: 'cascade' }),
+  activityTypeId: uuid('activity_type_id')
+    .notNull()
+    .references(() => topic.id),
+  state: activityState('state').notNull().default('idea'),
+  scope: activityScope('scope').notNull().default('friends'),
+  squadId: uuid('squad_id'),
+  audienceKind: audienceKind('audience_kind').notNull().default('all_friends'),
+  allowSuggestions: boolean('allow_suggestions').notNull().default(false),
+  confirmedTimeOptionId: uuid('confirmed_time_option_id'),
+  confirmedLocationOptionId: uuid('confirmed_location_option_id'),
+  communityEventId: uuid('community_event_id'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  confirmedAt: timestamp('confirmed_at', { withTimezone: true }),
+})
+
+// Proposed time/location options on an activity.
+export const activityOption = pgTable('activity_option', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  activityId: uuid('activity_id')
+    .notNull()
+    .references(() => activity.id, { onDelete: 'cascade' }),
+  kind: optionKind('kind').notNull(),
+  label: text('label').notNull(),
+  createdBy: uuid('created_by')
+    .notNull()
+    .references(() => profile.id, { onDelete: 'cascade' }),
+})
+
+// Who voted for which option.
+export const optionVote = pgTable(
+  'option_vote',
+  {
+    optionId: uuid('option_id')
+      .notNull()
+      .references(() => activityOption.id, { onDelete: 'cascade' }),
+    profileId: uuid('profile_id')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+  },
+  (t) => [primaryKey({ columns: [t.optionId, t.profileId] })],
+)
+
+// A participant's inline response. Absence = passive dismiss (no decline value).
+export const response = pgTable(
+  'response',
+  {
+    activityId: uuid('activity_id')
+      .notNull()
+      .references(() => activity.id, { onDelete: 'cascade' }),
+    profileId: uuid('profile_id')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+    value: responseValue('value').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.activityId, t.profileId] })],
+)
+
+// Recipients when audience_kind = people (empty for all_friends).
+export const activityAudience = pgTable(
+  'activity_audience',
+  {
+    activityId: uuid('activity_id')
+      .notNull()
+      .references(() => activity.id, { onDelete: 'cascade' }),
+    profileId: uuid('profile_id')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+  },
+  (t) => [primaryKey({ columns: [t.activityId, t.profileId] })],
+)

--- a/server/src/db/schema/index.ts
+++ b/server/src/db/schema/index.ts
@@ -1,2 +1,3 @@
 export * from './identity.ts'
 export * from './auth.ts'
+export * from './activity.ts'

--- a/server/src/domain/activity/service.ts
+++ b/server/src/domain/activity/service.ts
@@ -1,0 +1,261 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm'
+
+import type { Database } from '../../db/index.ts'
+import {
+  activity,
+  activityOption,
+  activityAudience,
+  optionVote,
+  response,
+  friendship,
+  topic,
+} from '../../db/schema/index.ts'
+import { ApiError, errors } from '../../contracts/errors.ts'
+
+export interface CreateIdeaInput {
+  activityTypeId: string
+  scope?: 'friends' | 'squad'
+  squadId?: string
+  audience: { kind: 'all_friends' | 'people'; personIds?: string[] }
+  allowSuggestions?: boolean
+  timeOptions?: string[]
+  locationOptions?: string[]
+  communityEventId?: string
+}
+
+type ActivityRow = typeof activity.$inferSelect
+
+export class ActivityService {
+  constructor(private readonly db: Database) {}
+
+  // Accepted friends of a profile (both directions of the double-opt-in graph).
+  async acceptedFriendIds(profileId: string): Promise<string[]> {
+    const edges = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          eq(friendship.status, 'accepted'),
+          or(
+            eq(friendship.requester, profileId),
+            eq(friendship.requestee, profileId),
+          ),
+        ),
+      )
+    return edges.map((e) => (e.requester === profileId ? e.requestee : e.requester))
+  }
+
+  // Can `viewer` see this activity? viewer is captain, or captain is an accepted
+  // friend AND (audience all_friends OR viewer is a named recipient).
+  async canView(viewerId: string, act: ActivityRow): Promise<boolean> {
+    if (act.scope !== 'friends') return false // squad scope not handled this stage
+    if (act.captainId === viewerId) return true
+    const friends = await this.acceptedFriendIds(viewerId)
+    if (!friends.includes(act.captainId)) return false
+    if (act.audienceKind === 'all_friends') return true
+    const [aud] = await this.db
+      .select()
+      .from(activityAudience)
+      .where(
+        and(
+          eq(activityAudience.activityId, act.id),
+          eq(activityAudience.profileId, viewerId),
+        ),
+      )
+    return Boolean(aud)
+  }
+
+  async getViewable(viewerId: string, activityId: string): Promise<ActivityRow> {
+    const [act] = await this.db.select().from(activity).where(eq(activity.id, activityId))
+    if (!act || !(await this.canView(viewerId, act))) {
+      // Don't distinguish "not found" from "not allowed".
+      throw new ApiError(404, 'not_found', 'Activity not found')
+    }
+    return act
+  }
+
+  // Create an idea (always starts in `idea` state). Friends-scoped only this stage.
+  async createIdea(captainId: string, input: CreateIdeaInput): Promise<string> {
+    if (input.scope && input.scope !== 'friends') {
+      throw errors.badRequest('unsupported_scope', 'Only friends-scoped ideas are supported')
+    }
+    if (input.communityEventId) {
+      throw errors.badRequest('unsupported', 'Community events are not available yet')
+    }
+    if (input.audience.kind === 'people' && !input.audience.personIds?.length) {
+      throw errors.badRequest('audience_required', 'people audience requires person_ids')
+    }
+
+    const [type] = await this.db
+      .select()
+      .from(topic)
+      .where(eq(topic.id, input.activityTypeId))
+    if (!type) throw errors.badRequest('activity_type_invalid', 'Unknown activity type')
+
+    return this.db.transaction(async (tx) => {
+      const [created] = await tx
+        .insert(activity)
+        .values({
+          captainId,
+          activityTypeId: input.activityTypeId,
+          state: 'idea',
+          scope: 'friends',
+          audienceKind: input.audience.kind,
+          allowSuggestions: input.allowSuggestions ?? false,
+        })
+        .returning({ id: activity.id })
+      const activityId = created!.id
+
+      const options = [
+        ...(input.timeOptions ?? []).map((label) => ({ kind: 'time' as const, label })),
+        ...(input.locationOptions ?? []).map((label) => ({
+          kind: 'location' as const,
+          label,
+        })),
+      ]
+      if (options.length) {
+        await tx
+          .insert(activityOption)
+          .values(options.map((o) => ({ activityId, createdBy: captainId, ...o })))
+      }
+
+      if (input.audience.kind === 'people') {
+        const ids = [...new Set(input.audience.personIds!)]
+        await tx
+          .insert(activityAudience)
+          .values(ids.map((profileId) => ({ activityId, profileId })))
+      }
+
+      return activityId
+    })
+  }
+
+  async setResponse(
+    viewerId: string,
+    activityId: string,
+    value: 'in' | 'interested' | 'next_time',
+  ): Promise<void> {
+    await this.getViewable(viewerId, activityId)
+    await this.db
+      .insert(response)
+      .values({ activityId, profileId: viewerId, value })
+      .onConflictDoUpdate({
+        target: [response.activityId, response.profileId],
+        set: { value },
+      })
+  }
+
+  async clearResponse(viewerId: string, activityId: string): Promise<void> {
+    await this.getViewable(viewerId, activityId)
+    await this.db
+      .delete(response)
+      .where(and(eq(response.activityId, activityId), eq(response.profileId, viewerId)))
+  }
+
+  async addOption(
+    viewerId: string,
+    activityId: string,
+    kind: 'time' | 'location',
+    label: string,
+  ): Promise<void> {
+    const act = await this.getViewable(viewerId, activityId)
+    if (!act.allowSuggestions) {
+      throw errors.forbidden('suggestions_disabled', 'Suggestions are not enabled')
+    }
+    await this.db.insert(activityOption).values({ activityId, kind, label, createdBy: viewerId })
+  }
+
+  async toggleVote(
+    viewerId: string,
+    activityId: string,
+    optionId: string,
+    voted: boolean,
+  ): Promise<void> {
+    await this.getViewable(viewerId, activityId)
+    const [opt] = await this.db
+      .select()
+      .from(activityOption)
+      .where(and(eq(activityOption.id, optionId), eq(activityOption.activityId, activityId)))
+    if (!opt) throw errors.badRequest('option_invalid', 'Unknown option for this activity')
+
+    if (voted) {
+      await this.db
+        .insert(optionVote)
+        .values({ optionId, profileId: viewerId })
+        .onConflictDoNothing()
+    } else {
+      await this.db
+        .delete(optionVote)
+        .where(and(eq(optionVote.optionId, optionId), eq(optionVote.profileId, viewerId)))
+    }
+  }
+
+  // Captain locks time + place → promotes idea to confirmed activity (same row).
+  async confirm(
+    viewerId: string,
+    activityId: string,
+    input: { timeOptionId?: string; locationOptionId?: string },
+  ): Promise<void> {
+    const [act] = await this.db.select().from(activity).where(eq(activity.id, activityId))
+    if (!act) throw new ApiError(404, 'not_found', 'Activity not found')
+    if (act.captainId !== viewerId) throw errors.forbidden('not_captain', 'Only the captain can confirm')
+
+    // Validate the chosen options belong to this activity and match kind.
+    const validate = async (id: string | undefined, kind: 'time' | 'location') => {
+      if (!id) return
+      const [opt] = await this.db
+        .select()
+        .from(activityOption)
+        .where(and(eq(activityOption.id, id), eq(activityOption.activityId, activityId)))
+      if (!opt || opt.kind !== kind) {
+        throw errors.badRequest('option_invalid', `Invalid ${kind} option`)
+      }
+    }
+    await validate(input.timeOptionId, 'time')
+    await validate(input.locationOptionId, 'location')
+
+    await this.db
+      .update(activity)
+      .set({
+        state: 'confirmed',
+        confirmedTimeOptionId: input.timeOptionId ?? null,
+        confirmedLocationOptionId: input.locationOptionId ?? null,
+        confirmedAt: new Date(),
+      })
+      .where(eq(activity.id, activityId))
+  }
+
+  // The My Friends timeline: friends-scoped activities visible to the viewer,
+  // newest first, cursor-paginated over (created_at, id).
+  async friendsTimeline(
+    viewerId: string,
+    limit: number,
+    before?: { createdAt: Date; id: string },
+  ): Promise<ActivityRow[]> {
+    const friendIds = [viewerId, ...(await this.acceptedFriendIds(viewerId))]
+
+    const visible = or(
+      eq(activity.audienceKind, 'all_friends'),
+      eq(activity.captainId, viewerId),
+      sql`exists (select 1 from ${activityAudience} aa where aa.activity_id = ${activity.id} and aa.profile_id = ${viewerId})`,
+    )
+
+    const cursor = before
+      ? sql`(${activity.createdAt}, ${activity.id}) < (${before.createdAt.toISOString()}, ${before.id})`
+      : undefined
+
+    return this.db
+      .select()
+      .from(activity)
+      .where(
+        and(
+          eq(activity.scope, 'friends'),
+          inArray(activity.captainId, friendIds),
+          visible,
+          ...(cursor ? [cursor] : []),
+        ),
+      )
+      .orderBy(sql`${activity.createdAt} desc, ${activity.id} desc`)
+      .limit(limit)
+  }
+}

--- a/server/src/routes/v1/ideas.ts
+++ b/server/src/routes/v1/ideas.ts
@@ -1,0 +1,119 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { eq } from 'drizzle-orm'
+
+import { activity } from '../../db/schema/index.ts'
+import { ActivityService, type CreateIdeaInput } from '../../domain/activity/service.ts'
+import { serializeActivity } from '../../contracts/activity.ts'
+
+// Ideas/activities lifecycle. See specs/api/ideas-activities.md. All authed.
+const ideaRoutes: FastifyPluginAsync = async (fastify) => {
+  const svc = new ActivityService(fastify.db)
+
+  // Re-load + serialize a single activity for the response body.
+  const respond = async (viewerId: string, activityId: string) => {
+    const [row] = await fastify.db.select().from(activity).where(eq(activity.id, activityId))
+    return serializeActivity(fastify.db, viewerId, row!)
+  }
+
+  fastify.post<{ Body: CreateIdeaInput }>(
+    '/ideas',
+    { preHandler: fastify.authenticate },
+    async (request, reply) => {
+      const id = await svc.createIdea(request.profileId!, request.body)
+      reply.code(201)
+      return respond(request.profileId!, id)
+    },
+  )
+
+  fastify.put<{ Params: { id: string }; Body: { value: 'in' | 'interested' | 'next_time' } }>(
+    '/ideas/:id/response',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['value'],
+          properties: { value: { type: 'string', enum: ['in', 'interested', 'next_time'] } },
+        },
+      },
+    },
+    async (request) => {
+      await svc.setResponse(request.profileId!, request.params.id, request.body.value)
+      return respond(request.profileId!, request.params.id)
+    },
+  )
+
+  fastify.delete<{ Params: { id: string } }>(
+    '/ideas/:id/response',
+    { preHandler: fastify.authenticate },
+    async (request) => {
+      await svc.clearResponse(request.profileId!, request.params.id)
+      return respond(request.profileId!, request.params.id)
+    },
+  )
+
+  fastify.post<{ Params: { id: string }; Body: { kind: 'time' | 'location'; label: string } }>(
+    '/ideas/:id/options',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['kind', 'label'],
+          properties: {
+            kind: { type: 'string', enum: ['time', 'location'] },
+            label: { type: 'string', minLength: 1 },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      await svc.addOption(request.profileId!, request.params.id, request.body.kind, request.body.label)
+      reply.code(201)
+      return respond(request.profileId!, request.params.id)
+    },
+  )
+
+  fastify.put<{ Params: { id: string }; Body: { option_id: string; voted: boolean } }>(
+    '/ideas/:id/votes',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['option_id', 'voted'],
+          properties: {
+            option_id: { type: 'string' },
+            voted: { type: 'boolean' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      await svc.toggleVote(
+        request.profileId!,
+        request.params.id,
+        request.body.option_id,
+        request.body.voted,
+      )
+      return respond(request.profileId!, request.params.id)
+    },
+  )
+
+  fastify.post<{
+    Params: { id: string }
+    Body: { time_option_id?: string; location_option_id?: string }
+  }>(
+    '/ideas/:id/confirm',
+    { preHandler: fastify.authenticate },
+    async (request) => {
+      await svc.confirm(request.profileId!, request.params.id, {
+        timeOptionId: request.body?.time_option_id,
+        locationOptionId: request.body?.location_option_id,
+      })
+      return respond(request.profileId!, request.params.id)
+    },
+  )
+}
+
+export default ideaRoutes

--- a/server/src/routes/v1/ideas.ts
+++ b/server/src/routes/v1/ideas.ts
@@ -2,8 +2,20 @@ import type { FastifyPluginAsync } from 'fastify'
 import { eq } from 'drizzle-orm'
 
 import { activity } from '../../db/schema/index.ts'
-import { ActivityService, type CreateIdeaInput } from '../../domain/activity/service.ts'
+import { ActivityService } from '../../domain/activity/service.ts'
 import { serializeActivity } from '../../contracts/activity.ts'
+
+// Wire (snake_case) body for POST /ideas — mapped to the domain's CreateIdeaInput.
+interface CreateIdeaBody {
+  activity_type_id: string
+  scope?: 'friends' | 'squad'
+  squad_id?: string
+  audience: { kind: 'all_friends' | 'people'; person_ids?: string[] }
+  allow_suggestions?: boolean
+  time_options?: string[]
+  location_options?: string[]
+  community_event_id?: string
+}
 
 // Ideas/activities lifecycle. See specs/api/ideas-activities.md. All authed.
 const ideaRoutes: FastifyPluginAsync = async (fastify) => {
@@ -15,11 +27,21 @@ const ideaRoutes: FastifyPluginAsync = async (fastify) => {
     return serializeActivity(fastify.db, viewerId, row!)
   }
 
-  fastify.post<{ Body: CreateIdeaInput }>(
+  fastify.post<{ Body: CreateIdeaBody }>(
     '/ideas',
     { preHandler: fastify.authenticate },
     async (request, reply) => {
-      const id = await svc.createIdea(request.profileId!, request.body)
+      const b = request.body
+      const id = await svc.createIdea(request.profileId!, {
+        activityTypeId: b.activity_type_id,
+        scope: b.scope,
+        squadId: b.squad_id,
+        audience: { kind: b.audience.kind, personIds: b.audience.person_ids },
+        allowSuggestions: b.allow_suggestions,
+        timeOptions: b.time_options,
+        locationOptions: b.location_options,
+        communityEventId: b.community_event_id,
+      })
       reply.code(201)
       return respond(request.profileId!, id)
     },

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -4,6 +4,8 @@ import healthRoutes from './health.ts'
 import authRoutes from './auth.ts'
 import meRoutes from './me.ts'
 import friendsRoutes from './friends.ts'
+import ideaRoutes from './ideas.ts'
+import timelineRoutes from './timeline.ts'
 
 // The /v1 contract surface. All client-facing endpoints register under here so
 // the URL major version is the coarse contract boundary (see
@@ -13,6 +15,8 @@ const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(authRoutes)
   await fastify.register(meRoutes)
   await fastify.register(friendsRoutes)
+  await fastify.register(ideaRoutes)
+  await fastify.register(timelineRoutes)
 }
 
 export default v1Routes

--- a/server/src/routes/v1/timeline.ts
+++ b/server/src/routes/v1/timeline.ts
@@ -1,0 +1,59 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+import { ActivityService } from '../../domain/activity/service.ts'
+import { serializeActivities } from '../../contracts/activity.ts'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
+
+// Opaque cursor over (created_at, id).
+function encodeCursor(createdAt: Date, id: string): string {
+  return Buffer.from(`${createdAt.toISOString()}|${id}`).toString('base64url')
+}
+function decodeCursor(raw: string): { createdAt: Date; id: string } | undefined {
+  try {
+    const [iso, id] = Buffer.from(raw, 'base64url').toString().split('|')
+    if (!iso || !id) return undefined
+    return { createdAt: new Date(iso), id }
+  } catch {
+    return undefined
+  }
+}
+
+// GET /v1/timeline/friends — the My Friends feed (ideas/activities only),
+// cursor-paginated newest-first. See specs/api/timeline.md.
+const timelineRoutes: FastifyPluginAsync = async (fastify) => {
+  const svc = new ActivityService(fastify.db)
+
+  fastify.get<{ Querystring: { limit?: number; before?: string } }>(
+    '/timeline/friends',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        querystring: {
+          type: 'object',
+          properties: {
+            limit: { type: 'integer', minimum: 1, maximum: MAX_LIMIT },
+            before: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const limit = Math.min(request.query.limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+      const before = request.query.before ? decodeCursor(request.query.before) : undefined
+
+      // Fetch one extra to know whether there's a next page.
+      const rows = await svc.friendsTimeline(request.profileId!, limit + 1, before)
+      const page = rows.slice(0, limit)
+      const last = page.at(-1)
+      const nextCursor =
+        rows.length > limit && last ? encodeCursor(last.createdAt, last.id) : null
+
+      const items = await serializeActivities(fastify.db, request.profileId!, page)
+      return { items, next_cursor: nextCursor }
+    },
+  )
+}
+
+export default timelineRoutes

--- a/server/test/activities.test.ts
+++ b/server/test/activities.test.ts
@@ -1,0 +1,260 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '0'
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+let topicId: string
+
+// Create a profile directly + mint an access token for it (skips OTP).
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  const token = server.signAccessToken(row.id)
+  return { id: row.id, token, auth: { authorization: `Bearer ${token}` } }
+}
+
+async function befriend(a: string, b: string) {
+  await server.sql`insert into friendship (requester, requestee, status) values (${a}, ${b}, 'accepted')`
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+beforeEach(async () => {
+  await server.sql`truncate activity, friendship, profile cascade`
+  const [t] = await server.sql<{ id: string }[]>`
+    insert into topic (noun, verb, label) values ('Paddleboarding', 'Go', 'Go Paddleboarding')
+    returning id`
+  topicId = t.id
+})
+
+test('create idea (all_friends) appears for a friend, hidden from a stranger', async () => {
+  const captain = await makeUser('+12150000001')
+  const friend = await makeUser('+12150000002')
+  const stranger = await makeUser('+12150000003')
+  await befriend(captain.id, friend.id)
+
+  const created = await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: captain.auth,
+    payload: {
+      activity_type_id: topicId,
+      audience: { kind: 'all_friends' },
+      allow_suggestions: true,
+      time_options: ['Sat 7am', 'Sun 8am'],
+    },
+  })
+  expect(created.statusCode).toBe(201)
+  expect(created.json().state).toBe('idea')
+  expect(created.json().time_options).toHaveLength(2)
+
+  const forFriend = await server.inject({
+    method: 'GET',
+    url: '/v1/timeline/friends',
+    headers: friend.auth,
+  })
+  expect(forFriend.json().items).toHaveLength(1)
+
+  const forStranger = await server.inject({
+    method: 'GET',
+    url: '/v1/timeline/friends',
+    headers: stranger.auth,
+  })
+  expect(forStranger.json().items).toHaveLength(0)
+})
+
+test('people-targeted idea is visible only to named recipients', async () => {
+  const captain = await makeUser('+12150000010')
+  const invited = await makeUser('+12150000011')
+  const other = await makeUser('+12150000012')
+  await befriend(captain.id, invited.id)
+  await befriend(captain.id, other.id)
+
+  await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: captain.auth,
+    payload: {
+      activity_type_id: topicId,
+      audience: { kind: 'people', person_ids: [invited.id] },
+    },
+  })
+
+  const a = await server.inject({ method: 'GET', url: '/v1/timeline/friends', headers: invited.auth })
+  expect(a.json().items).toHaveLength(1)
+  expect(a.json().items[0].audience).toEqual({ kind: 'people', summary: '1 person' })
+
+  const b = await server.inject({ method: 'GET', url: '/v1/timeline/friends', headers: other.auth })
+  expect(b.json().items).toHaveLength(0)
+})
+
+test('respond sets and clears your_response + counts', async () => {
+  const captain = await makeUser('+12150000020')
+  const friend = await makeUser('+12150000021')
+  await befriend(captain.id, friend.id)
+  const id = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/ideas',
+      headers: captain.auth,
+      payload: { activity_type_id: topicId, audience: { kind: 'all_friends' } },
+    })
+  ).json().id
+
+  const responded = await server.inject({
+    method: 'PUT',
+    url: `/v1/ideas/${id}/response`,
+    headers: friend.auth,
+    payload: { value: 'in' },
+  })
+  expect(responded.json().your_response).toBe('in')
+  expect(responded.json().counts.in).toBe(1)
+
+  const cleared = await server.inject({
+    method: 'DELETE',
+    url: `/v1/ideas/${id}/response`,
+    headers: friend.auth,
+  })
+  expect(cleared.json().your_response).toBeNull()
+  expect(cleared.json().counts.in).toBe(0)
+})
+
+test('suggest option is gated by allow_suggestions; voting toggles', async () => {
+  const captain = await makeUser('+12150000030')
+  const friend = await makeUser('+12150000031')
+  await befriend(captain.id, friend.id)
+
+  // allow_suggestions defaults false
+  const closed = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/ideas',
+      headers: captain.auth,
+      payload: { activity_type_id: topicId, audience: { kind: 'all_friends' } },
+    })
+  ).json()
+  const denied = await server.inject({
+    method: 'POST',
+    url: `/v1/ideas/${closed.id}/options`,
+    headers: friend.auth,
+    payload: { kind: 'time', label: 'Mon 6pm' },
+  })
+  expect(denied.statusCode).toBe(403)
+  expect(denied.json().error.code).toBe('suggestions_disabled')
+
+  // open idea with an option → vote toggles
+  const open = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/ideas',
+      headers: captain.auth,
+      payload: {
+        activity_type_id: topicId,
+        audience: { kind: 'all_friends' },
+        allow_suggestions: true,
+        time_options: ['Sat 7am'],
+      },
+    })
+  ).json()
+  const optionId = open.time_options[0].id
+
+  const voted = await server.inject({
+    method: 'PUT',
+    url: `/v1/ideas/${open.id}/votes`,
+    headers: friend.auth,
+    payload: { option_id: optionId, voted: true },
+  })
+  const opt = voted.json().time_options[0]
+  expect(opt.votes).toBe(1)
+  expect(opt.you_voted).toBe(true)
+})
+
+test('confirm is captain-only and promotes idea → activity', async () => {
+  const captain = await makeUser('+12150000040')
+  const friend = await makeUser('+12150000041')
+  await befriend(captain.id, friend.id)
+  const idea = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/ideas',
+      headers: captain.auth,
+      payload: {
+        activity_type_id: topicId,
+        audience: { kind: 'all_friends' },
+        time_options: ['Sun 2pm'],
+        location_options: ['Willamette'],
+      },
+    })
+  ).json()
+
+  const notCaptain = await server.inject({
+    method: 'POST',
+    url: `/v1/ideas/${idea.id}/confirm`,
+    headers: friend.auth,
+    payload: {
+      time_option_id: idea.time_options[0].id,
+      location_option_id: idea.location_options[0].id,
+    },
+  })
+  expect(notCaptain.statusCode).toBe(403)
+  expect(notCaptain.json().error.code).toBe('not_captain')
+
+  const confirmed = await server.inject({
+    method: 'POST',
+    url: `/v1/ideas/${idea.id}/confirm`,
+    headers: captain.auth,
+    payload: {
+      time_option_id: idea.time_options[0].id,
+      location_option_id: idea.location_options[0].id,
+    },
+  })
+  expect(confirmed.statusCode).toBe(200)
+  expect(confirmed.json().state).toBe('confirmed')
+  expect(confirmed.json().confirmed_time).toBe('Sun 2pm')
+  expect(confirmed.json().confirmed_location).toBe('Willamette')
+})
+
+test('friends timeline paginates over a cursor', async () => {
+  const captain = await makeUser('+12150000050')
+  const friend = await makeUser('+12150000051')
+  await befriend(captain.id, friend.id)
+  for (let i = 0; i < 3; i++) {
+    await server.inject({
+      method: 'POST',
+      url: '/v1/ideas',
+      headers: captain.auth,
+      payload: { activity_type_id: topicId, audience: { kind: 'all_friends' } },
+    })
+  }
+
+  const page1 = await server.inject({
+    method: 'GET',
+    url: '/v1/timeline/friends?limit=2',
+    headers: friend.auth,
+  })
+  expect(page1.json().items).toHaveLength(2)
+  expect(page1.json().next_cursor).toBeString()
+
+  const page2 = await server.inject({
+    method: 'GET',
+    url: `/v1/timeline/friends?limit=2&before=${page1.json().next_cursor}`,
+    headers: friend.auth,
+  })
+  expect(page2.json().items).toHaveLength(1)
+  expect(page2.json().next_cursor).toBeNull()
+})


### PR DESCRIPTION
The core social loop on top of Stage 1 (#408): the idea↔activity lifecycle and the My Friends timeline. Backend only.

Implements `specs/api/ideas-activities.md`, the friends section of `specs/api/timeline.md`, the activity slice of `specs/data-model.md`, and `behaviors/ideas-activities-lifecycle.md` + `response-system.md`.

## What's here

- **Schema** (migration 0001): `activity` (two-state idea|confirmed), `activity_option` (time|location), `option_vote`, `response`, `activity_audience`.
- **Domain** (`ActivityService`): create idea (friends-scoped, transactional, options + people-audience), set/clear response, suggest option (gated by `allow_suggestions`), toggle vote, **captain-only confirm** (idea→activity). One **visibility predicate** — *viewer is captain, or captain is an accepted friend AND (audience all_friends OR viewer is a named recipient)* — reused for both reads and write authz; `getViewable` 404s rather than leak existence.
- **Endpoints** (all authed): `POST /v1/ideas`; `PUT`/`DELETE /v1/ideas/:id/response`; `POST /v1/ideas/:id/options`; `PUT /v1/ideas/:id/votes`; `POST /v1/ideas/:id/confirm`; `GET /v1/timeline/friends` (cursor over created_at,id).
- **Serializer**: one batched assembler (options/votes/responses/captains/types loaded in a single pass each) → the activity wire shape, avoiding N+1 on the timeline page.

## Verification

`bun run type-check` clean; `bun test` 15/15 (6 Stage-1 + 9 Stage-2 incl. the new activities suite). Covered: all_friends + people-targeted visibility (friend sees, stranger/out-of-audience don't), response set/clear + counts, suggestion gating, vote toggle, captain-only confirm with confirmed_time/location, cursor pagination.

## Scope notes (deferred to later stages)

Friends scope only — squad scope, the community link / `event_ref` / bring-friends, threads/messages (`thread_count` stays 0), and SSE realtime are their own stages. `squad_id`/`community_event_id` columns exist unused; `confirmed_*_option_id` are plain uuids (no FK) to avoid a circular constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)