### PR TITLE
fix(server): squad activities show squad-scoped audience, not "all friends"

### DIFF
--- a/server/src/contracts/activity.ts
+++ b/server/src/contracts/activity.ts
@@ -9,6 +9,7 @@ import {
   response,
   profile,
   topic,
+  squad,
 } from '../db/schema/index.ts'
 
 type ActivityRow = typeof activity.$inferSelect
@@ -39,6 +40,13 @@ export async function serializeActivities(
   const votes = optionIds.length
     ? await db.select().from(optionVote).where(inArray(optionVote.optionId, optionIds))
     : []
+
+  // Squad names for squad-scoped rows (for the audience label).
+  const squadIds = [...new Set(rows.map((r) => r.squadId).filter((id): id is string => !!id))]
+  const squads = squadIds.length
+    ? await db.select().from(squad).where(inArray(squad.id, squadIds))
+    : []
+  const squadNameById = new Map(squads.map((s) => [s.id, s.name]))
 
   const captainById = new Map(captains.map((c) => [c.id, c]))
   const typeById = new Map(types.map((t) => [t.id, t]))
@@ -89,12 +97,25 @@ export async function serializeActivities(
     const opts = optionsByActivity.get(r.id) ?? []
     const counts = respCounts.get(r.id) ?? { in: 0, interested: 0 }
 
-    const audienceSummary =
-      r.audienceKind === 'all_friends'
-        ? 'all friends'
-        : `${audienceCount.get(r.id) ?? 0} ${
-            (audienceCount.get(r.id) ?? 0) === 1 ? 'person' : 'people'
-          }`
+    // Audience label reflects scope: squad activities are visible to the whole
+    // squad and only the squad (never "all friends"); friends activities use the
+    // audience kind (all_friends / N people).
+    const audience =
+      r.scope === 'squad'
+        ? {
+            kind: 'squad',
+            summary: r.squadId
+                ? `${squadNameById.get(r.squadId) ?? 'Squad'} members`
+                : 'Squad members',
+          }
+        : {
+            kind: r.audienceKind,
+            summary: r.audienceKind === 'all_friends'
+                ? 'all friends'
+                : `${audienceCount.get(r.id) ?? 0} ${
+                    (audienceCount.get(r.id) ?? 0) === 1 ? 'person' : 'people'
+                  }`,
+          }
 
     return {
       id: r.id,
@@ -105,7 +126,7 @@ export async function serializeActivities(
       activity_type: type ? { id: type.id, label: type.label } : null,
       scope: r.scope,
       squad_id: r.squadId,
-      audience: { kind: r.audienceKind, summary: audienceSummary },
+      audience,
       allow_suggestions: r.allowSuggestions,
       time_options: opts.filter((o) => o.kind === 'time').map(serializeOption),
       location_options: opts.filter((o) => o.kind === 'location').map(serializeOption),

--- a/server/test/squads.test.ts
+++ b/server/test/squads.test.ts
@@ -133,6 +133,8 @@ test('squad idea shows on the squad timeline, never on My Friends', async () => 
   })
   expect(created.statusCode).toBe(201)
   expect(created.json().scope).toBe('squad')
+  // audience reads as squad-scoped, never "all friends"
+  expect(created.json().audience).toEqual({ kind: 'squad', summary: 'Paddlers members' })
 
   // member sees it on the squad timeline
   const memberFeed = await server.inject({
@@ -141,6 +143,7 @@ test('squad idea shows on the squad timeline, never on My Friends', async () => 
     headers: member.auth,
   })
   expect(memberFeed.json().items).toHaveLength(1)
+  expect(memberFeed.json().items[0].audience.kind).toBe('squad')
 
   // it must NOT leak onto anyone's My Friends timeline (private-first)
   for (const u of [cap, member, outsider]) {


### PR DESCRIPTION
**Bug:** activities posted to a squad displayed **"all friends"** as their audience on the feed. The *visibility* was correct (squad ideas are members-only and never appear on any My Friends timeline — unit-tested), but the **label** was wrong.

**Cause:** squad-scoped activities store `audience_kind='all_friends'` as a placeholder (the column is `NOT NULL`; squad visibility is determined by membership, not by `audience_kind`). The serializer rendered that kind literally as "all friends".

**Fix:** the activity serializer now branches on `scope`. Squad activities emit `audience: { kind: 'squad', summary: '<squad name> members' }` (squad names batch-loaded for the page); friends activities are unchanged. Conveys full-squad + squad-only visibility.

Test added asserting a squad idea's audience is `{kind:'squad', summary:'<squad> members'}`. Full server suite green.

Found via live testing of the squad timeline.