### PR TITLE
v2 client: messages — squad feed, composer, activity threads

### DIFF
--- a/app/lib/models/feed_item.dart
+++ b/app/lib/models/feed_item.dart
@@ -1,0 +1,23 @@
+import 'activity.dart';
+import 'message.dart';
+
+/// A heterogeneous squad-timeline item (specs/screens/squads.md): an idea/activity
+/// or a free-text message, tagged by the server's `type` field.
+sealed class FeedItem {
+  const FeedItem();
+
+  factory FeedItem.fromJson(Map<String, dynamic> json) =>
+      json['type'] == 'message'
+      ? MessageFeedItem(Message.fromJson(json))
+      : ActivityFeedItem(Activity.fromJson(json));
+}
+
+class ActivityFeedItem extends FeedItem {
+  const ActivityFeedItem(this.activity);
+  final Activity activity;
+}
+
+class MessageFeedItem extends FeedItem {
+  const MessageFeedItem(this.message);
+  final Message message;
+}

--- a/app/lib/models/message.dart
+++ b/app/lib/models/message.dart
@@ -1,0 +1,33 @@
+/// A free-text message — a squad post or a thread reply (specs/api/messages.md).
+/// Attachments arrive with storage; body is non-null for now.
+class Message {
+  const Message({
+    required this.id,
+    this.senderName,
+    this.senderPhoto,
+    this.body,
+    this.threadCount = 0,
+    this.createdAt,
+  });
+
+  final String id;
+  final String? senderName;
+  final String? senderPhoto;
+  final String? body;
+  final int threadCount;
+  final DateTime? createdAt;
+
+  factory Message.fromJson(Map<String, dynamic> json) {
+    final sender = json['sender'] as Map<String, dynamic>?;
+    return Message(
+      id: json['id'] as String,
+      senderName: sender?['first_name'] as String?,
+      senderPhoto: sender?['photo'] as String?,
+      body: json['body'] as String?,
+      threadCount: (json['thread_count'] as num?)?.toInt() ?? 0,
+      createdAt: json['created_at'] == null
+          ? null
+          : DateTime.tryParse(json['created_at'] as String),
+    );
+  }
+}

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -3,11 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../api/api_client.dart';
 import '../config.dart';
 import '../models/friend.dart';
+import '../models/message.dart';
 import '../models/squad.dart';
 import '../models/topic.dart';
 import '../repositories/activity_repository.dart';
 import '../repositories/auth_repository.dart';
 import '../repositories/friend_repository.dart';
+import '../repositories/message_repository.dart';
 import '../repositories/profile_repository.dart';
 import '../repositories/squad_repository.dart';
 import '../repositories/timeline_repository.dart';
@@ -61,15 +63,27 @@ final friendRepositoryProvider = Provider<FriendRepository>(
   (ref) => ApiFriendRepository(apiClient: ref.watch(apiClientProvider)),
 );
 
