### PR TITLE
v2 client Stage 2: interactive timeline (compose + respond/vote/confirm)

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -49,6 +49,9 @@ class ApiClient {
   Future<Map<String, dynamic>> post(String path, {Object? body}) =>
       _send(() => _dio.post(path, data: body));
 
+  Future<Map<String, dynamic>> put(String path, {Object? body}) =>
+      _send(() => _dio.put(path, data: body));
+
   Future<Map<String, dynamic>> delete(String path, {Object? body}) =>
       _send(() => _dio.delete(path, data: body));
 

--- a/app/lib/models/activity.dart
+++ b/app/lib/models/activity.dart
@@ -5,6 +5,7 @@ class Activity {
   const Activity({
     required this.id,
     required this.state,
+    this.captainId,
     this.captainName,
     this.activityTypeLabel,
     this.audienceSummary,
@@ -20,6 +21,7 @@ class Activity {
 
   final String id;
   final String state; // 'idea' | 'confirmed'
+  final String? captainId;
   final String? captainName;
   final String? activityTypeLabel;
   final String? audienceSummary;
@@ -47,6 +49,7 @@ class Activity {
     return Activity(
       id: json['id'] as String,
       state: json['state'] as String? ?? 'idea',
+      captainId: captain?['id'] as String?,
       captainName: captain?['first_name'] as String?,
       activityTypeLabel: type?['label'] as String?,
       audienceSummary: audience?['summary'] as String?,

--- a/app/lib/models/topic.dart
+++ b/app/lib/models/topic.dart
@@ -1,0 +1,17 @@
+/// An activity type (specs/api/ideas-activities.md): a noun/verb pair with a
+/// display label, chosen when composing an idea.
+class Topic {
+  const Topic({required this.id, required this.label, this.noun, this.verb});
+
+  final String id;
+  final String label;
+  final String? noun;
+  final String? verb;
+
+  factory Topic.fromJson(Map<String, dynamic> json) => Topic(
+    id: json['id'] as String,
+    label: json['label'] as String? ?? '',
+    noun: json['noun'] as String?,
+    verb: json['verb'] as String?,
+  );
+}

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -2,10 +2,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../api/api_client.dart';
 import '../config.dart';
+import '../models/topic.dart';
+import '../repositories/activity_repository.dart';
 import '../repositories/auth_repository.dart';
 import '../repositories/profile_repository.dart';
 import '../repositories/timeline_repository.dart';
 import '../repositories/token_store.dart';
+import '../repositories/topic_repository.dart';
 import 'auth_controller.dart';
 
 /// Dependency-injection providers. Repositories expose abstract types so tests
@@ -38,7 +41,20 @@ final timelineRepositoryProvider = Provider<TimelineRepository>(
   (ref) => ApiTimelineRepository(apiClient: ref.watch(apiClientProvider)),
 );
 
+final topicRepositoryProvider = Provider<TopicRepository>(
+  (ref) => ApiTopicRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
+final activityRepositoryProvider = Provider<ActivityRepository>(
+  (ref) => ApiActivityRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
 /// The My Friends timeline (specs/screens/friends-timeline.md).
 final friendsTimelineProvider = FutureProvider<TimelinePage>(
   (ref) => ref.watch(timelineRepositoryProvider).friends(),
+);
+
+/// Activity types for the compose-idea form (specs/api/ideas-activities.md).
+final topicsProvider = FutureProvider<List<Topic>>(
+  (ref) => ref.watch(topicRepositoryProvider).list(),
 );

--- a/app/lib/repositories/activity_repository.dart
+++ b/app/lib/repositories/activity_repository.dart
@@ -1,0 +1,111 @@
+import '../api/api_client.dart';
+import '../models/activity.dart';
+
+/// Write actions on ideas/activities (specs/api/ideas-activities.md). Every action
+/// returns the updated [Activity] (the API re-serializes it), so callers can refresh
+/// without a separate read. Friends/all_friends audience only this stage.
+abstract class ActivityRepository {
+  Future<Activity> createIdea({
+    required String activityTypeId,
+    bool allowSuggestions,
+    List<String> timeOptions,
+    List<String> locationOptions,
+  });
+
+  Future<Activity> setResponse(String activityId, String value);
+  Future<Activity> clearResponse(String activityId);
+  Future<Activity> vote(
+    String activityId,
+    String optionId, {
+    required bool voted,
+  });
+  Future<Activity> addOption(String activityId, String kind, String label);
+  Future<Activity> confirm(
+    String activityId, {
+    String? timeOptionId,
+    String? locationOptionId,
+  });
+}
+
+class ApiActivityRepository implements ActivityRepository {
+  ApiActivityRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  @override
+  Future<Activity> createIdea({
+    required String activityTypeId,
+    bool allowSuggestions = false,
+    List<String> timeOptions = const [],
+    List<String> locationOptions = const [],
+  }) async {
+    final res = await apiClient.post(
+      '/v1/ideas',
+      body: {
+        'activity_type_id': activityTypeId,
+        'audience': {'kind': 'all_friends'},
+        'allow_suggestions': allowSuggestions,
+        if (timeOptions.isNotEmpty) 'time_options': timeOptions,
+        if (locationOptions.isNotEmpty) 'location_options': locationOptions,
+      },
+    );
+    return Activity.fromJson(res);
+  }
+
+  @override
+  Future<Activity> setResponse(String activityId, String value) async {
+    final res = await apiClient.put(
+      '/v1/ideas/$activityId/response',
+      body: {'value': value},
+    );
+    return Activity.fromJson(res);
+  }
+
+  @override
+  Future<Activity> clearResponse(String activityId) async {
+    final res = await apiClient.delete('/v1/ideas/$activityId/response');
+    return Activity.fromJson(res);
+  }
+
+  @override
+  Future<Activity> vote(
+    String activityId,
+    String optionId, {
+    required bool voted,
+  }) async {
+    final res = await apiClient.put(
+      '/v1/ideas/$activityId/votes',
+      body: {'option_id': optionId, 'voted': voted},
+    );
+    return Activity.fromJson(res);
+  }
+
+  @override
+  Future<Activity> addOption(
+    String activityId,
+    String kind,
+    String label,
+  ) async {
+    final res = await apiClient.post(
+      '/v1/ideas/$activityId/options',
+      body: {'kind': kind, 'label': label},
+    );
+    return Activity.fromJson(res);
+  }
+
+  @override
+  Future<Activity> confirm(
+    String activityId, {
+    String? timeOptionId,
+    String? locationOptionId,
+  }) async {
+    final res = await apiClient.post(
+      '/v1/ideas/$activityId/confirm',
+      body: {
+        'time_option_id': ?timeOptionId,
+        'location_option_id': ?locationOptionId,
+      },
+    );
+    return Activity.fromJson(res);
+  }
+}

--- a/app/lib/repositories/topic_repository.dart
+++ b/app/lib/repositories/topic_repository.dart
@@ -1,0 +1,20 @@
+import '../api/api_client.dart';
+import '../models/topic.dart';
+
+abstract class TopicRepository {
+  Future<List<Topic>> list();
+}
+
+class ApiTopicRepository implements TopicRepository {
+  ApiTopicRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  @override
+  Future<List<Topic>> list() async {
+    final res = await apiClient.get('/v1/topics');
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => Topic.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'models/activity.dart';
 import 'providers/auth_controller.dart';
+import 'screens/activity/activity_detail_screen.dart';
+import 'screens/compose/compose_idea_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
 
@@ -28,6 +31,12 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/splash', builder: (_, _) => const _Splash()),
       GoRoute(path: '/login', builder: (_, _) => const LoginScreen()),
       GoRoute(path: '/', builder: (_, _) => const TimelineScreen()),
+      GoRoute(path: '/ideas/new', builder: (_, _) => const ComposeIdeaScreen()),
+      GoRoute(
+        path: '/activity/:id',
+        builder: (_, state) =>
+            ActivityDetailScreen(activity: state.extra as Activity?),
+      ),
     ],
   );
 });

--- a/app/lib/screens/activity/activity_detail_screen.dart
+++ b/app/lib/screens/activity/activity_detail_screen.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_exception.dart';
+import '../../models/activity.dart';
+import '../../providers/auth_controller.dart';
+import '../../providers/providers.dart';
+
+/// Activity detail (specs/api/ideas-activities.md + response-system). Seeded from
+/// the [Activity] passed by the timeline; every action returns the updated activity,
+/// which replaces local state and invalidates the timeline so the list stays in sync.
+class ActivityDetailScreen extends ConsumerStatefulWidget {
+  const ActivityDetailScreen({super.key, required this.activity});
+
+  /// May be null on a cold deep-link (no GET /v1/ideas/:id this stage).
+  final Activity? activity;
+
+  @override
+  ConsumerState<ActivityDetailScreen> createState() =>
+      _ActivityDetailScreenState();
+}
+
+class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
+  late Activity? _activity = widget.activity;
+  bool _busy = false;
+  String? _error;
+
+  bool get _isCaptain {
+    final auth = ref.read(authControllerProvider);
+    final me = auth is SignedIn ? auth.profile.id : null;
+    return me != null && _activity?.captainId == me;
+  }
+
+  Future<void> _act(Future<Activity> Function() action) async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final updated = await action();
+      ref.invalidate(friendsTimelineProvider);
+      if (mounted) setState(() => _activity = updated);
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = 'Something went wrong. Please try again.');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final a = _activity;
+    return Scaffold(
+      appBar: AppBar(title: Text(a?.activityTypeLabel ?? 'Activity')),
+      body: a == null
+          ? const Center(
+              key: Key('detailUnavailable'),
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Text(
+                  'Open this from your timeline.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            )
+          : ListView(
+              key: const Key('activityDetail'),
+              padding: const EdgeInsets.all(16),
+              children: [
+                Text(
+                  '${a.captainName ?? 'Someone'} · ${a.activityTypeLabel ?? ''}',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  a.isConfirmed
+                      ? 'Confirmed · ${[a.confirmedTime, a.confirmedLocation].whereType<String>().join(' · ')}'
+                      : 'Idea · ${a.audienceSummary ?? ''}',
+                ),
+                const Divider(height: 32),
+
+                // Your response
+                Text(
+                  'Your response',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                _ResponseSelector(
+                  value: a.yourResponse,
+                  busy: _busy,
+                  onSelect: (v) => _act(
+                    () => v == null
+                        ? ref
+                              .read(activityRepositoryProvider)
+                              .clearResponse(a.id)
+                        : ref
+                              .read(activityRepositoryProvider)
+                              .setResponse(a.id, v),
+                  ),
+                ),
+                Text(
+                  '${a.inCount} in · ${a.interestedCount} interested',
+                  key: const Key('responseCounts'),
+                ),
+
+                if (a.timeOptions.isNotEmpty) ...[
+                  const Divider(height: 32),
+                  Text('When', style: Theme.of(context).textTheme.titleMedium),
+                  for (final o in a.timeOptions)
+                    _OptionTile(
+                      option: o,
+                      busy: _busy,
+                      onVote: (voted) => _act(
+                        () => ref
+                            .read(activityRepositoryProvider)
+                            .vote(a.id, o.id, voted: voted),
+                      ),
+                      onConfirm: _isCaptain && !a.isConfirmed
+                          ? () => _act(
+                              () => ref
+                                  .read(activityRepositoryProvider)
+                                  .confirm(a.id, timeOptionId: o.id),
+                            )
+                          : null,
+                    ),
+                ],
+
+                if (a.locationOptions.isNotEmpty) ...[
+                  const Divider(height: 32),
+                  Text('Where', style: Theme.of(context).textTheme.titleMedium),
+                  for (final o in a.locationOptions)
+                    _OptionTile(
+                      option: o,
+                      busy: _busy,
+                      onVote: (voted) => _act(
+                        () => ref
+                            .read(activityRepositoryProvider)
+                            .vote(a.id, o.id, voted: voted),
+                      ),
+                      onConfirm: _isCaptain && !a.isConfirmed
+                          ? () => _act(
+                              () => ref
+                                  .read(activityRepositoryProvider)
+                                  .confirm(a.id, locationOptionId: o.id),
+                            )
+                          : null,
+                    ),
+                ],
+
+                if (_error != null) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    _error!,
+                    key: const Key('detailError'),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+    );
+  }
+}
+
+class _ResponseSelector extends StatelessWidget {
+  const _ResponseSelector({
+    required this.value,
+    required this.busy,
+    required this.onSelect,
+  });
+
+  final String? value;
+  final bool busy;
+  final void Function(String? value) onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    const labels = {
+      'in': "I'm in",
+      'interested': 'Interested',
+      'next_time': 'Next time',
+    };
+    return Wrap(
+      spacing: 8,
+      children: [
+        for (final entry in labels.entries)
+          ChoiceChip(
+            key: Key('response_${entry.key}'),
+            label: Text(entry.value),
+            selected: value == entry.key,
+            onSelected: busy ? null : (sel) => onSelect(sel ? entry.key : null),
+          ),
+      ],
+    );
+  }
+}
+
+class _OptionTile extends StatelessWidget {
+  const _OptionTile({
+    required this.option,
+    required this.busy,
+    required this.onVote,
+    this.onConfirm,
+  });
+
+  final ActivityOption option;
+  final bool busy;
+  final void Function(bool voted) onVote;
+  final VoidCallback? onConfirm;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: IconButton(
+        icon: Icon(option.youVoted ? Icons.thumb_up : Icons.thumb_up_outlined),
+        onPressed: busy ? null : () => onVote(!option.youVoted),
+      ),
+      title: Text(option.label),
+      subtitle: Text('${option.votes} vote${option.votes == 1 ? '' : 's'}'),
+      trailing: onConfirm == null
+          ? null
+          : TextButton(
+              onPressed: busy ? null : onConfirm,
+              child: const Text('Confirm'),
+            ),
+    );
+  }
+}

--- a/app/lib/screens/activity/activity_detail_screen.dart
+++ b/app/lib/screens/activity/activity_detail_screen.dart
@@ -216,6 +216,7 @@ class _OptionTile extends StatelessWidget {
     return ListTile(
       contentPadding: EdgeInsets.zero,
       leading: IconButton(
+        key: Key('vote_${option.id}'),
         icon: Icon(option.youVoted ? Icons.thumb_up : Icons.thumb_up_outlined),
         onPressed: busy ? null : () => onVote(!option.youVoted),
       ),
@@ -224,6 +225,7 @@ class _OptionTile extends StatelessWidget {
       trailing: onConfirm == null
           ? null
           : TextButton(
+              key: Key('confirm_${option.id}'),
               onPressed: busy ? null : onConfirm,
               child: const Text('Confirm'),
             ),

--- a/app/lib/screens/compose/compose_idea_screen.dart
+++ b/app/lib/screens/compose/compose_idea_screen.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_exception.dart';
+import '../../models/topic.dart';
+import '../../providers/providers.dart';
+
+/// Compose a new idea (specs/api/ideas-activities.md). Friends/all_friends audience
+/// this stage: pick an activity type, optionally allow suggestions and seed a couple
+/// of time/location options, then POST /v1/ideas.
+class ComposeIdeaScreen extends ConsumerStatefulWidget {
+  const ComposeIdeaScreen({super.key});
+
+  @override
+  ConsumerState<ComposeIdeaScreen> createState() => _ComposeIdeaScreenState();
+}
+
+class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
+  String? _topicId;
+  bool _allowSuggestions = false;
+  final _time = TextEditingController();
+  final _location = TextEditingController();
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _time.dispose();
+    _location.dispose();
+    super.dispose();
+  }
+
+  List<String> _split(String raw) =>
+      raw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+
+  Future<void> _submit() async {
+    if (_topicId == null) {
+      setState(() => _error = 'Pick an activity type');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await ref
+          .read(activityRepositoryProvider)
+          .createIdea(
+            activityTypeId: _topicId!,
+            allowSuggestions: _allowSuggestions,
+            timeOptions: _split(_time.text),
+            locationOptions: _split(_location.text),
+          );
+      ref.invalidate(friendsTimelineProvider);
+      if (mounted) context.pop();
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = 'Couldn\'t create your idea. Please try again.');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final topics = ref.watch(topicsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('New idea')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            topics.when(
+              loading: () => const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+              error: (e, _) => Text('Couldn\'t load activity types.\n$e'),
+              data: (list) => DropdownButtonFormField<String>(
+                key: const Key('topicDropdown'),
+                initialValue: _topicId,
+                decoration: const InputDecoration(
+                  labelText: 'Activity type',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  for (final Topic t in list)
+                    DropdownMenuItem(value: t.id, child: Text(t.label)),
+                ],
+                onChanged: (v) => setState(() => _topicId = v),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              key: const Key('timeOptionsField'),
+              controller: _time,
+              decoration: const InputDecoration(
+                labelText: 'Time options (comma-separated)',
+                hintText: 'Sat 7am, Sun 8am',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              key: const Key('locationOptionsField'),
+              controller: _location,
+              decoration: const InputDecoration(
+                labelText: 'Location options (comma-separated)',
+                hintText: 'River, Lake',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              key: const Key('allowSuggestionsSwitch'),
+              title: const Text('Let friends suggest options'),
+              value: _allowSuggestions,
+              onChanged: (v) => setState(() => _allowSuggestions = v),
+            ),
+            const SizedBox(height: 8),
+            FilledButton(
+              key: const Key('createIdeaButton'),
+              onPressed: _busy ? null : _submit,
+              child: Text(_busy ? 'Creating…' : 'Share idea'),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 16),
+              Text(
+                _error!,
+                key: const Key('composeError'),
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../models/activity.dart';
 import '../../providers/auth_controller.dart';
@@ -25,6 +26,12 @@ class TimelineScreen extends ConsumerWidget {
             onPressed: () => ref.read(authControllerProvider.notifier).logout(),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        key: const Key('composeIdeaFab'),
+        tooltip: 'New idea',
+        onPressed: () => context.push('/ideas/new'),
+        child: const Icon(Icons.add),
       ),
       body: RefreshIndicator(
         onRefresh: () async => ref.refresh(friendsTimelineProvider.future),
@@ -92,6 +99,7 @@ class _ActivityTile extends StatelessWidget {
         : 'Idea · ${a.audienceSummary ?? ''}';
 
     return ListTile(
+      onTap: () => context.push('/activity/${a.id}', extra: a),
       leading: CircleAvatar(
         child: Text((a.captainName ?? '?').characters.first),
       ),

--- a/app/test/activity_detail_test.dart
+++ b/app/test/activity_detail_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/activity.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/activity_repository.dart';
+import 'package:squadquest/screens/activity/activity_detail_screen.dart';
+
+/// Fake that echoes a canned updated activity for each action, so the screen's
+/// state-swap + control wiring can be tested without a server.
+class FakeActivityRepository implements ActivityRepository {
+  FakeActivityRepository(this.result);
+  Activity result;
+
+  @override
+  Future<Activity> createIdea({
+    required String activityTypeId,
+    bool allowSuggestions = false,
+    List<String> timeOptions = const [],
+    List<String> locationOptions = const [],
+  }) async => result;
+
+  @override
+  Future<Activity> setResponse(String activityId, String value) async => result;
+  @override
+  Future<Activity> clearResponse(String activityId) async => result;
+  @override
+  Future<Activity> vote(
+    String activityId,
+    String optionId, {
+    required bool voted,
+  }) async => result;
+  @override
+  Future<Activity> addOption(
+    String activityId,
+    String kind,
+    String label,
+  ) async => result;
+  @override
+  Future<Activity> confirm(
+    String activityId, {
+    String? timeOptionId,
+    String? locationOptionId,
+  }) async => result;
+}
+
+void main() {
+  testWidgets('renders options + response counts; vote calls the repo', (
+    tester,
+  ) async {
+    const seed = Activity(
+      id: 'a1',
+      state: 'idea',
+      captainName: 'Katie',
+      activityTypeLabel: 'Paddleboarding',
+      audienceSummary: 'all friends',
+      inCount: 2,
+      interestedCount: 1,
+      timeOptions: [ActivityOption(id: 'o1', label: 'Sat 7am', votes: 1)],
+    );
+    final voted = const Activity(
+      id: 'a1',
+      state: 'idea',
+      captainName: 'Katie',
+      activityTypeLabel: 'Paddleboarding',
+      inCount: 2,
+      interestedCount: 1,
+      timeOptions: [
+        ActivityOption(id: 'o1', label: 'Sat 7am', votes: 2, youVoted: true),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activityRepositoryProvider.overrideWithValue(
+            FakeActivityRepository(voted),
+          ),
+        ],
+        child: const MaterialApp(home: ActivityDetailScreen(activity: seed)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('activityDetail')), findsOneWidget);
+    expect(find.text('2 in · 1 interested'), findsOneWidget);
+    expect(find.text('Sat 7am'), findsOneWidget);
+    expect(find.text('1 vote'), findsOneWidget);
+
+    // Tap the vote button → repo returns the "voted" activity → state swaps.
+    await tester.tap(find.byIcon(Icons.thumb_up_outlined));
+    await tester.pumpAndSettle();
+    expect(find.text('2 votes'), findsOneWidget);
+  });
+
+  testWidgets('shows fallback when opened without an activity', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activityRepositoryProvider.overrideWithValue(
+            FakeActivityRepository(const Activity(id: 'x', state: 'idea')),
+          ),
+        ],
+        child: const MaterialApp(home: ActivityDetailScreen(activity: null)),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('detailUnavailable')), findsOneWidget);
+  });
+}

--- a/plans/v2-client-stage2-interactive-timeline.md
+++ b/plans/v2-client-stage2-interactive-timeline.md
@@ -1,0 +1,67 @@
+---
+status: in-progress
+depends: [v2-client-stage1-auth-timeline]
+specs:
+  - specs/api/ideas-activities.md
+  - specs/screens/friends-timeline.md
+  - specs/behaviors/ideas-activities-lifecycle.md
+  - specs/behaviors/response-system.md
+issues: []
+pr:
+---
+
+# Plan: v2 client Stage 2 — interactive timeline (compose + respond/vote/confirm)
+
+## Scope
+
+Make the My Friends timeline interactive by wiring the rest of the Stage-2 API into the
+client: create an idea, respond (in/interested/next_time), vote on options, suggest an option,
+and (as captain) confirm. Adds the one missing backend bit: `GET /v1/topics`.
+
+Out: people-targeted audience picker (all_friends only this stage); communities/squads/threads;
+polished mock UI re-port; SSE realtime; push.
+
+## Implements
+
+Client side of `specs/api/ideas-activities.md` (POST /ideas, PUT/DELETE response, POST options,
+PUT votes, POST confirm) + `behaviors/{ideas-activities-lifecycle,response-system}.md`; new
+`GET /v1/topics` (backend).
+
+## Approach
+
+- **Backend**: `GET /v1/topics` (authed) → list topics (id, noun, verb, label) via a small
+  contract serializer; + a route test.
+- **Client**:
+  - models: `Topic`.
+  - repositories: `TopicRepository` (list) + `ActivityRepository` (createIdea, setResponse,
+    clearResponse, vote, addOption, confirm) — abstract + Api impls + fakes.
+  - providers: `topicsProvider`; `activityRepositoryProvider`; mutations invalidate
+    `friendsTimelineProvider` (and the detail provider).
+  - screens: **compose idea** (topic pick, allow_suggestions, time/location options →
+    POST /ideas) reached via a timeline FAB; **activity detail** (`/activity/:id`) showing
+    options with vote toggles, response selector, suggest-option (if allowed), confirm
+    (captain only) — reached by tapping a tile.
+  - router: add `/ideas/new` and `/activity/:id`.
+
+## Validation
+
+- [ ] `GET /v1/topics` returns seeded topics; `bun test` + `flutter analyze`/`test` clean; CI green.
+- [ ] MCP end-to-end: log in → compose an idea (FAB) → it appears on the timeline → open detail
+      → set response (counts update) → vote an option (count/you_voted update) → confirm as
+      captain (state→confirmed, time/location shown). Screenshot each.
+- [ ] non-captain sees no confirm control; suggest-option hidden when allow_suggestions=false.
+
+## Risks / unknowns
+
+- Provider invalidation after mutations (timeline + detail stay in sync without manual refetch).
+- Detail screen needs a single-activity read; reuse timeline data vs a `GET /v1/ideas/:id`
+  (no such endpoint yet — derive detail from the action responses, which return the activity).
+- Keep the compose form minimal (all_friends only) to bound scope.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-client-stage2-interactive-timeline.md
+++ b/plans/v2-client-stage2-interactive-timeline.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-client-stage1-auth-timeline]
 specs:
   - specs/api/ideas-activities.md
@@ -7,7 +7,7 @@ specs:
   - specs/behaviors/ideas-activities-lifecycle.md
   - specs/behaviors/response-system.md
 issues: []
-pr:
+pr: 413
 ---
 
 # Plan: v2 client Stage 2 — interactive timeline (compose + respond/vote/confirm)
@@ -45,11 +45,15 @@ PUT votes, POST confirm) + `behaviors/{ideas-activities-lifecycle,response-syste
 
 ## Validation
 
-- [ ] `GET /v1/topics` returns seeded topics; `bun test` + `flutter analyze`/`test` clean; CI green.
-- [ ] MCP end-to-end: log in → compose an idea (FAB) → it appears on the timeline → open detail
-      → set response (counts update) → vote an option (count/you_voted update) → confirm as
-      captain (state→confirmed, time/location shown). Screenshot each.
-- [ ] non-captain sees no confirm control; suggest-option hidden when allow_suggestions=false.
+- [x] `GET /v1/topics` returns seeded topics; `bun test` + `flutter analyze`/`test` (4 widget
+      tests) clean; CI `app` + `server` green on #413.
+- [x] MCP end-to-end: logged in → composed "Go Paddleboarding" w/ two time options (FAB) →
+      appeared on the timeline → opened detail → set response (1 in) → voted Sat 7am (1 vote) →
+      confirmed as captain (state→confirmed, "Confirmed · Sat 7am"; DB verified). Screenshotted.
+- [x] captain confirm control present (own idea); confirm controls disappear once confirmed.
+- [~] non-captain-hides-confirm + suggest-option UI: confirm is gated on `captainId == me` in
+      code but not driven from a second account this stage; suggest-option UI deferred (see
+      Follow-ups).
 
 ## Risks / unknowns
 
@@ -60,8 +64,19 @@ PUT votes, POST confirm) + `behaviors/{ideas-activities-lifecycle,response-syste
 
 ## Notes
 
-(closeout)
+Shipped as PR #413 (4 commits: GET /v1/topics + plan, client data layer, screens+routing,
+tests+keys); CI green. The detail screen is seeded from the tapped tile's `Activity` (via
+go_router `extra`) and each mutation returns the updated activity which is swapped into local
+state + invalidates the timeline — so no `GET /v1/ideas/:id` was needed (none exists). Added
+`captainId` to the Activity model to gate the captain-only confirm client-side. MCP-driven
+flutter_driver needs unique keys for repeated controls — added `Key('vote_<id>')` /
+`Key('confirm_<id>')` after the first run hit an ambiguous-finder error on two "Confirm" texts.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred to plan:** suggest-option UI (gated by allow_suggestions); people-targeted
+  audience picker in the composer; verify non-captain hides confirm + people-audience
+  visibility by driving a second account; polished mock UI re-port; communities/squads/
+  threads; SSE realtime; push.
+- **Tracked as (skill feedback):** the flutter_driver "unique Key per repeated control"
+  lesson joins the macOS gotchas already noted for the `mobile-flutter` skill.

--- a/server/src/contracts/topic.ts
+++ b/server/src/contracts/topic.ts
@@ -1,0 +1,13 @@
+import type { topic } from '../db/schema/index.ts'
+
+type TopicRow = typeof topic.$inferSelect
+
+// Serialized topic (activity type) wire shape. See specs/api/ideas-activities.md.
+export function serializeTopic(row: TopicRow) {
+  return {
+    id: row.id,
+    noun: row.noun,
+    verb: row.verb,
+    label: row.label,
+  }
+}

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -6,6 +6,7 @@ import meRoutes from './me.ts'
 import friendsRoutes from './friends.ts'
 import ideaRoutes from './ideas.ts'
 import timelineRoutes from './timeline.ts'
+import topicRoutes from './topics.ts'
 
 // The /v1 contract surface. All client-facing endpoints register under here so
 // the URL major version is the coarse contract boundary (see
@@ -17,6 +18,7 @@ const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(friendsRoutes)
   await fastify.register(ideaRoutes)
   await fastify.register(timelineRoutes)
+  await fastify.register(topicRoutes)
 }
 
 export default v1Routes

--- a/server/src/routes/v1/topics.ts
+++ b/server/src/routes/v1/topics.ts
@@ -1,0 +1,16 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { asc } from 'drizzle-orm'
+
+import { topic } from '../../db/schema/index.ts'
+import { serializeTopic } from '../../contracts/topic.ts'
+
+// GET /v1/topics — the activity types available when composing an idea.
+// See specs/api/ideas-activities.md.
+const topicRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/topics', { preHandler: fastify.authenticate }, async () => {
+    const rows = await fastify.db.select().from(topic).orderBy(asc(topic.label))
+    return { items: rows.map(serializeTopic) }
+  })
+}
+
+export default topicRoutes

--- a/server/test/topics.test.ts
+++ b/server/test/topics.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '0'
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  const token = server.signAccessToken(row.id)
+  return { auth: { authorization: `Bearer ${token}` } }
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+beforeEach(async () => {
+  await server.sql`truncate activity, friendship, profile, topic cascade`
+})
+
+test('GET /v1/topics requires auth', async () => {
+  const res = await server.inject({ method: 'GET', url: '/v1/topics' })
+  expect(res.statusCode).toBe(401)
+})
+
+test('GET /v1/topics lists topics alphabetically by label', async () => {
+  await server.sql`insert into topic (noun, verb, label) values ('Hiking', 'Go', 'Go Hiking')`
+  await server.sql`insert into topic (noun, verb, label) values ('Paddleboarding', 'Go', 'Boarding')`
+  const user = await makeUser('+12150009000')
+
+  const res = await server.inject({
+    method: 'GET',
+    url: '/v1/topics',
+    headers: user.auth,
+  })
+  expect(res.statusCode).toBe(200)
+  const items = res.json().items
+  expect(items).toHaveLength(2)
+  expect(items.map((t: { label: string }) => t.label)).toEqual(['Boarding', 'Go Hiking'])
+  expect(items[0]).toHaveProperty('id')
+  expect(items[0]).toHaveProperty('noun')
+  expect(items[0]).toHaveProperty('verb')
+})


### PR DESCRIPTION
Makes the My Friends timeline interactive by wiring the rest of the Stage-2 API into the client. Builds on #412.

Implements client side of `specs/api/ideas-activities.md` (compose + respond/vote/confirm) + `behaviors/{ideas-activities-lifecycle,response-system}.md`, plus the one missing backend bit: `GET /v1/topics`.

## What's here
- **Backend**: `GET /v1/topics` (authed, alphabetical) + serializer + test.
- **Client data**: `Topic` model + `TopicRepository`; `ActivityRepository` (createIdea, set/clear response, vote, addOption, confirm) — each returns the updated `Activity`, so the UI swaps state without a refetch; `ApiClient.put`; `Activity.captainId` (gates the captain-only confirm). Abstract repos + fakes per the `mobile-flutter` skill.
- **Client UI**: a **compose-idea** screen (topic dropdown, allow-suggestions, comma-separated time/location options) reached via a timeline FAB; an **activity-detail** screen (`/activity/:id`, seeded by the tapped tile) with a response selector, per-option vote toggle, and captain-only confirm. Mutations invalidate the timeline so the list stays in sync.

## Verified end-to-end (dart MCP, macOS)
Drove the real app against the local API: log in → FAB → compose "Go Paddleboarding" with two time options → idea appears on the timeline → open detail → **I'm in** (counts → 1 in) → **vote** Sat 7am (→ 1 vote) → **confirm** Sat 7am → header shows **Confirmed · Sat 7am** (DB: `state=confirmed, confirmed_time=Sat 7am`). `flutter analyze`/`test` (4 widget tests) + `bun test` green.

## Scope (deferred)
People-targeted audience picker (all_friends only here); suggest-option UI; communities/squads/threads; polished mock UI; SSE realtime; push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)