### PR TITLE
v2 client: communities — discover/follow, timeline, RSVP gradient

### DIFF
--- a/app/lib/models/community.dart
+++ b/app/lib/models/community.dart
@@ -1,0 +1,89 @@
+/// An open, followable community (specs/api/communities.md).
+class Community {
+  const Community({
+    required this.id,
+    required this.name,
+    this.tagline,
+    this.icon,
+    this.color,
+    this.followerCount = 0,
+    this.youFollow = false,
+  });
+
+  final String id;
+  final String name;
+  final String? tagline;
+  final String? icon;
+  final String? color;
+  final int followerCount;
+  final bool youFollow;
+
+  factory Community.fromJson(Map<String, dynamic> json) => Community(
+    id: json['id'] as String,
+    name: json['name'] as String? ?? '',
+    tagline: json['tagline'] as String?,
+    icon: json['icon'] as String?,
+    color: json['color'] as String?,
+    followerCount: (json['follower_count'] as num?)?.toInt() ?? 0,
+    youFollow: json['you_follow'] as bool? ?? false,
+  );
+}
+
+/// A leader-broadcast, born-confirmed recurring event + the viewer's RSVP.
+class CommunityEvent {
+  const CommunityEvent({
+    required this.id,
+    required this.title,
+    this.communityName,
+    this.communityIcon,
+    this.activityTypeLabel,
+    this.time,
+    this.recurrence,
+    this.location,
+    this.goingCount = 0,
+    this.publicGoing = const [],
+    this.youGoing = false,
+    this.youPublic = false,
+    this.threadCount = 0,
+  });
+
+  final String id;
+  final String title;
+  final String? communityName;
+  final String? communityIcon;
+  final String? activityTypeLabel;
+  final String? time;
+  final String? recurrence;
+  final String? location;
+  final int goingCount;
+  final List<String> publicGoing; // first names for the face-pile
+  final bool youGoing;
+  final bool youPublic;
+  final int threadCount;
+
+  factory CommunityEvent.fromJson(Map<String, dynamic> json) {
+    final community = json['community'] as Map<String, dynamic>?;
+    final type = json['activity_type'] as Map<String, dynamic>?;
+    final rsvp = json['your_rsvp'] as Map<String, dynamic>? ?? const {};
+    return CommunityEvent(
+      id: json['id'] as String,
+      title: json['title'] as String? ?? '',
+      communityName: community?['name'] as String?,
+      communityIcon: community?['icon'] as String?,
+      activityTypeLabel: type?['label'] as String?,
+      time: json['time'] as String?,
+      recurrence: json['recurrence'] as String?,
+      location: json['location'] as String?,
+      goingCount: (json['going_count'] as num?)?.toInt() ?? 0,
+      publicGoing: ((json['public_going'] as List<dynamic>?) ?? const [])
+          .map(
+            (e) => (e as Map<String, dynamic>)['first_name'] as String? ?? '',
+          )
+          .where((s) => s.isNotEmpty)
+          .toList(),
+      youGoing: rsvp['going'] as bool? ?? false,
+      youPublic: rsvp['public'] as bool? ?? false,
+      threadCount: (json['thread_count'] as num?)?.toInt() ?? 0,
+    );
+  }
+}

--- a/app/lib/providers/active_context.dart
+++ b/app/lib/providers/active_context.dart
@@ -17,6 +17,12 @@ class SquadContext extends ActiveContext {
   final String name;
 }
 
