### PR TITLE
v2 server: squads (create/members, scope=squad ideas, squad timeline)

### DIFF
--- a/plans/v2-squads-context-selector.md
+++ b/plans/v2-squads-context-selector.md
@@ -1,0 +1,84 @@
+---
+status: in-progress
+depends: [v2-client-stage2-interactive-timeline]
+specs:
+  - specs/data-model.md
+  - specs/screens/squads.md
+  - specs/behaviors/context-selector.md
+  - specs/api/ideas-activities.md
+  - specs/api/timeline.md
+issues: []
+pr:
+---
+
+# Plan: v2 squads + context selector
+
+## Scope
+
+Closed, persistent named groups (squads) + the title-bar **context selector** that switches
+the active context (My Friends ▸ a Squad) — timeline, title, audience indicator, and compose
+destination all follow one source of truth. Squad-scoped ideas/activities reuse the existing
+lifecycle. Backend + client; styling deferred.
+
+**In:** squad + squad_membership; create squad / list my squads / add member; extend
+`createIdea` to `scope=squad`; squad timeline (squad-scoped activities); client context
+selector + active-context provider + squad timeline + create-squad flow.
+
+**Out (later stages):** free-text squad messages + thread drawer (messages stage — the squad
+timeline is activities-only for now, a subset of the spec's heterogeneous feed); polished
+captain membership management (spec defers it); Communities/Discover entries in the selector
+(communities stage — selector is built to extend to them).
+
+## Implements
+
+`specs/screens/squads.md` (activity slice), `specs/behaviors/context-selector.md`
+(My Friends ▸ Squads), squad slice of `specs/data-model.md`, and the `scope=squad` path of
+`specs/api/ideas-activities.md`.
+
+## Approach
+
+- **Backend** (`server/`):
+  - schema `squad.ts`: `squad` (id, name, created_at), `squad_membership` (squad, profile,
+    role ∈ captain|member, pk) + migration.
+  - domain/routes: `POST /v1/squads` (creator → captain; optional initial member_ids, each
+    must be an accepted friend), `GET /v1/squads` (my squads + role + member_count),
+    `GET /v1/squads/:id` (detail + members, members-only), `POST /v1/squads/:id/members`
+    (captain adds an accepted friend), `GET /v1/squads/:id/timeline` (squad-scoped activities,
+    members-only, cursor-paginated).
+  - extend `ActivityService.createIdea` to accept `scope=squad` + `squadId` (validate caller
+    is a member); squad activities visible to squad members (new visibility branch).
+  - squad serializer; tests.
+- **Client** (`app/`):
+  - `activeContextProvider` (sealed: `FriendsContext` | `SquadContext(id,name)`) — the single
+    source of truth; timeline/title/compose read it.
+  - context selector (tappable AppBar title → sheet: My Friends, my squads, New squad).
+  - timeline screen branches on context → `friendsTimeline` or `squadTimeline(id)`; reuses the
+    activity tiles.
+  - composer: scope follows context (friends→all_friends; squad→scope=squad+squad_id);
+    audience banner states the destination.
+  - create-squad screen (name + multiselect from `GET /v1/friends`); SquadRepository.
+
+## Validation
+
+- [ ] migration applies; `bun run type-check` + `bun test` (squad create/list/add-member,
+      member-gated timeline, scope=squad create, non-member 403) green; CI green.
+- [ ] MCP end-to-end (two accounts): A creates a squad incl. B → both see it in the selector;
+      A composes a squad idea → on the squad timeline for A & B, **absent** from My Friends;
+      B responds/votes; A confirms. Screenshot the selector, squad timeline, compose-scoped.
+- [ ] switching context updates title + feed + compose destination consistently.
+
+## Risks / unknowns
+
+- Visibility now has two branches (friends graph vs squad membership) — keep the predicate
+  centralized and reused by reads + write authz.
+- Active-context as one source of truth (title/feed/composer/destination never disagree).
+- Squad timeline is activities-only this stage; wire the heterogeneous message feed in the
+  messages stage without reshaping the context model.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/server/migrations/0002_greedy_odin.sql
+++ b/server/migrations/0002_greedy_odin.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."squad_role" AS ENUM('captain', 'member');--> statement-breakpoint
+CREATE TABLE "squad" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "squad_membership" (
+	"squad_id" uuid NOT NULL,
+	"profile_id" uuid NOT NULL,
+	"role" "squad_role" DEFAULT 'member' NOT NULL,
+	CONSTRAINT "squad_membership_squad_id_profile_id_pk" PRIMARY KEY("squad_id","profile_id")
+);
+--> statement-breakpoint
+ALTER TABLE "squad_membership" ADD CONSTRAINT "squad_membership_squad_id_squad_id_fk" FOREIGN KEY ("squad_id") REFERENCES "public"."squad"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "squad_membership" ADD CONSTRAINT "squad_membership_profile_id_profile_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profile"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/migrations/meta/0002_snapshot.json
+++ b/server/migrations/meta/0002_snapshot.json
@@ -1,0 +1,929 @@
+{
+  "id": "7b48d26a-36e8-4a35-9f6c-f0ef5e0a815d",
+  "prevId": "671aa870-52d0-4cdd-8639-48363e3e4917",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester": {
+          "name": "requester",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestee": {
+          "name": "requestee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_requester_profile_id_fk": {
+          "name": "friendship_requester_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requester"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_requestee_profile_id_fk": {
+          "name": "friendship_requestee_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requestee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "friendship_pair": {
+          "name": "friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "requester",
+            "requestee"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_phone_unique": {
+          "name": "profile_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "noun": {
+          "name": "noun",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_subscription": {
+      "name": "topic_subscription",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_subscription_topic_id_topic_id_fk": {
+          "name": "topic_subscription_topic_id_topic_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_subscription_profile_id_profile_id_fk": {
+          "name": "topic_subscription_profile_id_profile_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_subscription_topic_id_profile_id_pk": {
+          "name": "topic_subscription_topic_id_profile_id_pk",
+          "columns": [
+            "topic_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_code": {
+      "name": "otp_code",
+      "schema": "",
+      "columns": {
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_token": {
+      "name": "refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_token_profile_id_profile_id_fk": {
+          "name": "refresh_token_profile_id_profile_id_fk",
+          "tableFrom": "refresh_token",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_token_token_hash_unique": {
+          "name": "refresh_token_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "activity_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "activity_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_kind": {
+          "name": "audience_kind",
+          "type": "audience_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_friends'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmed_time_option_id": {
+          "name": "confirmed_time_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_location_option_id": {
+          "name": "confirmed_location_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_event_id": {
+          "name": "community_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_captain_id_profile_id_fk": {
+          "name": "activity_captain_id_profile_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_activity_type_id_topic_id_fk": {
+          "name": "activity_activity_type_id_topic_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_audience": {
+      "name": "activity_audience",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_audience_activity_id_activity_id_fk": {
+          "name": "activity_audience_activity_id_activity_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_audience_profile_id_profile_id_fk": {
+          "name": "activity_audience_profile_id_profile_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_audience_activity_id_profile_id_pk": {
+          "name": "activity_audience_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_option": {
+      "name": "activity_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "option_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_option_activity_id_activity_id_fk": {
+          "name": "activity_option_activity_id_activity_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_option_created_by_profile_id_fk": {
+          "name": "activity_option_created_by_profile_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.option_vote": {
+      "name": "option_vote",
+      "schema": "",
+      "columns": {
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "option_vote_option_id_activity_option_id_fk": {
+          "name": "option_vote_option_id_activity_option_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "activity_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "option_vote_profile_id_profile_id_fk": {
+          "name": "option_vote_profile_id_profile_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "option_vote_option_id_profile_id_pk": {
+          "name": "option_vote_option_id_profile_id_pk",
+          "columns": [
+            "option_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response": {
+      "name": "response",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "response_activity_id_activity_id_fk": {
+          "name": "response_activity_id_activity_id_fk",
+          "tableFrom": "response",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "response_profile_id_profile_id_fk": {
+          "name": "response_profile_id_profile_id_fk",
+          "tableFrom": "response",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "response_activity_id_profile_id_pk": {
+          "name": "response_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad": {
+      "name": "squad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad_membership": {
+      "name": "squad_membership",
+      "schema": "",
+      "columns": {
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "squad_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "squad_membership_squad_id_squad_id_fk": {
+          "name": "squad_membership_squad_id_squad_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "squad_membership_profile_id_profile_id_fk": {
+          "name": "squad_membership_profile_id_profile_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "squad_membership_squad_id_profile_id_pk": {
+          "name": "squad_membership_squad_id_profile_id_pk",
+          "columns": [
+            "squad_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.activity_scope": {
+      "name": "activity_scope",
+      "schema": "public",
+      "values": [
+        "friends",
+        "squad"
+      ]
+    },
+    "public.activity_state": {
+      "name": "activity_state",
+      "schema": "public",
+      "values": [
+        "idea",
+        "confirmed"
+      ]
+    },
+    "public.audience_kind": {
+      "name": "audience_kind",
+      "schema": "public",
+      "values": [
+        "all_friends",
+        "people"
+      ]
+    },
+    "public.option_kind": {
+      "name": "option_kind",
+      "schema": "public",
+      "values": [
+        "time",
+        "location"
+      ]
+    },
+    "public.response_value": {
+      "name": "response_value",
+      "schema": "public",
+      "values": [
+        "in",
+        "interested",
+        "next_time"
+      ]
+    },
+    "public.squad_role": {
+      "name": "squad_role",
+      "schema": "public",
+      "values": [
+        "captain",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780972500889,
       "tag": "0001_glorious_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781025288002,
+      "tag": "0002_greedy_odin",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/contracts/squad.ts
+++ b/server/src/contracts/squad.ts
@@ -1,0 +1,26 @@
+import type { SquadSummary, SquadDetail } from '../domain/squad/service.ts'
+
+// Squad wire shapes. See specs/screens/squads.md + data-model.md.
+export function serializeSquadSummary(s: SquadSummary) {
+  return {
+    id: s.squad.id,
+    name: s.squad.name,
+    role: s.role,
+    member_count: s.memberCount,
+    created_at: s.squad.createdAt.toISOString(),
+  }
+}
+
+export function serializeSquadDetail(d: SquadDetail) {
+  return {
+    id: d.squad.id,
+    name: d.squad.name,
+    created_at: d.squad.createdAt.toISOString(),
+    members: d.members.map((m) => ({
+      id: m.profile.id,
+      first_name: m.profile.firstName,
+      photo: m.profile.photo,
+      role: m.role,
+    })),
+  }
+}

--- a/server/src/db/schema/index.ts
+++ b/server/src/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './identity.ts'
 export * from './auth.ts'
 export * from './activity.ts'
+export * from './squad.ts'

--- a/server/src/db/schema/squad.ts
+++ b/server/src/db/schema/squad.ts
@@ -1,0 +1,27 @@
+import { pgTable, pgEnum, uuid, text, timestamp, primaryKey } from 'drizzle-orm/pg-core'
+
+import { profile } from './identity.ts'
+
+export const squadRole = pgEnum('squad_role', ['captain', 'member'])
+
+// Closed, persistent named groups — the evolution of the group text
+// (specs/data-model.md). Captain controls membership; everyone may post.
+export const squad = pgTable('squad', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
+export const squadMembership = pgTable(
+  'squad_membership',
+  {
+    squadId: uuid('squad_id')
+      .notNull()
+      .references(() => squad.id, { onDelete: 'cascade' }),
+    profileId: uuid('profile_id')
+      .notNull()
+      .references(() => profile.id, { onDelete: 'cascade' }),
+    role: squadRole('role').notNull().default('member'),
+  },
+  (t) => [primaryKey({ columns: [t.squadId, t.profileId] })],
+)

--- a/server/src/domain/activity/service.ts
+++ b/server/src/domain/activity/service.ts
@@ -9,6 +9,7 @@ import {
   response,
   friendship,
   topic,
+  squadMembership,
 } from '../../db/schema/index.ts'
 import { ApiError, errors } from '../../contracts/errors.ts'
 
@@ -45,10 +46,27 @@ export class ActivityService {
     return edges.map((e) => (e.requester === profileId ? e.requestee : e.requester))
   }
 
-  // Can `viewer` see this activity? viewer is captain, or captain is an accepted
-  // friend AND (audience all_friends OR viewer is a named recipient).
+  async isSquadMember(squadId: string, profileId: string): Promise<boolean> {
+    const [m] = await this.db
+      .select()
+      .from(squadMembership)
+      .where(
+        and(
+          eq(squadMembership.squadId, squadId),
+          eq(squadMembership.profileId, profileId),
+        ),
+      )
+    return Boolean(m)
+  }
+
+  // Can `viewer` see this activity?
+  // - squad scope: viewer is a member of the squad.
+  // - friends scope: viewer is captain, or captain is an accepted friend AND
+  //   (audience all_friends OR viewer is a named recipient).
   async canView(viewerId: string, act: ActivityRow): Promise<boolean> {
-    if (act.scope !== 'friends') return false // squad scope not handled this stage
+    if (act.scope === 'squad') {
+      return act.squadId ? this.isSquadMember(act.squadId, viewerId) : false
+    }
     if (act.captainId === viewerId) return true
     const friends = await this.acceptedFriendIds(viewerId)
     if (!friends.includes(act.captainId)) return false
@@ -74,15 +92,24 @@ export class ActivityService {
     return act
   }
 
-  // Create an idea (always starts in `idea` state). Friends-scoped only this stage.
+  // Create an idea (always starts in `idea` state). Supports friends scope
+  // (all_friends / people audience) and squad scope (visible to squad members).
   async createIdea(captainId: string, input: CreateIdeaInput): Promise<string> {
-    if (input.scope && input.scope !== 'friends') {
-      throw errors.badRequest('unsupported_scope', 'Only friends-scoped ideas are supported')
+    const scope = input.scope ?? 'friends'
+    if (scope !== 'friends' && scope !== 'squad') {
+      throw errors.badRequest('unsupported_scope', 'Unsupported scope')
     }
     if (input.communityEventId) {
       throw errors.badRequest('unsupported', 'Community events are not available yet')
     }
-    if (input.audience.kind === 'people' && !input.audience.personIds?.length) {
+    if (scope === 'squad') {
+      if (!input.squadId) {
+        throw errors.badRequest('squad_required', 'squad scope requires squad_id')
+      }
+      if (!(await this.isSquadMember(input.squadId, captainId))) {
+        throw errors.forbidden('not_a_member', 'You are not a member of this squad')
+      }
+    } else if (input.audience.kind === 'people' && !input.audience.personIds?.length) {
       throw errors.badRequest('audience_required', 'people audience requires person_ids')
     }
 
@@ -92,6 +119,7 @@ export class ActivityService {
       .where(eq(topic.id, input.activityTypeId))
     if (!type) throw errors.badRequest('activity_type_invalid', 'Unknown activity type')
 
+    const isSquad = scope === 'squad'
     return this.db.transaction(async (tx) => {
       const [created] = await tx
         .insert(activity)
@@ -99,8 +127,11 @@ export class ActivityService {
           captainId,
           activityTypeId: input.activityTypeId,
           state: 'idea',
-          scope: 'friends',
-          audienceKind: input.audience.kind,
+          scope,
+          squadId: isSquad ? input.squadId : null,
+          // audience_kind is unused for squad scope (all members see it); store the
+          // default so the NOT NULL column is satisfied.
+          audienceKind: isSquad ? 'all_friends' : input.audience.kind,
           allowSuggestions: input.allowSuggestions ?? false,
         })
         .returning({ id: activity.id })
@@ -119,7 +150,7 @@ export class ActivityService {
           .values(options.map((o) => ({ activityId, createdBy: captainId, ...o })))
       }
 
-      if (input.audience.kind === 'people') {
+      if (!isSquad && input.audience.kind === 'people') {
         const ids = [...new Set(input.audience.personIds!)]
         await tx
           .insert(activityAudience)
@@ -252,6 +283,32 @@ export class ActivityService {
           eq(activity.scope, 'friends'),
           inArray(activity.captainId, friendIds),
           visible,
+          ...(cursor ? [cursor] : []),
+        ),
+      )
+      .orderBy(sql`${activity.createdAt} desc, ${activity.id} desc`)
+      .limit(limit)
+  }
+
+  // A squad timeline: squad-scoped activities for one squad, newest first,
+  // cursor-paginated. Membership must be checked by the caller (route).
+  // (Free-text squad messages are interleaved here in a later stage.)
+  async squadTimeline(
+    squadId: string,
+    limit: number,
+    before?: { createdAt: Date; id: string },
+  ): Promise<ActivityRow[]> {
+    const cursor = before
+      ? sql`(${activity.createdAt}, ${activity.id}) < (${before.createdAt.toISOString()}, ${before.id})`
+      : undefined
+
+    return this.db
+      .select()
+      .from(activity)
+      .where(
+        and(
+          eq(activity.scope, 'squad'),
+          eq(activity.squadId, squadId),
           ...(cursor ? [cursor] : []),
         ),
       )

--- a/server/src/domain/squad/service.ts
+++ b/server/src/domain/squad/service.ts
@@ -1,0 +1,141 @@
+import { and, eq, inArray, or } from 'drizzle-orm'
+
+import type { Database } from '../../db/index.ts'
+import { squad, squadMembership, friendship, profile } from '../../db/schema/index.ts'
+import { ApiError, errors } from '../../contracts/errors.ts'
+
+type SquadRow = typeof squad.$inferSelect
+type ProfileRow = typeof profile.$inferSelect
+
+export interface SquadSummary {
+  squad: SquadRow
+  role: 'captain' | 'member'
+  memberCount: number
+}
+
+export interface SquadDetail {
+  squad: SquadRow
+  members: { profile: ProfileRow; role: 'captain' | 'member' }[]
+}
+
+export class SquadService {
+  constructor(private readonly db: Database) {}
+
+  private async acceptedFriendIds(profileId: string): Promise<string[]> {
+    const edges = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          eq(friendship.status, 'accepted'),
+          or(eq(friendship.requester, profileId), eq(friendship.requestee, profileId)),
+        ),
+      )
+    return edges.map((e) => (e.requester === profileId ? e.requestee : e.requester))
+  }
+
+  async isMember(squadId: string, profileId: string): Promise<boolean> {
+    const [m] = await this.db
+      .select()
+      .from(squadMembership)
+      .where(
+        and(eq(squadMembership.squadId, squadId), eq(squadMembership.profileId, profileId)),
+      )
+    return Boolean(m)
+  }
+
+  // Create a squad; creator becomes captain. Optional initial members must be the
+  // creator's accepted friends.
+  async createSquad(
+    creatorId: string,
+    name: string,
+    memberIds: string[] = [],
+  ): Promise<string> {
+    const trimmed = name.trim()
+    if (!trimmed) throw errors.badRequest('name_required', 'Squad name is required')
+
+    const friends = new Set(await this.acceptedFriendIds(creatorId))
+    const members = [...new Set(memberIds)].filter((id) => id !== creatorId)
+    const notFriends = members.filter((id) => !friends.has(id))
+    if (notFriends.length) {
+      throw errors.badRequest('not_friends', 'Members must be accepted friends')
+    }
+
+    return this.db.transaction(async (tx) => {
+      const [created] = await tx.insert(squad).values({ name: trimmed }).returning({ id: squad.id })
+      const squadId = created!.id
+      await tx.insert(squadMembership).values({ squadId, profileId: creatorId, role: 'captain' })
+      if (members.length) {
+        await tx
+          .insert(squadMembership)
+          .values(members.map((profileId) => ({ squadId, profileId, role: 'member' as const })))
+      }
+      return squadId
+    })
+  }
+
+  async listMySquads(profileId: string): Promise<SquadSummary[]> {
+    const mine = await this.db
+      .select({ squadId: squadMembership.squadId, role: squadMembership.role })
+      .from(squadMembership)
+      .where(eq(squadMembership.profileId, profileId))
+    if (mine.length === 0) return []
+
+    const ids = mine.map((m) => m.squadId)
+    const squads = await this.db.select().from(squad).where(inArray(squad.id, ids))
+    const allMembers = await this.db
+      .select({ squadId: squadMembership.squadId })
+      .from(squadMembership)
+      .where(inArray(squadMembership.squadId, ids))
+
+    const counts = new Map<string, number>()
+    for (const m of allMembers) counts.set(m.squadId, (counts.get(m.squadId) ?? 0) + 1)
+    const roleById = new Map(mine.map((m) => [m.squadId, m.role]))
+    const squadById = new Map(squads.map((s) => [s.id, s]))
+
+    return mine
+      .map((m) => ({
+        squad: squadById.get(m.squadId)!,
+        role: roleById.get(m.squadId)!,
+        memberCount: counts.get(m.squadId) ?? 0,
+      }))
+      .filter((s) => s.squad)
+  }
+
+  async getSquad(viewerId: string, squadId: string): Promise<SquadDetail> {
+    if (!(await this.isMember(squadId, viewerId))) {
+      throw new ApiError(404, 'not_found', 'Squad not found')
+    }
+    const [row] = await this.db.select().from(squad).where(eq(squad.id, squadId))
+    if (!row) throw new ApiError(404, 'not_found', 'Squad not found')
+
+    const rows = await this.db
+      .select({ profile, role: squadMembership.role })
+      .from(squadMembership)
+      .innerJoin(profile, eq(profile.id, squadMembership.profileId))
+      .where(eq(squadMembership.squadId, squadId))
+
+    return { squad: row, members: rows.map((r) => ({ profile: r.profile, role: r.role })) }
+  }
+
+  async addMember(captainId: string, squadId: string, profileId: string): Promise<void> {
+    const [me] = await this.db
+      .select()
+      .from(squadMembership)
+      .where(
+        and(eq(squadMembership.squadId, squadId), eq(squadMembership.profileId, captainId)),
+      )
+    if (!me) throw new ApiError(404, 'not_found', 'Squad not found')
+    if (me.role !== 'captain') {
+      throw errors.forbidden('not_captain', 'Only the captain can add members')
+    }
+    const friends = new Set(await this.acceptedFriendIds(captainId))
+    if (!friends.has(profileId)) {
+      throw errors.badRequest('not_friends', 'New members must be accepted friends')
+    }
+    await this.db
+      .insert(squadMembership)
+      .values({ squadId, profileId, role: 'member' })
+      .onConflictDoNothing()
+  }
+}

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -7,6 +7,7 @@ import friendsRoutes from './friends.ts'
 import ideaRoutes from './ideas.ts'
 import timelineRoutes from './timeline.ts'
 import topicRoutes from './topics.ts'
+import squadRoutes from './squads.ts'
 
 // The /v1 contract surface. All client-facing endpoints register under here so
 // the URL major version is the coarse contract boundary (see
@@ -19,6 +20,7 @@ const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(ideaRoutes)
   await fastify.register(timelineRoutes)
   await fastify.register(topicRoutes)
+  await fastify.register(squadRoutes)
 }
 
 export default v1Routes

--- a/server/src/routes/v1/squads.ts
+++ b/server/src/routes/v1/squads.ts
@@ -1,0 +1,119 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+import { SquadService } from '../../domain/squad/service.ts'
+import { ActivityService } from '../../domain/activity/service.ts'
+import { serializeSquadSummary, serializeSquadDetail } from '../../contracts/squad.ts'
+import { serializeActivities } from '../../contracts/activity.ts'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
+
+function encodeCursor(createdAt: Date, id: string): string {
+  return Buffer.from(`${createdAt.toISOString()}|${id}`).toString('base64url')
+}
+function decodeCursor(raw: string): { createdAt: Date; id: string } | undefined {
+  try {
+    const [iso, id] = Buffer.from(raw, 'base64url').toString().split('|')
+    if (!iso || !id) return undefined
+    return { createdAt: new Date(iso), id }
+  } catch {
+    return undefined
+  }
+}
+
+// Squads: closed, persistent named groups (specs/screens/squads.md,
+// behaviors/context-selector.md). All authed.
+const squadRoutes: FastifyPluginAsync = async (fastify) => {
+  const squads = new SquadService(fastify.db)
+  const activities = new ActivityService(fastify.db)
+
+  fastify.post<{ Body: { name: string; member_ids?: string[] } }>(
+    '/squads',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: { type: 'string', minLength: 1 },
+            member_ids: { type: 'array', items: { type: 'string' } },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const id = await squads.createSquad(
+        request.profileId!,
+        request.body.name,
+        request.body.member_ids ?? [],
+      )
+      reply.code(201)
+      return serializeSquadDetail(await squads.getSquad(request.profileId!, id))
+    },
+  )
+
+  fastify.get('/squads', { preHandler: fastify.authenticate }, async (request) => {
+    const mine = await squads.listMySquads(request.profileId!)
+    return { items: mine.map(serializeSquadSummary) }
+  })
+
+  fastify.get<{ Params: { id: string } }>(
+    '/squads/:id',
+    { preHandler: fastify.authenticate },
+    async (request) =>
+      serializeSquadDetail(await squads.getSquad(request.profileId!, request.params.id)),
+  )
+
+  fastify.post<{ Params: { id: string }; Body: { profile_id: string } }>(
+    '/squads/:id/members',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['profile_id'],
+          properties: { profile_id: { type: 'string' } },
+        },
+      },
+    },
+    async (request) => {
+      await squads.addMember(request.profileId!, request.params.id, request.body.profile_id)
+      return serializeSquadDetail(await squads.getSquad(request.profileId!, request.params.id))
+    },
+  )
+
+  fastify.get<{ Params: { id: string }; Querystring: { limit?: number; before?: string } }>(
+    '/squads/:id/timeline',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        querystring: {
+          type: 'object',
+          properties: {
+            limit: { type: 'integer', minimum: 1, maximum: MAX_LIMIT },
+            before: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const viewer = request.profileId!
+      const squadId = request.params.id
+      // Membership-gates the read (404s for non-members, indistinguishable from missing).
+      await squads.getSquad(viewer, squadId)
+
+      const limit = Math.min(request.query.limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+      const before = request.query.before ? decodeCursor(request.query.before) : undefined
+      const rows = await activities.squadTimeline(squadId, limit + 1, before)
+      const page = rows.slice(0, limit)
+      const last = page.at(-1)
+      const nextCursor =
+        rows.length > limit && last ? encodeCursor(last.createdAt, last.id) : null
+      const items = await serializeActivities(fastify.db, viewer, page)
+      return { items, next_cursor: nextCursor }
+    },
+  )
+}
+
+export default squadRoutes

--- a/server/test/squads.test.ts
+++ b/server/test/squads.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '0'
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+let topicId: string
+
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  const token = server.signAccessToken(row.id)
+  return { id: row.id, auth: { authorization: `Bearer ${token}` } }
+}
+
+async function befriend(a: string, b: string) {
+  await server.sql`insert into friendship (requester, requestee, status) values (${a}, ${b}, 'accepted')`
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+beforeEach(async () => {
+  await server.sql`truncate squad, squad_membership, activity, friendship, profile, topic cascade`
+  const [t] = await server.sql<{ id: string }[]>`
+    insert into topic (noun, verb, label) values ('Bike Ride', 'Go on a', 'Go on a Bike Ride')
+    returning id`
+  topicId = t.id
+})
+
+async function createSquad(auth: object, name: string, memberIds: string[] = []) {
+  return server.inject({
+    method: 'POST',
+    url: '/v1/squads',
+    headers: auth,
+    payload: { name, member_ids: memberIds },
+  })
+}
+
+test('create squad → creator is captain; members must be friends', async () => {
+  const cap = await makeUser('+12150001000')
+  const friend = await makeUser('+12150001001')
+  const stranger = await makeUser('+12150001002')
+  await befriend(cap.id, friend.id)
+
+  // non-friend member rejected
+  const bad = await createSquad(cap.auth, 'Riders', [stranger.id])
+  expect(bad.statusCode).toBe(400)
+  expect(bad.json().error.code).toBe('not_friends')
+
+  const res = await createSquad(cap.auth, 'Riders', [friend.id])
+  expect(res.statusCode).toBe(201)
+  const detail = res.json()
+  expect(detail.name).toBe('Riders')
+  expect(detail.members).toHaveLength(2)
+  const cation = detail.members.find((m: { id: string }) => m.id === cap.id)
+  expect(cation.role).toBe('captain')
+
+  // both members see it in their squad list
+  for (const u of [cap, friend]) {
+    const list = await server.inject({ method: 'GET', url: '/v1/squads', headers: u.auth })
+    expect(list.json().items).toHaveLength(1)
+    expect(list.json().items[0].member_count).toBe(2)
+  }
+  // stranger sees none, and is 404 on detail
+  const strangerList = await server.inject({ method: 'GET', url: '/v1/squads', headers: stranger.auth })
+  expect(strangerList.json().items).toHaveLength(0)
+  const denied = await server.inject({ method: 'GET', url: `/v1/squads/${detail.id}`, headers: stranger.auth })
+  expect(denied.statusCode).toBe(404)
+})
+
+test('captain adds a friend; non-captain cannot', async () => {
+  const cap = await makeUser('+12150001010')
+  const m1 = await makeUser('+12150001011')
+  const m2 = await makeUser('+12150001012')
+  await befriend(cap.id, m1.id)
+  await befriend(cap.id, m2.id)
+  const squadId = (await createSquad(cap.auth, 'Crew', [m1.id])).json().id
+
+  // m1 (member, not captain) cannot add
+  const denied = await server.inject({
+    method: 'POST',
+    url: `/v1/squads/${squadId}/members`,
+    headers: m1.auth,
+    payload: { profile_id: m2.id },
+  })
+  expect(denied.statusCode).toBe(403)
+  expect(denied.json().error.code).toBe('not_captain')
+
+  // captain adds m2
+  const ok = await server.inject({
+    method: 'POST',
+    url: `/v1/squads/${squadId}/members`,
+    headers: cap.auth,
+    payload: { profile_id: m2.id },
+  })
+  expect(ok.statusCode).toBe(200)
+  expect(ok.json().members).toHaveLength(3)
+})
+
+test('squad idea shows on the squad timeline, never on My Friends', async () => {
+  const cap = await makeUser('+12150001020')
+  const member = await makeUser('+12150001021')
+  const outsider = await makeUser('+12150001022')
+  await befriend(cap.id, member.id)
+  await befriend(cap.id, outsider.id) // friend, but NOT in the squad
+  const squadId = (await createSquad(cap.auth, 'Paddlers', [member.id])).json().id
+
+  const created = await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: cap.auth,
+    payload: {
+      activity_type_id: topicId,
+      scope: 'squad',
+      squad_id: squadId,
+      audience: { kind: 'all_friends' },
+      time_options: ['Sat 9am'],
+    },
+  })
+  expect(created.statusCode).toBe(201)
+  expect(created.json().scope).toBe('squad')
+
+  // member sees it on the squad timeline
+  const memberFeed = await server.inject({
+    method: 'GET',
+    url: `/v1/squads/${squadId}/timeline`,
+    headers: member.auth,
+  })
+  expect(memberFeed.json().items).toHaveLength(1)
+
+  // it must NOT leak onto anyone's My Friends timeline (private-first)
+  for (const u of [cap, member, outsider]) {
+    const friends = await server.inject({ method: 'GET', url: '/v1/timeline/friends', headers: u.auth })
+    expect(friends.json().items).toHaveLength(0)
+  }
+
+  // a friend who isn't a squad member can't read the squad timeline
+  const denied = await server.inject({
+    method: 'GET',
+    url: `/v1/squads/${squadId}/timeline`,
+    headers: outsider.auth,
+  })
+  expect(denied.statusCode).toBe(404)
+})
+
+test('non-member cannot create a squad-scoped idea', async () => {
+  const cap = await makeUser('+12150001030')
+  const outsider = await makeUser('+12150001031')
+  const squadId = (await createSquad(cap.auth, 'Solo', [])).json().id
+
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: outsider.auth,
+    payload: {
+      activity_type_id: topicId,
+      scope: 'squad',
+      squad_id: squadId,
+      audience: { kind: 'all_friends' },
+    },
+  })
+  expect(res.statusCode).toBe(403)
+  expect(res.json().error.code).toBe('not_a_member')
+})


### PR DESCRIPTION
Backend half of the **squads + context selector** stage. Closed, persistent named groups + squad-scoped ideas/activities.

Implements the squad slice of `specs/screens/squads.md`, `specs/behaviors/context-selector.md`, the squad part of `specs/data-model.md`, and the `scope=squad` path of `specs/api/ideas-activities.md`.

## What's here
- **Schema** (migration 0002): `squad` (id, name) + `squad_membership` (squad, profile, role captain|member).
- **SquadService**: `createSquad` (creator→captain; initial members must be accepted friends), `listMySquads` (+ role + member_count), `getSquad` (members-only detail), `addMember` (captain-only, friend-gated), `isMember`.
- **Routes**: `POST`/`GET /v1/squads`, `GET /v1/squads/:id`, `POST /v1/squads/:id/members`, `GET /v1/squads/:id/timeline` (member-gated, cursor-paginated).
- **ActivityService**: `createIdea` now supports `scope=squad` (validates membership); `canView` gains a squad-membership branch; new `squadTimeline`. **Squad ideas are visible to members and never leak onto any My Friends timeline** (private-first).

## Tests (4 new; full suite 21/21)
create→captain + friend-gated members; captain-only add-member; squad idea on the squad timeline + absent from every My Friends feed + non-member 404; non-member can't create a squad-scoped idea.

## Scope
Backend only — the client context selector + squad timeline + create-squad flow are the companion PR. Free-text squad messages + thread drawer are deferred to the messages stage (squad timeline is activities-only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)