### PR TITLE
v2 client: squads + context selector

### DIFF
--- a/app/lib/models/squad.dart
+++ b/app/lib/models/squad.dart
@@ -1,0 +1,55 @@
+/// A squad — a closed, persistent named group (specs/screens/squads.md).
+class Squad {
+  const Squad({
+    required this.id,
+    required this.name,
+    this.role,
+    this.memberCount = 0,
+  });
+
+  final String id;
+  final String name;
+  final String? role; // 'captain' | 'member'
+  final int memberCount;
+
+  factory Squad.fromJson(Map<String, dynamic> json) => Squad(
+    id: json['id'] as String,
+    name: json['name'] as String? ?? '',
+    role: json['role'] as String?,
+    memberCount: (json['member_count'] as num?)?.toInt() ?? 0,
+  );
+}
+
+class SquadMember {
+  const SquadMember({required this.id, this.firstName, this.photo, this.role});
+  final String id;
+  final String? firstName;
+  final String? photo;
+  final String? role;
+
+  factory SquadMember.fromJson(Map<String, dynamic> json) => SquadMember(
+    id: json['id'] as String,
+    firstName: json['first_name'] as String?,
+    photo: json['photo'] as String?,
+    role: json['role'] as String?,
+  );
+}
+
+class SquadDetail {
+  const SquadDetail({
+    required this.id,
+    required this.name,
+    this.members = const [],
+  });
+  final String id;
+  final String name;
+  final List<SquadMember> members;
+
+  factory SquadDetail.fromJson(Map<String, dynamic> json) => SquadDetail(
+    id: json['id'] as String,
+    name: json['name'] as String? ?? '',
+    members: ((json['members'] as List<dynamic>?) ?? const [])
+        .map((e) => SquadMember.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}

--- a/app/lib/providers/active_context.dart
+++ b/app/lib/providers/active_context.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The single source of truth for the active timeline context
+/// (specs/behaviors/context-selector.md). Title, feed, audience indicator, and
+/// compose destination all read this — they can never disagree.
+sealed class ActiveContext {
+  const ActiveContext();
+}
+
+class FriendsContext extends ActiveContext {
+  const FriendsContext();
+}
+
+class SquadContext extends ActiveContext {
+  const SquadContext(this.id, this.name);
+  final String id;
+  final String name;
+}
+
+final activeContextProvider =
+    NotifierProvider<ActiveContextController, ActiveContext>(
+      ActiveContextController.new,
+    );
+
+class ActiveContextController extends Notifier<ActiveContext> {
+  @override
+  ActiveContext build() => const FriendsContext();
+
+  void toFriends() => state = const FriendsContext();
+  void toSquad(String id, String name) => state = SquadContext(id, name);
+}

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -2,10 +2,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../api/api_client.dart';
 import '../config.dart';
+import '../models/friend.dart';
+import '../models/squad.dart';
 import '../models/topic.dart';
 import '../repositories/activity_repository.dart';
 import '../repositories/auth_repository.dart';
+import '../repositories/friend_repository.dart';
 import '../repositories/profile_repository.dart';
+import '../repositories/squad_repository.dart';
 import '../repositories/timeline_repository.dart';
 import '../repositories/token_store.dart';
 import '../repositories/topic_repository.dart';
@@ -49,12 +53,35 @@ final activityRepositoryProvider = Provider<ActivityRepository>(
   (ref) => ApiActivityRepository(apiClient: ref.watch(apiClientProvider)),
 );
 
+final squadRepositoryProvider = Provider<SquadRepository>(
+  (ref) => ApiSquadRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
+final friendRepositoryProvider = Provider<FriendRepository>(
+  (ref) => ApiFriendRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
 /// The My Friends timeline (specs/screens/friends-timeline.md).
 final friendsTimelineProvider = FutureProvider<TimelinePage>(
   (ref) => ref.watch(timelineRepositoryProvider).friends(),
 );
 
+/// A squad's timeline (specs/screens/squads.md), keyed by squad id.
+final squadTimelineProvider = FutureProvider.family<TimelinePage, String>(
+  (ref, squadId) => ref.watch(timelineRepositoryProvider).squad(squadId),
+);
+
+/// The user's squads (for the context selector).
+final squadsProvider = FutureProvider<List<Squad>>(
+  (ref) => ref.watch(squadRepositoryProvider).list(),
+);
+
 /// Activity types for the compose-idea form (specs/api/ideas-activities.md).
 final topicsProvider = FutureProvider<List<Topic>>(
   (ref) => ref.watch(topicRepositoryProvider).list(),
+);
+
+/// The user's accepted friends (for squad member selection).
+final friendsProvider = FutureProvider<List<Friend>>(
+  (ref) => ref.watch(friendRepositoryProvider).list(),
 );

--- a/app/lib/repositories/activity_repository.dart
+++ b/app/lib/repositories/activity_repository.dart
@@ -5,11 +5,14 @@ import '../models/activity.dart';
 /// returns the updated [Activity] (the API re-serializes it), so callers can refresh
 /// without a separate read. Friends/all_friends audience only this stage.
 abstract class ActivityRepository {
+  /// Create an idea. Friends scope (default) → all_friends audience; squad scope →
+  /// pass [squadId] (visible to that squad's members).
   Future<Activity> createIdea({
     required String activityTypeId,
     bool allowSuggestions,
     List<String> timeOptions,
     List<String> locationOptions,
+    String? squadId,
   });
 
   Future<Activity> setResponse(String activityId, String value);
@@ -38,11 +41,14 @@ class ApiActivityRepository implements ActivityRepository {
     bool allowSuggestions = false,
     List<String> timeOptions = const [],
     List<String> locationOptions = const [],
+    String? squadId,
   }) async {
     final res = await apiClient.post(
       '/v1/ideas',
       body: {
         'activity_type_id': activityTypeId,
+        if (squadId != null) 'scope': 'squad',
+        'squad_id': ?squadId,
         'audience': {'kind': 'all_friends'},
         'allow_suggestions': allowSuggestions,
         if (timeOptions.isNotEmpty) 'time_options': timeOptions,

--- a/app/lib/repositories/friend_repository.dart
+++ b/app/lib/repositories/friend_repository.dart
@@ -1,0 +1,20 @@
+import '../api/api_client.dart';
+import '../models/friend.dart';
+
+abstract class FriendRepository {
+  Future<List<Friend>> list();
+}
+
+class ApiFriendRepository implements FriendRepository {
+  ApiFriendRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  @override
+  Future<List<Friend>> list() async {
+    final res = await apiClient.get('/v1/friends');
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => Friend.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/app/lib/repositories/squad_repository.dart
+++ b/app/lib/repositories/squad_repository.dart
@@ -1,0 +1,45 @@
+import '../api/api_client.dart';
+import '../models/squad.dart';
+
+abstract class SquadRepository {
+  Future<List<Squad>> list();
+  Future<SquadDetail> create(String name, List<String> memberIds);
+  Future<SquadDetail> get(String squadId);
+  Future<SquadDetail> addMember(String squadId, String profileId);
+}
+
+class ApiSquadRepository implements SquadRepository {
+  ApiSquadRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  @override
+  Future<List<Squad>> list() async {
+    final res = await apiClient.get('/v1/squads');
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => Squad.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<SquadDetail> create(String name, List<String> memberIds) async {
+    final res = await apiClient.post(
+      '/v1/squads',
+      body: {'name': name, 'member_ids': memberIds},
+    );
+    return SquadDetail.fromJson(res);
+  }
+
+  @override
+  Future<SquadDetail> get(String squadId) async =>
+      SquadDetail.fromJson(await apiClient.get('/v1/squads/$squadId'));
+
+  @override
+  Future<SquadDetail> addMember(String squadId, String profileId) async {
+    final res = await apiClient.post(
+      '/v1/squads/$squadId/members',
+      body: {'profile_id': profileId},
+    );
+    return SquadDetail.fromJson(res);
+  }
+}

--- a/app/lib/repositories/timeline_repository.dart
+++ b/app/lib/repositories/timeline_repository.dart
@@ -9,6 +9,7 @@ class TimelinePage {
 
 abstract class TimelineRepository {
   Future<TimelinePage> friends({int limit, String? before});
+  Future<TimelinePage> squad(String squadId, {int limit, String? before});
 }
 
 class ApiTimelineRepository implements TimelineRepository {
@@ -16,12 +17,7 @@ class ApiTimelineRepository implements TimelineRepository {
 
   final ApiClient apiClient;
 
-  @override
-  Future<TimelinePage> friends({int limit = 50, String? before}) async {
-    final res = await apiClient.get(
-      '/v1/timeline/friends',
-      query: {'limit': limit, 'before': ?before},
-    );
+  TimelinePage _page(Map<String, dynamic> res) {
     final items = ((res['items'] as List<dynamic>?) ?? const [])
         .map((e) => Activity.fromJson(e as Map<String, dynamic>))
         .toList();
@@ -30,4 +26,24 @@ class ApiTimelineRepository implements TimelineRepository {
       nextCursor: res['next_cursor'] as String?,
     );
   }
+
+  @override
+  Future<TimelinePage> friends({int limit = 50, String? before}) async => _page(
+    await apiClient.get(
+      '/v1/timeline/friends',
+      query: {'limit': limit, 'before': ?before},
+    ),
+  );
+
+  @override
+  Future<TimelinePage> squad(
+    String squadId, {
+    int limit = 50,
+    String? before,
+  }) async => _page(
+    await apiClient.get(
+      '/v1/squads/$squadId/timeline',
+      query: {'limit': limit, 'before': ?before},
+    ),
+  );
 }

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -7,6 +7,7 @@ import 'providers/auth_controller.dart';
 import 'screens/activity/activity_detail_screen.dart';
 import 'screens/compose/compose_idea_screen.dart';
 import 'screens/login/login_screen.dart';
+import 'screens/squads/create_squad_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
 
 /// Auth-gated router. Redirects to /login until signed in, to /splash while the
@@ -32,6 +33,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/login', builder: (_, _) => const LoginScreen()),
       GoRoute(path: '/', builder: (_, _) => const TimelineScreen()),
       GoRoute(path: '/ideas/new', builder: (_, _) => const ComposeIdeaScreen()),
+      GoRoute(
+        path: '/squads/new',
+        builder: (_, _) => const CreateSquadScreen(),
+      ),
       GoRoute(
         path: '/activity/:id',
         builder: (_, state) =>

--- a/app/lib/screens/activity/activity_detail_screen.dart
+++ b/app/lib/screens/activity/activity_detail_screen.dart
@@ -38,7 +38,9 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
     });
     try {
       final updated = await action();
+      // Refresh whichever timeline this item lives on (friends or any squad).
       ref.invalidate(friendsTimelineProvider);
+      ref.invalidate(squadTimelineProvider);
       if (mounted) setState(() => _activity = updated);
     } on ApiException catch (e) {
       setState(() => _error = e.message);

--- a/app/lib/screens/compose/compose_idea_screen.dart
+++ b/app/lib/screens/compose/compose_idea_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../api/api_exception.dart';
 import '../../models/topic.dart';
+import '../../providers/active_context.dart';
 import '../../providers/providers.dart';
 
 /// Compose a new idea (specs/api/ideas-activities.md). Friends/all_friends audience
@@ -43,6 +44,7 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
       _busy = true;
       _error = null;
     });
+    final ctx = ref.read(activeContextProvider);
     try {
       await ref
           .read(activityRepositoryProvider)
@@ -51,8 +53,17 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
             allowSuggestions: _allowSuggestions,
             timeOptions: _split(_time.text),
             locationOptions: _split(_location.text),
+            squadId: switch (ctx) {
+              SquadContext(:final id) => id,
+              FriendsContext() => null,
+            },
           );
-      ref.invalidate(friendsTimelineProvider);
+      switch (ctx) {
+        case FriendsContext():
+          ref.invalidate(friendsTimelineProvider);
+        case SquadContext(:final id):
+          ref.invalidate(squadTimelineProvider(id));
+      }
       if (mounted) context.pop();
     } on ApiException catch (e) {
       setState(() => _error = e.message);
@@ -66,6 +77,12 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
   @override
   Widget build(BuildContext context) {
     final topics = ref.watch(topicsProvider);
+    final ctx = ref.watch(activeContextProvider);
+    // Audience clarity at the moment of action (context-selector principle).
+    final destination = switch (ctx) {
+      FriendsContext() => 'Visible to all your friends',
+      SquadContext(:final name) => 'Visible to $name members',
+    };
 
     return Scaffold(
       appBar: AppBar(title: const Text('New idea')),
@@ -74,6 +91,22 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            Container(
+              key: const Key('composeDestination'),
+              padding: const EdgeInsets.all(12),
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.visibility_outlined, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(child: Text(destination)),
+                ],
+              ),
+            ),
             topics.when(
               loading: () => const Center(
                 child: Padding(

--- a/app/lib/screens/squads/create_squad_screen.dart
+++ b/app/lib/screens/squads/create_squad_screen.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_exception.dart';
+import '../../providers/active_context.dart';
+import '../../providers/providers.dart';
+
+/// Create a squad: name + pick members from your friends (specs/screens/squads.md).
+/// On success the new squad becomes the active context. Fuller membership
+/// management is deferred.
+class CreateSquadScreen extends ConsumerStatefulWidget {
+  const CreateSquadScreen({super.key});
+
+  @override
+  ConsumerState<CreateSquadScreen> createState() => _CreateSquadScreenState();
+}
+
+class _CreateSquadScreenState extends ConsumerState<CreateSquadScreen> {
+  final _name = TextEditingController();
+  final _selected = <String>{};
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_name.text.trim().isEmpty) {
+      setState(() => _error = 'Give your squad a name');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final squad = await ref
+          .read(squadRepositoryProvider)
+          .create(_name.text.trim(), _selected.toList());
+      ref.invalidate(squadsProvider);
+      ref.read(activeContextProvider.notifier).toSquad(squad.id, squad.name);
+      if (mounted) context.pop();
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = 'Couldn\'t create the squad. Please try again.');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final friends = ref.watch(friendsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('New squad')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              key: const Key('squadNameField'),
+              controller: _name,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Squad name',
+                hintText: 'Wednesday Riders',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Add members',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+          Expanded(
+            child: friends.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) =>
+                  Center(child: Text('Couldn\'t load friends.\n$e')),
+              data: (list) => list.isEmpty
+                  ? const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(32),
+                        child: Text(
+                          'No friends yet — you can create the squad solo and add members later.',
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    )
+                  : ListView(
+                      key: const Key('friendPicker'),
+                      children: [
+                        for (final f in list)
+                          CheckboxListTile(
+                            key: Key('friend_${f.id}'),
+                            value: _selected.contains(f.id),
+                            title: Text(
+                              [
+                                    f.firstName,
+                                    f.lastName,
+                                  ].whereType<String>().join(' ').trim().isEmpty
+                                  ? 'Friend'
+                                  : [
+                                      f.firstName,
+                                      f.lastName,
+                                    ].whereType<String>().join(' ').trim(),
+                            ),
+                            onChanged: (sel) => setState(() {
+                              if (sel ?? false) {
+                                _selected.add(f.id);
+                              } else {
+                                _selected.remove(f.id);
+                              }
+                            }),
+                          ),
+                      ],
+                    ),
+            ),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                _error!,
+                key: const Key('createSquadError'),
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: FilledButton(
+              key: const Key('createSquadButton'),
+              onPressed: _busy ? null : _submit,
+              child: Text(_busy ? 'Creating…' : 'Create squad'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -3,21 +3,53 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../models/activity.dart';
+import '../../providers/active_context.dart';
 import '../../providers/auth_controller.dart';
 import '../../providers/providers.dart';
+import '../../repositories/timeline_repository.dart';
 
-/// The My Friends timeline (specs/screens/friends-timeline.md). Minimal-functional
-/// for this stage: a list of idea/activity tiles; the polished card UI comes later.
+/// The active timeline — My Friends or a Squad, per the context selector
+/// (specs/behaviors/context-selector.md). The title, feed, and compose destination
+/// all derive from `activeContextProvider` (one source of truth). Minimal-functional;
+/// polished cards come later.
 class TimelineScreen extends ConsumerWidget {
   const TimelineScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final timeline = ref.watch(friendsTimelineProvider);
+    final ctx = ref.watch(activeContextProvider);
+    final AsyncValue<TimelinePage> timeline = switch (ctx) {
+      FriendsContext() => ref.watch(friendsTimelineProvider),
+      SquadContext(:final id) => ref.watch(squadTimelineProvider(id)),
+    };
+    final title = switch (ctx) {
+      FriendsContext() => 'My Friends',
+      SquadContext(:final name) => name,
+    };
+    final emptyText = switch (ctx) {
+      FriendsContext() =>
+        'No ideas yet.\nWhen a friend shares an idea, it shows up here.',
+      SquadContext() => 'No ideas in this squad yet.\nTap + to share one.',
+    };
+
+    void refresh() => switch (ctx) {
+      FriendsContext() => ref.invalidate(friendsTimelineProvider),
+      SquadContext(:final id) => ref.invalidate(squadTimelineProvider(id)),
+    };
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('My Friends'),
+        title: InkWell(
+          key: const Key('contextSelectorButton'),
+          onTap: () => _showContextSelector(context, ref),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(child: Text(title, overflow: TextOverflow.ellipsis)),
+              const Icon(Icons.arrow_drop_down),
+            ],
+          ),
+        ),
         actions: [
           IconButton(
             key: const Key('logoutButton'),
@@ -34,7 +66,12 @@ class TimelineScreen extends ConsumerWidget {
         child: const Icon(Icons.add),
       ),
       body: RefreshIndicator(
-        onRefresh: () async => ref.refresh(friendsTimelineProvider.future),
+        onRefresh: () => switch (ctx) {
+          FriendsContext() => ref.refresh(friendsTimelineProvider.future),
+          SquadContext(:final id) => ref.refresh(
+            squadTimelineProvider(id).future,
+          ),
+        },
         child: timeline.when(
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (e, _) => ListView(
@@ -42,14 +79,14 @@ class TimelineScreen extends ConsumerWidget {
               const SizedBox(height: 120),
               Center(
                 child: Text(
-                  'Couldn\'t load your timeline.\n$e',
+                  'Couldn\'t load this timeline.\n$e',
                   textAlign: TextAlign.center,
                 ),
               ),
               const SizedBox(height: 12),
               Center(
                 child: FilledButton(
-                  onPressed: () => ref.invalidate(friendsTimelineProvider),
+                  onPressed: refresh,
                   child: const Text('Retry'),
                 ),
               ),
@@ -58,16 +95,13 @@ class TimelineScreen extends ConsumerWidget {
           data: (page) {
             if (page.items.isEmpty) {
               return ListView(
-                children: const [
-                  SizedBox(height: 160),
+                children: [
+                  const SizedBox(height: 160),
                   Center(
-                    key: Key('timelineEmpty'),
+                    key: const Key('timelineEmpty'),
                     child: Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 32),
-                      child: Text(
-                        'No ideas yet.\nWhen a friend shares an idea, it shows up here.',
-                        textAlign: TextAlign.center,
-                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Text(emptyText, textAlign: TextAlign.center),
                     ),
                   ),
                 ],
@@ -82,6 +116,71 @@ class TimelineScreen extends ConsumerWidget {
             );
           },
         ),
+      ),
+    );
+  }
+
+  void _showContextSelector(BuildContext context, WidgetRef ref) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) => Consumer(
+        builder: (_, ref, _) {
+          final squads = ref.watch(squadsProvider);
+          return SafeArea(
+            child: ListView(
+              key: const Key('contextSelectorSheet'),
+              shrinkWrap: true,
+              children: [
+                const ListTile(
+                  dense: true,
+                  title: Text(
+                    'SWITCH CONTEXT',
+                    style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                ListTile(
+                  key: const Key('ctx_friends'),
+                  leading: const Icon(Icons.group),
+                  title: const Text('My Friends'),
+                  onTap: () {
+                    ref.read(activeContextProvider.notifier).toFriends();
+                    Navigator.pop(sheetContext);
+                  },
+                ),
+                const Divider(height: 1),
+                ...squads.maybeWhen(
+                  data: (list) => list.map(
+                    (s) => ListTile(
+                      key: Key('ctx_squad_${s.id}'),
+                      leading: const Icon(Icons.shield_outlined),
+                      title: Text(s.name),
+                      subtitle: Text('${s.memberCount} members · ${s.role}'),
+                      onTap: () {
+                        ref
+                            .read(activeContextProvider.notifier)
+                            .toSquad(s.id, s.name);
+                        Navigator.pop(sheetContext);
+                      },
+                    ),
+                  ),
+                  orElse: () => [
+                    const ListTile(title: Text('Loading squads…')),
+                  ],
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  key: const Key('ctx_new_squad'),
+                  leading: const Icon(Icons.add),
+                  title: const Text('New squad'),
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    context.push('/squads/new');
+                  },
+                ),
+              ],
+            ),
+          );
+        },
       ),
     );
   }

--- a/app/test/activity_detail_test.dart
+++ b/app/test/activity_detail_test.dart
@@ -18,6 +18,7 @@ class FakeActivityRepository implements ActivityRepository {
     bool allowSuggestions = false,
     List<String> timeOptions = const [],
     List<String> locationOptions = const [],
+    String? squadId,
   }) async => result;
 
   @override

--- a/app/test/create_squad_test.dart
+++ b/app/test/create_squad_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/friend.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/friend_repository.dart';
+import 'package:squadquest/screens/squads/create_squad_screen.dart';
+
+class FakeFriendRepository implements FriendRepository {
+  FakeFriendRepository(this._friends);
+  final List<Friend> _friends;
+  @override
+  Future<List<Friend>> list() async => _friends;
+}
+
+void main() {
+  testWidgets('create-squad lists friends to pick from', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          friendRepositoryProvider.overrideWithValue(
+            FakeFriendRepository(const [
+              Friend(id: 'f1', firstName: 'Katie'),
+              Friend(id: 'f2', firstName: 'Mike'),
+            ]),
+          ),
+        ],
+        child: const MaterialApp(home: CreateSquadScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('squadNameField')), findsOneWidget);
+    expect(find.byKey(const Key('friendPicker')), findsOneWidget);
+    expect(find.byKey(const Key('friend_f1')), findsOneWidget);
+    expect(find.text('Katie'), findsOneWidget);
+    expect(find.text('Mike'), findsOneWidget);
+    expect(find.byKey(const Key('createSquadButton')), findsOneWidget);
+  });
+
+  testWidgets('shows a solo hint when there are no friends', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          friendRepositoryProvider.overrideWithValue(
+            FakeFriendRepository(const []),
+          ),
+        ],
+        child: const MaterialApp(home: CreateSquadScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.textContaining('create the squad solo'), findsOneWidget);
+  });
+}

--- a/app/test/timeline_screen_test.dart
+++ b/app/test/timeline_screen_test.dart
@@ -13,6 +13,12 @@ class FakeTimelineRepository implements TimelineRepository {
   final TimelinePage _page;
   @override
   Future<TimelinePage> friends({int limit = 50, String? before}) async => _page;
+  @override
+  Future<TimelinePage> squad(
+    String squadId, {
+    int limit = 50,
+    String? before,
+  }) async => _page;
 }
 
 Widget _harness(TimelinePage page) => ProviderScope(

--- a/plans/v2-squads-context-selector.md
+++ b/plans/v2-squads-context-selector.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-client-stage2-interactive-timeline]
 specs:
   - specs/data-model.md
@@ -8,7 +8,7 @@ specs:
   - specs/api/ideas-activities.md
   - specs/api/timeline.md
 issues: []
-pr:
+pr: 417
 ---
 
 # Plan: v2 squads + context selector
@@ -60,12 +60,18 @@ captain membership management (spec defers it); Communities/Discover entries in 
 
 ## Validation
 
-- [ ] migration applies; `bun run type-check` + `bun test` (squad create/list/add-member,
-      member-gated timeline, scope=squad create, non-member 403) green; CI green.
-- [ ] MCP end-to-end (two accounts): A creates a squad incl. B → both see it in the selector;
-      A composes a squad idea → on the squad timeline for A & B, **absent** from My Friends;
-      B responds/votes; A confirms. Screenshot the selector, squad timeline, compose-scoped.
-- [ ] switching context updates title + feed + compose destination consistently.
+- [x] migration applies; `bun run type-check` + `bun test` (squad create/list/add-member,
+      member-gated timeline, scope=squad create, non-member 403) — 4 squad tests, full suite
+      21/21; backend CI green (#416, merged).
+- [x] client `flutter analyze` clean + 6 widget tests (create-squad picker + updated
+      timeline/detail fakes); client CI on #417.
+- [~] MCP end-to-end screenshot walkthrough (two accounts): **deferred** — driving text entry
+      needs the app window foregrounded, impractical while the machine is in use. The
+      member-only / never-on-friends visibility is unit-tested (#416) and the login→compose→
+      respond→vote→confirm driver loop was demonstrated in the prior stage; only the visual
+      squad walkthrough is outstanding.
+- [x] switching context updates title + feed + compose destination from one source of truth
+      (`activeContextProvider`) — implemented; verified structurally, not screenshot-demoed.
 
 ## Risks / unknowns
 
@@ -77,8 +83,21 @@ captain membership management (spec defers it); Communities/Discover entries in 
 
 ## Notes
 
-(closeout)
+Shipped as two PRs: **#416** (backend — schema/migration 0002, SquadService, routes,
+`scope=squad` in createIdea + squad-membership visibility branch + squadTimeline, 4 tests)
+merged to develop; **#417** (client — active-context provider, context selector, squad
+timeline, scoped composer + destination banner, create-squad flow, 6 widget tests). One
+visibility predicate now spans friends-graph and squad-membership, reused by reads + write
+authz. `activity.squad_id` stays a plain uuid (no FK) — membership integrity enforced in the
+domain. Activities-only squad timeline this stage.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred (visual QA):** run the two-account MCP screenshot walkthrough of the squad flow
+  when the machine is free to hold the app window in foreground.
+- **Deferred to plan:** free-text squad messages + thread drawer (messages stage — fills out
+  the heterogeneous squad feed); Communities/Discover entries in the context selector
+  (communities stage); polished captain membership management; people-targeted audience +
+  suggest-option client UI.
+- **Tracked as (skill):** the desktop window-focus constraint for MCP text entry is already
+  documented in the mobile-flutter skill's mcp-driving reference.


### PR DESCRIPTION
Client half of the **squads + context selector** stage (backend was #416). Styling still deferred.

Implements `specs/behaviors/context-selector.md` + the squad slice of `specs/screens/squads.md`.

## What's here
- **`activeContextProvider`** (`FriendsContext` | `SquadContext`) — one source of truth for the title, feed, and compose destination (they can never disagree).
- **Repositories/models**: `SquadRepository`, `FriendRepository` (+ squad/friend models); `TimelineRepository.squad`; `squadsProvider` / `friendsProvider` / `squadTimelineProvider(family)`.
- **Timeline screen** branches on the active context; tappable title → context-selector sheet (My Friends ▸ my squads ▸ New squad).
- **Composer** scope follows context (friends→all_friends, squad→`scope=squad`+`squad_id`) with a destination banner ("Visible to <squad> members"); mutations invalidate the active timeline.
- **Create-squad screen** (name + pick friends) → the new squad becomes the active context.

## Verification
`flutter analyze` clean; **6 widget tests** green (create-squad picker + existing timeline/detail, fakes updated for the new interfaces). Backend visibility (squad ideas members-only, never on My Friends) is unit-tested in #416.

The interactive MCP screenshot walkthrough is deferred (it needs the app window foregrounded, which isn't practical while the machine is in use) — the same driver loop was demonstrated in the interactive-timeline stage.

## Scope
Free-text squad messages + thread drawer are the messages stage (squad timeline is activities-only for now). Communities/Discover entries in the selector come with the communities stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)