+class CommunityContext extends ActiveContext {
+  const CommunityContext(this.id, this.name);
+  final String id;
+  final String name;
+}
+
 final activeContextProvider =
     NotifierProvider<ActiveContextController, ActiveContext>(
       ActiveContextController.new,
@@ -28,4 +34,6 @@ class ActiveContextController extends Notifier<ActiveContext> {
 
   void toFriends() => state = const FriendsContext();
   void toSquad(String id, String name) => state = SquadContext(id, name);
+  void toCommunity(String id, String name) =>
+      state = CommunityContext(id, name);
 }

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -2,12 +2,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../api/api_client.dart';
 import '../config.dart';
+import '../models/community.dart';
 import '../models/friend.dart';
 import '../models/message.dart';
 import '../models/squad.dart';
 import '../models/topic.dart';
 import '../repositories/activity_repository.dart';
 import '../repositories/auth_repository.dart';
+import '../repositories/community_repository.dart';
 import '../repositories/friend_repository.dart';
 import '../repositories/message_repository.dart';
 import '../repositories/profile_repository.dart';
@@ -67,6 +69,10 @@ final messageRepositoryProvider = Provider<MessageRepository>(
   (ref) => ApiMessageRepository(apiClient: ref.watch(apiClientProvider)),
 );
 
+final communityRepositoryProvider = Provider<CommunityRepository>(
+  (ref) => ApiCommunityRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
 /// The My Friends timeline (specs/screens/friends-timeline.md).
 final friendsTimelineProvider = FutureProvider<TimelinePage>(
   (ref) => ref.watch(timelineRepositoryProvider).friends(),
@@ -99,3 +105,19 @@ final topicsProvider = FutureProvider<List<Topic>>(
 final friendsProvider = FutureProvider<List<Friend>>(
   (ref) => ref.watch(friendRepositoryProvider).list(),
 );
+
+/// Communities to discover (all, with you_follow), optional search query.
+final communitiesProvider = FutureProvider.family<List<Community>, String>((
+  ref,
+  search,
+) {
+  return ref
+      .watch(communityRepositoryProvider)
+      .discover(search: search.isEmpty ? null : search);
+});
+
+/// A community's events, keyed by community id.
+final communityEventsProvider =
+    FutureProvider.family<List<CommunityEvent>, String>((ref, communityId) {
+      return ref.watch(communityRepositoryProvider).events(communityId);
+    });

--- a/app/lib/repositories/community_repository.dart
+++ b/app/lib/repositories/community_repository.dart
@@ -1,0 +1,66 @@
+import '../api/api_client.dart';
+import '../models/community.dart';
+
+abstract class CommunityRepository {
+  Future<List<Community>> discover({String? search});
+  Future<Community> follow(String communityId, {required bool follow});
+  Future<List<CommunityEvent>> events(String communityId);
+  Future<CommunityEvent> rsvp(
+    String eventId, {
+    required bool going,
+    required bool public,
+  });
+}
+
+class ApiCommunityRepository implements CommunityRepository {
+  ApiCommunityRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  @override
+  Future<List<Community>> discover({String? search}) async {
+    final res = await apiClient.get(
+      '/v1/communities',
+      query: {'search': ?search},
+    );
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => Community.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<Community> follow(String communityId, {required bool follow}) async {
+    // Returns {you_follow, follower_count}; merge onto a thin Community for the toggle.
+    final res = await apiClient.put(
+      '/v1/communities/$communityId/follow',
+      body: {'follow': follow},
+    );
+    return Community(
+      id: communityId,
+      name: '',
+      followerCount: (res['follower_count'] as num?)?.toInt() ?? 0,
+      youFollow: res['you_follow'] as bool? ?? follow,
+    );
+  }
+
+  @override
+  Future<List<CommunityEvent>> events(String communityId) async {
+    final res = await apiClient.get('/v1/communities/$communityId/events');
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => CommunityEvent.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<CommunityEvent> rsvp(
+    String eventId, {
+    required bool going,
+    required bool public,
+  }) async {
+    final res = await apiClient.put(
+      '/v1/community-events/$eventId/rsvp',
+      body: {'going': going, 'public': public},
+    );
+    return CommunityEvent.fromJson(res);
+  }
+}

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -7,6 +7,7 @@ import 'models/message.dart';
 import 'providers/auth_controller.dart';
 import 'screens/activity/activity_detail_screen.dart';
 import 'screens/compose/compose_idea_screen.dart';
+import 'screens/communities/discover_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
 import 'screens/thread/thread_screen.dart';
@@ -38,6 +39,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/squads/new',
         builder: (_, _) => const CreateSquadScreen(),
+      ),
+      GoRoute(
+        path: '/communities',
+        builder: (_, _) => const DiscoverCommunitiesScreen(),
       ),
       GoRoute(
         path: '/activity/:id',

--- a/app/lib/screens/communities/discover_screen.dart
+++ b/app/lib/screens/communities/discover_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../providers/active_context.dart';
+import '../../providers/providers.dart';
+
+/// Discover communities — search + follow (specs/screens/communities.md,
+/// context-selector). Communities are found, not added; following is frictionless.
+class DiscoverCommunitiesScreen extends ConsumerStatefulWidget {
+  const DiscoverCommunitiesScreen({super.key});
+
+  @override
+  ConsumerState<DiscoverCommunitiesScreen> createState() => _DiscoverState();
+}
+
+class _DiscoverState extends ConsumerState<DiscoverCommunitiesScreen> {
+  String _search = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final communities = ref.watch(communitiesProvider(_search));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Discover communities')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: TextField(
+              key: const Key('communitySearchField'),
+              decoration: const InputDecoration(
+                hintText: 'Search communities…',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              onChanged: (v) => setState(() => _search = v.trim()),
+            ),
+          ),
+          Expanded(
+            child: communities.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Couldn\'t load.\n$e')),
+              data: (list) => list.isEmpty
+                  ? const Center(child: Text('No communities found.'))
+                  : ListView(
+                      key: const Key('discoverList'),
+                      children: [
+                        for (final c in list)
+                          ListTile(
+                            key: Key('discover_${c.id}'),
+                            leading: Text(
+                              c.icon ?? '📣',
+                              style: const TextStyle(fontSize: 22),
+                            ),
+                            title: Text(c.name),
+                            subtitle: Text(
+                              [
+                                c.tagline,
+                                '${c.followerCount} followers',
+                              ].whereType<String>().join(' · '),
+                            ),
+                            onTap: () {
+                              ref
+                                  .read(activeContextProvider.notifier)
+                                  .toCommunity(c.id, c.name);
+                              context.go('/');
+                            },
+                            trailing: _FollowButton(
+                              communityId: c.id,
+                              following: c.youFollow,
+                            ),
+                          ),
+                      ],
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FollowButton extends ConsumerStatefulWidget {
+  const _FollowButton({required this.communityId, required this.following});
+  final String communityId;
+  final bool following;
+
+  @override
+  ConsumerState<_FollowButton> createState() => _FollowButtonState();
+}
+
+class _FollowButtonState extends ConsumerState<_FollowButton> {
+  bool _busy = false;
+
+  Future<void> _toggle() async {
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(communityRepositoryProvider)
+          .follow(widget.communityId, follow: !widget.following);
+      ref.invalidate(communitiesProvider);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.following
+        ? OutlinedButton(
+            key: Key('unfollow_${widget.communityId}'),
+            onPressed: _busy ? null : _toggle,
+            child: const Text('Following'),
+          )
+        : FilledButton(
+            key: Key('follow_${widget.communityId}'),
+            onPressed: _busy ? null : _toggle,
+            child: const Text('Follow'),
+          );
+  }
+}

--- a/app/lib/screens/compose/compose_idea_screen.dart
+++ b/app/lib/screens/compose/compose_idea_screen.dart
@@ -55,14 +55,14 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
             locationOptions: _split(_location.text),
             squadId: switch (ctx) {
               SquadContext(:final id) => id,
-              FriendsContext() => null,
+              _ => null,
             },
           );
       switch (ctx) {
-        case FriendsContext():
-          ref.invalidate(friendsTimelineProvider);
         case SquadContext(:final id):
           ref.invalidate(squadTimelineProvider(id));
+        case _:
+          ref.invalidate(friendsTimelineProvider);
       }
       if (mounted) context.pop();
     } on ApiException catch (e) {
@@ -80,8 +80,8 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
     final ctx = ref.watch(activeContextProvider);
     // Audience clarity at the moment of action (context-selector principle).
     final destination = switch (ctx) {
-      FriendsContext() => 'Visible to all your friends',
       SquadContext(:final name) => 'Visible to $name members',
+      _ => 'Visible to all your friends',
     };
 
     return Scaffold(

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -8,37 +8,23 @@ import '../../models/message.dart';
 import '../../providers/active_context.dart';
 import '../../providers/auth_controller.dart';
 import '../../providers/providers.dart';
+import '../../widgets/community_event_card.dart';
 
-/// The active timeline — My Friends (ideas/activities only) or a Squad (the
-/// heterogeneous activities + messages feed), per the context selector
-/// (specs/behaviors/context-selector.md). One source of truth: `activeContextProvider`.
+/// The active timeline, per the context selector (specs/behaviors/context-selector.md):
+/// My Friends (ideas/activities), a Squad (heterogeneous activities + messages), or a
+/// Community (leader-broadcast event cards, RSVP, no posting). One source of truth:
+/// `activeContextProvider`.
 class TimelineScreen extends ConsumerWidget {
   const TimelineScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ctx = ref.watch(activeContextProvider);
-
-    // Unify both contexts to a list of FeedItem so rendering is single-path.
-    final AsyncValue<List<FeedItem>> feed = switch (ctx) {
-      FriendsContext() =>
-        ref
-            .watch(friendsTimelineProvider)
-            .whenData(
-              (p) => p.items.map<FeedItem>(ActivityFeedItem.new).toList(),
-            ),
-      SquadContext(:final id) =>
-        ref.watch(squadTimelineProvider(id)).whenData((p) => p.items),
-    };
+    final isCommunity = ctx is CommunityContext;
     final title = switch (ctx) {
       FriendsContext() => 'My Friends',
       SquadContext(:final name) => name,
-    };
-    final emptyText = switch (ctx) {
-      FriendsContext() =>
-        'No ideas yet.\nWhen a friend shares an idea, it shows up here.',
-      SquadContext() =>
-        'Nothing here yet.\nShare an idea (+) or post a message below.',
+      CommunityContext(:final name) => name,
     };
 
     return Scaffold(
@@ -63,69 +49,19 @@ class TimelineScreen extends ConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        key: const Key('composeIdeaFab'),
-        tooltip: 'New idea',
-        onPressed: () => context.push('/ideas/new'),
-        child: const Icon(Icons.add),
-      ),
-      body: Column(
-        children: [
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () => switch (ctx) {
-                FriendsContext() => ref.refresh(friendsTimelineProvider.future),
-                SquadContext(:final id) => ref.refresh(
-                  squadTimelineProvider(id).future,
-                ),
-              },
-              child: feed.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (e, _) => ListView(
-                  children: [
-                    const SizedBox(height: 120),
-                    Center(
-                      child: Text(
-                        'Couldn\'t load this timeline.\n$e',
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ],
-                ),
-                data: (items) {
-                  if (items.isEmpty) {
-                    return ListView(
-                      children: [
-                        const SizedBox(height: 160),
-                        Center(
-                          key: const Key('timelineEmpty'),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 32),
-                            child: Text(emptyText, textAlign: TextAlign.center),
-                          ),
-                        ),
-                      ],
-                    );
-                  }
-                  return ListView.separated(
-                    key: const Key('timelineList'),
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    itemCount: items.length,
-                    separatorBuilder: (_, _) => const Divider(height: 1),
-                    itemBuilder: (_, i) => switch (items[i]) {
-                      ActivityFeedItem(:final activity) => _ActivityTile(
-                        activity,
-                      ),
-                      MessageFeedItem(:final message) => _MessageTile(message),
-                    },
-                  );
-                },
-              ),
+      // Communities are leaders-broadcast: followers don't compose here.
+      floatingActionButton: isCommunity
+          ? null
+          : FloatingActionButton(
+              key: const Key('composeIdeaFab'),
+              tooltip: 'New idea',
+              onPressed: () => context.push('/ideas/new'),
+              child: const Icon(Icons.add),
             ),
-          ),
-          if (ctx is SquadContext) _SquadComposer(squadId: ctx.id),
-        ],
-      ),
+      body: switch (ctx) {
+        CommunityContext(:final id) => _CommunityBody(communityId: id),
+        _ => _FeedBody(ctx: ctx),
+      },
     );
   }
 
@@ -135,18 +71,13 @@ class TimelineScreen extends ConsumerWidget {
       builder: (sheetContext) => Consumer(
         builder: (_, ref, _) {
           final squads = ref.watch(squadsProvider);
+          final communities = ref.watch(communitiesProvider(''));
           return SafeArea(
             child: ListView(
               key: const Key('contextSelectorSheet'),
               shrinkWrap: true,
               children: [
-                const ListTile(
-                  dense: true,
-                  title: Text(
-                    'SWITCH CONTEXT',
-                    style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
-                  ),
-                ),
+                const _SheetHeader('MY FRIENDS'),
                 ListTile(
                   key: const Key('ctx_friends'),
                   leading: const Icon(Icons.group),
@@ -156,7 +87,7 @@ class TimelineScreen extends ConsumerWidget {
                     Navigator.pop(sheetContext);
                   },
                 ),
-                const Divider(height: 1),
+                const _SheetHeader('SQUADS'),
                 ...squads.maybeWhen(
                   data: (list) => list.map(
                     (s) => ListTile(
@@ -173,10 +104,9 @@ class TimelineScreen extends ConsumerWidget {
                     ),
                   ),
                   orElse: () => [
-                    const ListTile(title: Text('Loading squads…')),
+                    const ListTile(dense: true, title: Text('Loading…')),
                   ],
                 ),
-                const Divider(height: 1),
                 ListTile(
                   key: const Key('ctx_new_squad'),
                   leading: const Icon(Icons.add),
@@ -186,11 +116,207 @@ class TimelineScreen extends ConsumerWidget {
                     context.push('/squads/new');
                   },
                 ),
+                const _SheetHeader('COMMUNITIES'),
+                ...communities.maybeWhen(
+                  data: (list) => list
+                      .where((c) => c.youFollow)
+                      .map(
+                        (c) => ListTile(
+                          key: Key('ctx_community_${c.id}'),
+                          leading: Text(
+                            c.icon ?? '📣',
+                            style: const TextStyle(fontSize: 20),
+                          ),
+                          title: Text(c.name),
+                          subtitle: Text('${c.followerCount} followers'),
+                          onTap: () {
+                            ref
+                                .read(activeContextProvider.notifier)
+                                .toCommunity(c.id, c.name);
+                            Navigator.pop(sheetContext);
+                          },
+                        ),
+                      ),
+                  orElse: () => [
+                    const ListTile(dense: true, title: Text('Loading…')),
+                  ],
+                ),
+                ListTile(
+                  key: const Key('ctx_discover'),
+                  leading: const Icon(Icons.travel_explore),
+                  title: const Text('Discover communities'),
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    context.push('/communities');
+                  },
+                ),
               ],
             ),
           );
         },
       ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader(this.label);
+  final String label;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+    child: Text(
+      label,
+      style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+    ),
+  );
+}
+
+/// My Friends / Squad: the unified activities(+messages) feed + (squad) composer.
+class _FeedBody extends ConsumerWidget {
+  const _FeedBody({required this.ctx});
+  final ActiveContext ctx;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<List<FeedItem>> feed = switch (ctx) {
+      SquadContext(:final id) =>
+        ref.watch(squadTimelineProvider(id)).whenData((p) => p.items),
+      _ =>
+        ref
+            .watch(friendsTimelineProvider)
+            .whenData(
+              (p) => p.items.map<FeedItem>(ActivityFeedItem.new).toList(),
+            ),
+    };
+    final emptyText = switch (ctx) {
+      SquadContext() =>
+        'Nothing here yet.\nShare an idea (+) or post a message below.',
+      _ => 'No ideas yet.\nWhen a friend shares an idea, it shows up here.',
+    };
+
+    return Column(
+      children: [
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: () => switch (ctx) {
+              SquadContext(:final id) => ref.refresh(
+                squadTimelineProvider(id).future,
+              ),
+              _ => ref.refresh(friendsTimelineProvider.future),
+            },
+            child: feed.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => ListView(
+                children: [
+                  const SizedBox(height: 120),
+                  Center(
+                    child: Text(
+                      'Couldn\'t load this timeline.\n$e',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
+              ),
+              data: (items) {
+                if (items.isEmpty) {
+                  return ListView(
+                    children: [
+                      const SizedBox(height: 160),
+                      Center(
+                        key: const Key('timelineEmpty'),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 32),
+                          child: Text(emptyText, textAlign: TextAlign.center),
+                        ),
+                      ),
+                    ],
+                  );
+                }
+                return ListView.separated(
+                  key: const Key('timelineList'),
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: items.length,
+                  separatorBuilder: (_, _) => const Divider(height: 1),
+                  itemBuilder: (_, i) => switch (items[i]) {
+                    ActivityFeedItem(:final activity) => _ActivityTile(
+                      activity,
+                    ),
+                    MessageFeedItem(:final message) => _MessageTile(message),
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+        if (ctx is SquadContext)
+          _SquadComposer(squadId: (ctx as SquadContext).id),
+      ],
+    );
+  }
+}
+
+/// Community: leader-broadcast event cards + a read-only follower banner.
+class _CommunityBody extends ConsumerWidget {
+  const _CommunityBody({required this.communityId});
+  final String communityId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final events = ref.watch(communityEventsProvider(communityId));
+    return Column(
+      children: [
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: () =>
+                ref.refresh(communityEventsProvider(communityId).future),
+            child: events.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => ListView(
+                children: [
+                  const SizedBox(height: 120),
+                  Center(
+                    child: Text(
+                      'Couldn\'t load events.\n$e',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
+              ),
+              data: (list) => list.isEmpty
+                  ? ListView(
+                      children: const [
+                        SizedBox(height: 160),
+                        Center(
+                          key: Key('communityEmpty'),
+                          child: Text('No upcoming events.'),
+                        ),
+                      ],
+                    )
+                  : ListView(
+                      key: const Key('communityEvents'),
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      children: [
+                        for (final e in list)
+                          CommunityEventCard(
+                            communityId: communityId,
+                            event: e,
+                          ),
+                      ],
+                    ),
+            ),
+          ),
+        ),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          child: const Text(
+            'Following · only leaders post events here',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -205,7 +331,6 @@ class _ActivityTile extends StatelessWidget {
     final subtitle = a.isConfirmed
         ? [a.confirmedTime, a.confirmedLocation].whereType<String>().join(' · ')
         : 'Idea · ${a.audienceSummary ?? ''}';
-
     return ListTile(
       onTap: () => context.push('/activity/${a.id}', extra: a),
       leading: CircleAvatar(
@@ -245,11 +370,9 @@ class _MessageTile extends StatelessWidget {
   }
 }
 
-/// Bottom input to post a free-text message to the active squad.
 class _SquadComposer extends ConsumerStatefulWidget {
   const _SquadComposer({required this.squadId});
   final String squadId;
-
   @override
   ConsumerState<_SquadComposer> createState() => _SquadComposerState();
 }

--- a/app/lib/widgets/community_event_card.dart
+++ b/app/lib/widgets/community_event_card.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/community.dart';
+import '../providers/providers.dart';
+
+/// A born-confirmed community event card with the dual-attendance display and the
+/// RSVP visibility gradient (specs/screens/communities.md): an anonymous headcount,
+/// an opt-in public face-pile, and Going / Show-name toggles. "Show name" implies
+/// going; going never escalates to public on its own.
+class CommunityEventCard extends ConsumerStatefulWidget {
+  const CommunityEventCard({
+    super.key,
+    required this.communityId,
+    required this.event,
+  });
+
+  final String communityId;
+  final CommunityEvent event;
+
+  @override
+  ConsumerState<CommunityEventCard> createState() => _CommunityEventCardState();
+}
+
+class _CommunityEventCardState extends ConsumerState<CommunityEventCard> {
+  bool _busy = false;
+
+  Future<void> _rsvp({required bool going, required bool public}) async {
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(communityRepositoryProvider)
+          .rsvp(widget.event.id, going: going, public: public);
+      ref.invalidate(communityEventsProvider(widget.communityId));
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t update your RSVP.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final e = widget.event;
+    final facePile = e.publicGoing.isEmpty
+        ? null
+        : '${e.publicGoing.take(2).join(', ')}'
+              '${e.publicGoing.length > 2 ? ' +${e.publicGoing.length - 2}' : ''} publicly';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${e.communityIcon ?? '📣'}  ${e.communityName ?? 'Community'}'
+              '${e.recurrence != null ? ' · ${e.recurrence}' : ''}',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            const SizedBox(height: 6),
+            Text(e.title, style: Theme.of(context).textTheme.titleMedium),
+            if (e.time != null || e.location != null) ...[
+              const SizedBox(height: 4),
+              Text([e.time, e.location].whereType<String>().join(' · ')),
+            ],
+            const SizedBox(height: 10),
+            Text(
+              '${e.goingCount} going'
+              '${facePile != null ? '  ·  $facePile' : ''}',
+              key: Key('going_${e.id}'),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                FilterChip(
+                  key: Key('going_toggle_${e.id}'),
+                  label: const Text('Going'),
+                  selected: e.youGoing,
+                  onSelected: _busy
+                      ? null
+                      : (sel) => _rsvp(
+                          going: sel,
+                          public: sel ? e.youPublic : false,
+                        ),
+                ),
+                FilterChip(
+                  key: Key('public_toggle_${e.id}'),
+                  label: const Text('Show my name'),
+                  selected: e.youPublic,
+                  onSelected: _busy
+                      ? null
+                      : (sel) => _rsvp(going: true, public: sel),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/community_event_card_test.dart
+++ b/app/test/community_event_card_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/community.dart';
+import 'package:squadquest/widgets/community_event_card.dart';
+
+void main() {
+  testWidgets('event card shows headcount + face-pile + RSVP toggles', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: CommunityEventCard(
+              communityId: 'c1',
+              event: CommunityEvent(
+                id: 'e1',
+                title: 'Cherry Blossoms Ride',
+                communityName: 'Wednesday Night Rides',
+                recurrence: 'Every other Wed',
+                time: 'Wed 6:30pm',
+                location: 'Clark Park',
+                goingCount: 64,
+                publicGoing: ['Maya', 'Jordan', 'Sam'],
+                youGoing: true,
+                youPublic: false,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Cherry Blossoms Ride'), findsOneWidget);
+    // anonymous headcount + opt-in face-pile (truncated)
+    expect(find.textContaining('64 going'), findsOneWidget);
+    expect(find.textContaining('Maya, Jordan +1 publicly'), findsOneWidget);
+    // RSVP gradient toggles, reflecting state
+    expect(find.byKey(const Key('going_toggle_e1')), findsOneWidget);
+    expect(find.byKey(const Key('public_toggle_e1')), findsOneWidget);
+  });
+}

--- a/plans/v2-communities-core.md
+++ b/plans/v2-communities-core.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-messages-and-threads]
 specs:
   - specs/api/communities.md
@@ -7,7 +7,7 @@ specs:
   - specs/behaviors/context-selector.md
   - specs/data-model.md
 issues: []
-pr:
+pr: 422
 ---
 
 # Plan: v2 communities — core (discover / follow / events / RSVP)
@@ -57,12 +57,13 @@ community entries of `specs/behaviors/context-selector.md`, and the community sl
 
 ## Validation
 
-- [ ] migration applies; `bun run type-check` + `bun test` (discover + you_follow; follow
-      toggles follower_count; events list w/ counts; RSVP gradient — going-only anonymous,
-      public implies going, going:false clears, public never a side effect) green; CI green.
-- [ ] client `flutter analyze` + widget tests green; CI green.
-- [ ] (when machine free) MCP: follow a community → it appears in the selector; open it →
-      event cards; RSVP Going (count +1, not in face-pile) → Show name (joins face-pile).
+- [x] migration applies; `bun run type-check` + `bun test` (discover + you_follow; follow
+      toggles follower_count; full RSVP gradient — going-only anonymous, public implies going,
+      going:false clears, public never a side effect) — 2 tests, full suite 26/26; backend CI
+      green (#421, merged).
+- [x] client `flutter analyze` clean + 9 widget tests (community card render); client CI on #422.
+- [~] MCP visual walkthrough deferred (window-foreground conflict); dev DB seeded with the 3
+      Philly communities + events for live exploration.
 
 ## Risks / unknowns
 
@@ -73,8 +74,20 @@ community entries of `specs/behaviors/context-selector.md`, and the community sl
 
 ## Notes
 
-(closeout)
+Two PRs: **#421** (backend — schema/migration 0004, CommunityService with the RSVP visibility
+gradient, discover/follow/events/rsvp routes, dev seed-communities script, 2 tests) merged;
+**#422** (client — Community/CommunityEvent models, CommunityRepository, CommunityContext + the
+four-section context selector, community event cards with headcount/face-pile/RSVP toggles,
+Discover screen). Leader tooling stood in via the seed script.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred to plan (next):** **bring-friends bridge** — `createIdea` with
+  `community_event_id` (event_ref serialization), the composer pre-fill from an event +
+  destination picker, and attendance coupling (a brought-along "I'm in" → the event's
+  *anonymous* headcount, never the public face-pile). Keep the going_count query factored to
+  extend it.
+- **Deferred to plan:** leader tooling (create/edit communities + post/schedule events);
+  community-event **threads** (count surfaced; reads/replies need community_event added to the
+  message thread-target visibility); photos; SSE.
+- **Deferred (visual QA):** MCP walkthrough of follow → RSVP gradient when the machine is free.


### PR DESCRIPTION
Client half of the **communities core** stage (backend #421). The flagship public surface, follower-facing. Styling deferred.

Implements `specs/screens/communities.md` + the community entries of `specs/behaviors/context-selector.md`.

## What's here
- **Models/data**: `Community`, `CommunityEvent`; `CommunityRepository` (discover, follow, events, rsvp); `communitiesProvider(family)`, `communityEventsProvider(family)`.
- **Context selector** now has four sections from one source of truth: **My Friends ▸ Squads ▸ Communities (followed) ▸ Discover**. `activeContext` gains `CommunityContext`.
- **Community timeline**: leader-broadcast **event cards** — community author + recurrence, **anonymous headcount**, opt-in **public face-pile** ("Maya, Jordan +6 publicly"), and the **RSVP gradient** (Going toggle → count; Show-my-name toggle → face-pile, implies going; Going never escalates to public on its own). A read-only **follower banner** ("only leaders post events here") replaces the composer.
- **Discover screen**: search + follow/unfollow; tapping a community switches context to it.

## Verification
`flutter analyze` clean; **9 widget tests** (added community-card render: headcount + truncated face-pile + toggles). Backend RSVP-gradient invariants unit-tested in #421.

## Scope
**Bring-friends bridge** (compose an idea referencing an event + attendance coupling), **leader tooling**, and **community-event threads** are the follow-ons. The dev `seed-communities` script stands in for leaders until their tooling lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)