### PR TITLE
feat(app): flutter_driver entrypoint for MCP-driven UI testing

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -57,8 +57,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_driver:
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -72,6 +85,11 @@ packages:
     version: "6.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -139,6 +157,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -176,6 +210,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -208,6 +250,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
 sdks:
   dart: ">=3.12.1 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/app/test_driver/app.dart
+++ b/app/test_driver/app.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_driver/driver_extension.dart';
+
+import 'package:squadquest/main.dart' as app;
+
+// Driver entrypoint: enables the Flutter Driver extension so the app can be
+// driven/inspected over the VM service (e.g. via the Dart MCP server) without
+// touching the production main(). Run with:
+//   flutter run test_driver/app.dart -d macos
+void main() {
+  enableFlutterDriverExtension();
+  app.main();
+}


### PR DESCRIPTION
Adds `app/test_driver/app.dart` (enables the Flutter Driver extension + runs the app) and `flutter_driver` to dev_dependencies, so the app can be **launched, inspected, driven, and screenshotted** over the VM service via the dart MCP.

This closes the capability gap from earlier tonight: the dart MCP now runs on the correct SDK (Flutter 3.44.1 / Dart 3.12.1, after the stale-process restart), and with the driver extension enabled I validated the full loop on macOS:

1. `flutter run test_driver/app.dart -d macos`
2. `dtd` → listDtdUris → connect
3. `widget_inspector get_widget_tree` (see structure)
4. `flutter_driver_command screenshot` → counter at **0**
5. `flutter_driver_command tap` (FAB, tooltip "Increment") ×2
6. screenshot → counter at **2** ✅

This unblocks self-verifiable UI work (e.g. wiring the `app/` client to the `/v1` API and confirming real flows visually). Pairs with the `flutter-add-integration-test` skill for turning these MCP actions into committed integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)