+final messageRepositoryProvider = Provider<MessageRepository>(
+  (ref) => ApiMessageRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
 /// The My Friends timeline (specs/screens/friends-timeline.md).
 final friendsTimelineProvider = FutureProvider<TimelinePage>(
   (ref) => ref.watch(timelineRepositoryProvider).friends(),
 );
 
-/// A squad's timeline (specs/screens/squads.md), keyed by squad id.
-final squadTimelineProvider = FutureProvider.family<TimelinePage, String>(
-  (ref, squadId) => ref.watch(timelineRepositoryProvider).squad(squadId),
+/// A squad's heterogeneous timeline (activities + messages), keyed by squad id.
+final squadTimelineProvider = FutureProvider.family<SquadFeedPage, String>(
+  (ref, squadId) => ref.watch(timelineRepositoryProvider).squadFeed(squadId),
 );
+
+/// A thread's messages, keyed by `targetType:targetId`.
+final threadProvider = FutureProvider.family<List<Message>, String>((ref, key) {
+  final i = key.indexOf(':');
+  return ref
+      .watch(messageRepositoryProvider)
+      .thread(key.substring(0, i), key.substring(i + 1));
+});
 
 /// The user's squads (for the context selector).
 final squadsProvider = FutureProvider<List<Squad>>(

--- a/app/lib/repositories/message_repository.dart
+++ b/app/lib/repositories/message_repository.dart
@@ -1,0 +1,43 @@
+import '../api/api_client.dart';
+import '../models/message.dart';
+
+/// Free-text messages: squad posts + thread replies (specs/api/messages.md).
+abstract class MessageRepository {
+  Future<Message> postSquadMessage(String squadId, String body);
+  Future<List<Message>> thread(String targetType, String targetId);
+  Future<Message> reply(String targetType, String targetId, String body);
+}
+
+class ApiMessageRepository implements MessageRepository {
+  ApiMessageRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  @override
+  Future<Message> postSquadMessage(String squadId, String body) async {
+    final res = await apiClient.post(
+      '/v1/squads/$squadId/messages',
+      body: {'body': body},
+    );
+    return Message.fromJson(res);
+  }
+
+  @override
+  Future<List<Message>> thread(String targetType, String targetId) async {
+    final res = await apiClient.get(
+      '/v1/threads/$targetType/$targetId/messages',
+    );
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => Message.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<Message> reply(String targetType, String targetId, String body) async {
+    final res = await apiClient.post(
+      '/v1/threads/$targetType/$targetId/messages',
+      body: {'body': body},
+    );
+    return Message.fromJson(res);
+  }
+}

--- a/app/lib/repositories/timeline_repository.dart
+++ b/app/lib/repositories/timeline_repository.dart
@@ -1,5 +1,6 @@
 import '../api/api_client.dart';
 import '../models/activity.dart';
+import '../models/feed_item.dart';
 
 class TimelinePage {
   const TimelinePage({required this.items, this.nextCursor});
@@ -7,9 +8,16 @@ class TimelinePage {
   final String? nextCursor;
 }
 
+/// A heterogeneous squad feed page (activities + messages).
+class SquadFeedPage {
+  const SquadFeedPage({required this.items, this.nextCursor});
+  final List<FeedItem> items;
+  final String? nextCursor;
+}
+
 abstract class TimelineRepository {
   Future<TimelinePage> friends({int limit, String? before});
-  Future<TimelinePage> squad(String squadId, {int limit, String? before});
+  Future<SquadFeedPage> squadFeed(String squadId, {int limit, String? before});
 }
 
 class ApiTimelineRepository implements TimelineRepository {
@@ -17,7 +25,12 @@ class ApiTimelineRepository implements TimelineRepository {
 
   final ApiClient apiClient;
 
-  TimelinePage _page(Map<String, dynamic> res) {
+  @override
+  Future<TimelinePage> friends({int limit = 50, String? before}) async {
+    final res = await apiClient.get(
+      '/v1/timeline/friends',
+      query: {'limit': limit, 'before': ?before},
+    );
     final items = ((res['items'] as List<dynamic>?) ?? const [])
         .map((e) => Activity.fromJson(e as Map<String, dynamic>))
         .toList();
@@ -28,22 +41,21 @@ class ApiTimelineRepository implements TimelineRepository {
   }
 
   @override
-  Future<TimelinePage> friends({int limit = 50, String? before}) async => _page(
-    await apiClient.get(
-      '/v1/timeline/friends',
-      query: {'limit': limit, 'before': ?before},
-    ),
-  );
-
-  @override
-  Future<TimelinePage> squad(
+  Future<SquadFeedPage> squadFeed(
     String squadId, {
     int limit = 50,
     String? before,
-  }) async => _page(
-    await apiClient.get(
+  }) async {
+    final res = await apiClient.get(
       '/v1/squads/$squadId/timeline',
       query: {'limit': limit, 'before': ?before},
-    ),
-  );
+    );
+    final items = ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => FeedItem.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return SquadFeedPage(
+      items: items,
+      nextCursor: res['next_cursor'] as String?,
+    );
+  }
 }

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -3,11 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'models/activity.dart';
+import 'models/message.dart';
 import 'providers/auth_controller.dart';
 import 'screens/activity/activity_detail_screen.dart';
 import 'screens/compose/compose_idea_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
+import 'screens/thread/thread_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
 
 /// Auth-gated router. Redirects to /login until signed in, to /splash while the
@@ -41,6 +43,14 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/activity/:id',
         builder: (_, state) =>
             ActivityDetailScreen(activity: state.extra as Activity?),
+      ),
+      GoRoute(
+        path: '/thread/:targetType/:targetId',
+        builder: (_, state) => ThreadScreen(
+          targetType: state.pathParameters['targetType']!,
+          targetId: state.pathParameters['targetId']!,
+          root: state.extra as Message?,
+        ),
       ),
     ],
   );

--- a/app/lib/screens/activity/activity_detail_screen.dart
+++ b/app/lib/screens/activity/activity_detail_screen.dart
@@ -5,6 +5,7 @@ import '../../api/api_exception.dart';
 import '../../models/activity.dart';
 import '../../providers/auth_controller.dart';
 import '../../providers/providers.dart';
+import '../../widgets/thread_view.dart';
 
 /// Activity detail (specs/api/ideas-activities.md + response-system). Seeded from
 /// the [Activity] passed by the timeline; every action returns the updated activity,
@@ -161,6 +162,14 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
                     ),
                   ),
                 ],
+
+                const Divider(height: 32),
+                Text(
+                  'Discussion',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                ThreadView(targetType: 'activity', targetId: a.id),
               ],
             ),
     );

--- a/app/lib/screens/thread/thread_screen.dart
+++ b/app/lib/screens/thread/thread_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../../models/message.dart';
+import '../../widgets/thread_view.dart';
+
+/// A standalone thread (e.g. tapping a squad message). The root message is passed
+/// as a header; replies + input come from [ThreadView]. (specs/behaviors/thread-drawer.md)
+class ThreadScreen extends StatelessWidget {
+  const ThreadScreen({
+    super.key,
+    required this.targetType,
+    required this.targetId,
+    this.root,
+  });
+
+  final String targetType;
+  final String targetId;
+  final Message? root;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Thread')),
+      body: ListView(
+        key: const Key('threadScreen'),
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (root != null) ...[
+            Text(
+              root!.senderName ?? 'Someone',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(root!.body ?? ''),
+            const Divider(height: 32),
+          ],
+          ThreadView(targetType: targetType, targetId: targetId),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -3,24 +3,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../models/activity.dart';
+import '../../models/feed_item.dart';
+import '../../models/message.dart';
 import '../../providers/active_context.dart';
 import '../../providers/auth_controller.dart';
 import '../../providers/providers.dart';
-import '../../repositories/timeline_repository.dart';
 
-/// The active timeline — My Friends or a Squad, per the context selector
-/// (specs/behaviors/context-selector.md). The title, feed, and compose destination
-/// all derive from `activeContextProvider` (one source of truth). Minimal-functional;
-/// polished cards come later.
+/// The active timeline — My Friends (ideas/activities only) or a Squad (the
+/// heterogeneous activities + messages feed), per the context selector
+/// (specs/behaviors/context-selector.md). One source of truth: `activeContextProvider`.
 class TimelineScreen extends ConsumerWidget {
   const TimelineScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ctx = ref.watch(activeContextProvider);
-    final AsyncValue<TimelinePage> timeline = switch (ctx) {
-      FriendsContext() => ref.watch(friendsTimelineProvider),
-      SquadContext(:final id) => ref.watch(squadTimelineProvider(id)),
+
+    // Unify both contexts to a list of FeedItem so rendering is single-path.
+    final AsyncValue<List<FeedItem>> feed = switch (ctx) {
+      FriendsContext() =>
+        ref
+            .watch(friendsTimelineProvider)
+            .whenData(
+              (p) => p.items.map<FeedItem>(ActivityFeedItem.new).toList(),
+            ),
+      SquadContext(:final id) =>
+        ref.watch(squadTimelineProvider(id)).whenData((p) => p.items),
     };
     final title = switch (ctx) {
       FriendsContext() => 'My Friends',
@@ -29,12 +37,8 @@ class TimelineScreen extends ConsumerWidget {
     final emptyText = switch (ctx) {
       FriendsContext() =>
         'No ideas yet.\nWhen a friend shares an idea, it shows up here.',
-      SquadContext() => 'No ideas in this squad yet.\nTap + to share one.',
-    };
-
-    void refresh() => switch (ctx) {
-      FriendsContext() => ref.invalidate(friendsTimelineProvider),
-      SquadContext(:final id) => ref.invalidate(squadTimelineProvider(id)),
+      SquadContext() =>
+        'Nothing here yet.\nShare an idea (+) or post a message below.',
     };
 
     return Scaffold(
@@ -65,57 +69,62 @@ class TimelineScreen extends ConsumerWidget {
         onPressed: () => context.push('/ideas/new'),
         child: const Icon(Icons.add),
       ),
-      body: RefreshIndicator(
-        onRefresh: () => switch (ctx) {
-          FriendsContext() => ref.refresh(friendsTimelineProvider.future),
-          SquadContext(:final id) => ref.refresh(
-            squadTimelineProvider(id).future,
-          ),
-        },
-        child: timeline.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => ListView(
-            children: [
-              const SizedBox(height: 120),
-              Center(
-                child: Text(
-                  'Couldn\'t load this timeline.\n$e',
-                  textAlign: TextAlign.center,
+      body: Column(
+        children: [
+          Expanded(
+            child: RefreshIndicator(
+              onRefresh: () => switch (ctx) {
+                FriendsContext() => ref.refresh(friendsTimelineProvider.future),
+                SquadContext(:final id) => ref.refresh(
+                  squadTimelineProvider(id).future,
                 ),
-              ),
-              const SizedBox(height: 12),
-              Center(
-                child: FilledButton(
-                  onPressed: refresh,
-                  child: const Text('Retry'),
-                ),
-              ),
-            ],
-          ),
-          data: (page) {
-            if (page.items.isEmpty) {
-              return ListView(
-                children: [
-                  const SizedBox(height: 160),
-                  Center(
-                    key: const Key('timelineEmpty'),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 32),
-                      child: Text(emptyText, textAlign: TextAlign.center),
+              },
+              child: feed.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => ListView(
+                  children: [
+                    const SizedBox(height: 120),
+                    Center(
+                      child: Text(
+                        'Couldn\'t load this timeline.\n$e',
+                        textAlign: TextAlign.center,
+                      ),
                     ),
-                  ),
-                ],
-              );
-            }
-            return ListView.separated(
-              key: const Key('timelineList'),
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: page.items.length,
-              separatorBuilder: (_, _) => const Divider(height: 1),
-              itemBuilder: (_, i) => _ActivityTile(page.items[i]),
-            );
-          },
-        ),
+                  ],
+                ),
+                data: (items) {
+                  if (items.isEmpty) {
+                    return ListView(
+                      children: [
+                        const SizedBox(height: 160),
+                        Center(
+                          key: const Key('timelineEmpty'),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 32),
+                            child: Text(emptyText, textAlign: TextAlign.center),
+                          ),
+                        ),
+                      ],
+                    );
+                  }
+                  return ListView.separated(
+                    key: const Key('timelineList'),
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: items.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (_, i) => switch (items[i]) {
+                      ActivityFeedItem(:final activity) => _ActivityTile(
+                        activity,
+                      ),
+                      MessageFeedItem(:final message) => _MessageTile(message),
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+          if (ctx is SquadContext) _SquadComposer(squadId: ctx.id),
+        ],
       ),
     );
   }
@@ -209,6 +218,104 @@ class _ActivityTile extends StatelessWidget {
       trailing: a.isConfirmed
           ? const Icon(Icons.event_available)
           : Text('${a.inCount} in'),
+    );
+  }
+}
+
+class _MessageTile extends StatelessWidget {
+  const _MessageTile(this.message);
+  final Message message;
+
+  @override
+  Widget build(BuildContext context) {
+    final m = message;
+    return ListTile(
+      key: Key('message_${m.id}'),
+      onTap: () => context.push('/thread/message/${m.id}', extra: m),
+      leading: CircleAvatar(
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        child: Text((m.senderName ?? '?').characters.first),
+      ),
+      title: Text(m.senderName ?? 'Someone'),
+      subtitle: Text(m.body ?? ''),
+      trailing: m.threadCount > 0
+          ? Text('${m.threadCount} ${m.threadCount == 1 ? 'reply' : 'replies'}')
+          : null,
+    );
+  }
+}
+
+/// Bottom input to post a free-text message to the active squad.
+class _SquadComposer extends ConsumerStatefulWidget {
+  const _SquadComposer({required this.squadId});
+  final String squadId;
+
+  @override
+  ConsumerState<_SquadComposer> createState() => _SquadComposerState();
+}
+
+class _SquadComposerState extends ConsumerState<_SquadComposer> {
+  final _controller = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final body = _controller.text.trim();
+    if (body.isEmpty || _busy) return;
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(messageRepositoryProvider)
+          .postSquadMessage(widget.squadId, body);
+      _controller.clear();
+      ref.invalidate(squadTimelineProvider(widget.squadId));
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t send. Try again.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 4, 8, 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                key: const Key('squadMessageField'),
+                controller: _controller,
+                minLines: 1,
+                maxLines: 4,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => _send(),
+                decoration: const InputDecoration(
+                  hintText: 'Message your squad…',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+              ),
+            ),
+            IconButton(
+              key: const Key('squadMessageSend'),
+              icon: const Icon(Icons.send),
+              onPressed: _busy ? null : _send,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/widgets/thread_view.dart
+++ b/app/lib/widgets/thread_view.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/message.dart';
+import '../providers/providers.dart';
+
+/// A thread conversation (specs/behaviors/thread-drawer.md, sans the slide-in chrome
+/// and realtime): the replies for a target plus a reply input. Renders as a non-scrolling
+/// Column so it can embed in a ListView (activity Discussion) or a screen.
+class ThreadView extends ConsumerStatefulWidget {
+  const ThreadView({
+    super.key,
+    required this.targetType,
+    required this.targetId,
+  });
+
+  final String targetType; // 'activity' | 'message'
+  final String targetId;
+
+  @override
+  ConsumerState<ThreadView> createState() => _ThreadViewState();
+}
+
+class _ThreadViewState extends ConsumerState<ThreadView> {
+  final _controller = TextEditingController();
+  bool _busy = false;
+
+  String get _key => '${widget.targetType}:${widget.targetId}';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final body = _controller.text.trim();
+    if (body.isEmpty || _busy) return;
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(messageRepositoryProvider)
+          .reply(widget.targetType, widget.targetId, body);
+      _controller.clear();
+      ref.invalidate(threadProvider(_key));
+      // thread_count changed → refresh the timelines that show it.
+      ref.invalidate(friendsTimelineProvider);
+      ref.invalidate(squadTimelineProvider);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t send your reply.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final thread = ref.watch(threadProvider(_key));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        thread.when(
+          loading: () => const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (e, _) => Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text('Couldn\'t load the thread.\n$e'),
+          ),
+          data: (msgs) => msgs.isEmpty
+              ? const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 12),
+                  child: Text('No replies yet. Start the conversation.'),
+                )
+              : Column(
+                  key: const Key('threadMessages'),
+                  // endpoint returns newest-first; show chronological
+                  children: msgs.reversed.map(_MessageRow.new).toList(),
+                ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                key: const Key('threadReplyField'),
+                controller: _controller,
+                minLines: 1,
+                maxLines: 4,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => _send(),
+                decoration: const InputDecoration(
+                  hintText: 'Reply…',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+              ),
+            ),
+            IconButton(
+              key: const Key('threadReplySend'),
+              icon: const Icon(Icons.send),
+              onPressed: _busy ? null : _send,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _MessageRow extends StatelessWidget {
+  const _MessageRow(this.message);
+  final Message message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            message.senderName ?? 'Someone',
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+          ),
+          Text(message.body ?? ''),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/thread_view_test.dart
+++ b/app/test/thread_view_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/message.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/message_repository.dart';
+import 'package:squadquest/widgets/thread_view.dart';
+
+class FakeMessageRepository implements MessageRepository {
+  FakeMessageRepository(this._messages);
+  final List<Message> _messages;
+
+  @override
+  Future<List<Message>> thread(String targetType, String targetId) async =>
+      _messages;
+  @override
+  Future<Message> reply(String t, String id, String body) async =>
+      Message(id: 'new', body: body);
+  @override
+  Future<Message> postSquadMessage(String squadId, String body) async =>
+      Message(id: 'new', body: body);
+}
+
+void main() {
+  testWidgets('thread renders replies (chronological) + a reply input', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          messageRepositoryProvider.overrideWithValue(
+            // endpoint returns newest-first; view should show oldest first
+            FakeMessageRepository(const [
+              Message(id: 'm2', senderName: 'Mike', body: 'second'),
+              Message(id: 'm1', senderName: 'Katie', body: 'first'),
+            ]),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: ThreadView(targetType: 'activity', targetId: 'a1'),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('threadMessages')), findsOneWidget);
+    expect(find.text('first'), findsOneWidget);
+    expect(find.text('second'), findsOneWidget);
+    expect(find.byKey(const Key('threadReplyField')), findsOneWidget);
+    expect(find.byKey(const Key('threadReplySend')), findsOneWidget);
+  });
+
+  testWidgets('empty thread shows a start-the-conversation hint', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          messageRepositoryProvider.overrideWithValue(
+            FakeMessageRepository(const []),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: ThreadView(targetType: 'message', targetId: 'x'),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.textContaining('No replies yet'), findsOneWidget);
+  });
+}

--- a/app/test/timeline_screen_test.dart
+++ b/app/test/timeline_screen_test.dart
@@ -14,11 +14,11 @@ class FakeTimelineRepository implements TimelineRepository {
   @override
   Future<TimelinePage> friends({int limit = 50, String? before}) async => _page;
   @override
-  Future<TimelinePage> squad(
+  Future<SquadFeedPage> squadFeed(
     String squadId, {
     int limit = 50,
     String? before,
-  }) async => _page;
+  }) async => const SquadFeedPage(items: []);
 }
 
 Widget _harness(TimelinePage page) => ProviderScope(

--- a/plans/v2-messages-and-threads.md
+++ b/plans/v2-messages-and-threads.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-squads-context-selector]
 specs:
   - specs/api/messages.md
@@ -7,7 +7,7 @@ specs:
   - specs/screens/squads.md
   - specs/data-model.md
 issues: []
-pr:
+pr: 420
 ---
 
 # Plan: v2 messages + threads (text)
@@ -58,12 +58,14 @@ feed of `specs/screens/squads.md`.
 
 ## Validation
 
-- [ ] migration applies; `bun run type-check` + `bun test` (post squad message member-gated;
-      heterogeneous squad timeline tags + ordering; activity thread reply visible to audience,
-      non-member/non-audience 403/404; thread_count) green; CI green.
-- [ ] client `flutter analyze` + widget tests green; CI green.
-- [ ] (when machine free) MCP: post a squad message → appears in the squad feed; reply on an
-      activity → shows in its Discussion + thread_count increments; messages never on My Friends.
+- [x] migration applies; `bun run type-check` + `bun test` (post squad message member-gated;
+      heterogeneous squad timeline tags + ordering; activity thread reply audience-gated +
+      thread_count; squad-message thread membership-gated; no free text on friends) — 3 tests,
+      full suite 24/24; backend CI green (#419, merged).
+- [x] client `flutter analyze` clean + 8 widget tests (ThreadView render/empty + updated
+      timeline/detail/create-squad fakes); client CI on #420.
+- [~] MCP visual walkthrough deferred (window-foreground conflict while the machine is in
+      use); backend gating is unit-tested, the driver loop proven in prior stages.
 
 ## Risks / unknowns
 
@@ -75,8 +77,19 @@ feed of `specs/screens/squads.md`.
 
 ## Notes
 
-(closeout)
+Two PRs: **#419** (backend — message schema/migration 0003, MessageService with per-target
+visibility reused from ActivityService.canView / squad membership, heterogeneous squad
+timeline, real thread_count, 3 tests) merged; **#420** (client — Message/FeedItem models,
+MessageRepository, squadFeed, message tiles + squad composer, reusable ThreadView embedded in
+activity detail + a ThreadScreen). Heterogeneous feed merges two tables in memory (fetch
+limit+1 each, sort, derive cursor). Squad-timeline items gained an additive `type` field; the
+client branches on it.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred to plan:** photo attachments + `POST /v1/uploads` (storage stage — `attachments`
+  is `[]` for now); SSE `message.created` realtime (realtime stage — feed/threads render from
+  fetch + pull-to-refresh); `community_event` thread targets (communities stage); the slide-in
+  drawer chrome + persistent vote-bar restructure (visual polish).
+- **Deferred (visual QA):** MCP walkthrough of post-message + activity-thread reply when the
+  machine is free.


### PR DESCRIPTION
Client half of the **messages** stage (backend #419). Text only; styling deferred.

Implements the client side of `specs/api/messages.md` + `specs/behaviors/thread-drawer.md` (conversation) and the heterogeneous feed of `specs/screens/squads.md`.

## What's here
- **Models**: `Message`, `FeedItem` (sealed `ActivityFeedItem` | `MessageFeedItem`, tagged by the server's `type`).
- **Data**: `MessageRepository` (post squad message, thread read/reply); `TimelineRepository.squadFeed` (type-tagged feed) replacing the activities-only squad read; `messageRepositoryProvider`, `threadProvider(family)`, `squadTimelineProvider → SquadFeedPage`.
- **Timeline**: unified `FeedItem` rendering — activity tiles + **message tiles** (with reply count) — and a **bottom message composer** shown in squad context.
- **Threads**: a reusable `ThreadView` (replies + reply input), embedded as a **Discussion** section on the activity detail, and hosted by a standalone **ThreadScreen** (`/thread/:targetType/:targetId`) reached by tapping a squad message.

## Verification
`flutter analyze` clean; **8 widget tests** (added `ThreadView` render-chronological + empty-state; existing fakes updated for the `squad`→`squadFeed` interface change). Backend visibility/gating is unit-tested in #419.

MCP visual walkthrough deferred (window-foreground conflict while the machine's in use) — same driver loop proven previously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)