### PR TITLE
v2 server: bring-friends bridge (embed a community event in a friends idea)

### DIFF
--- a/plans/v2-bring-friends-bridge.md
+++ b/plans/v2-bring-friends-bridge.md
@@ -1,0 +1,79 @@
+---
+status: in-progress
+depends: [v2-communities-core]
+specs:
+  - specs/behaviors/bring-friends-bridge.md
+  - specs/api/ideas-activities.md
+  - specs/api/communities.md
+  - specs/screens/communities.md
+issues: []
+pr:
+---
+
+# Plan: v2 bring-friends bridge
+
+## Scope
+
+Bringing friends to a community event by posting a **friends-scoped idea that embeds the
+event** — never sharing the public event onto the friends timeline. The public event stays
+community-owned; what lands on My Friends is a private envelope whose thread is the logistics
+room. Backend + client; styling deferred.
+
+**In:** `createIdea` accepts `community_event_id` → a friends/squad-scoped activity with
+`event_ref` (the event's title/time/place/community, read-only); activity serializer exposes
+`event_ref`; **attendance coupling** — a brought-along "I'm in" counts in the event's
+**anonymous** `going_count`, never the public face-pile; client "Bring friends" action on a
+community event → composer pre-filled (event chip + destination picker) → posts the idea;
+the friends/squad timeline + activity detail render the embedded-event chip.
+
+**Out:** leader tooling; community-event threads; photos; SSE; auto "born confirmed" state
+nuance (brought-along idea follows the normal lifecycle with the event providing time/place).
+
+## Implements
+
+`specs/behaviors/bring-friends-bridge.md` + the `community_event_id` path of
+`specs/api/ideas-activities.md`; the "Bring friends" action of `specs/screens/communities.md`.
+
+## Approach
+
+- **Backend** (`server/`):
+  - `createIdea`: allow `communityEventId` (currently rejected) — validate the event exists;
+    store `activity.community_event_id`; idea is friends- or squad-scoped as chosen.
+  - activity serializer: add `event_ref` (event id, title, time, recurrence, location,
+    community {name,icon}) when `community_event_id` set.
+  - **attendance coupling** in `CommunityService.events`/going_count: distinct attendees =
+    direct RSVPs (going=true) ∪ profiles who responded `in` to any activity linked to the
+    event. Never adds anyone to `public_going` without an explicit public RSVP. (Factor the
+    count so this extends cleanly.)
+  - a `GET /v1/community-events/:id` (single event) for the composer pre-fill, or reuse the
+    event already in client state.
+  - tests: brought-along idea has event_ref + is friends-scoped (never on a community feed);
+    an "I'm in" responder is counted in going_count anonymously, absent from public_going.
+- **Client** (`app/`):
+  - "Bring friends" on a `CommunityEventCard` → switch to My Friends, open the composer
+    pre-filled (event reference chip + activity type) with a destination picker (My Friends
+    or a squad); `createIdea` with `community_event_id`.
+  - Activity model + tiles/detail render the `event_ref` chip (read-only event context).
+
+## Validation
+
+- [ ] `bun run type-check` + `bun test` (brought-along idea: event_ref + friends-scoped +
+      absent from community feed; "I'm in" → anonymous headcount +1, not public) green; CI.
+- [ ] client `flutter analyze` + widget tests green; CI.
+- [ ] (when machine free) MCP: Bring friends on an event → idea on My Friends w/ event chip;
+      friend responds "I'm in" → event going_count +1, face-pile unchanged.
+
+## Risks / unknowns
+
+- The firewall invariant: the My-Friends composer only emits friends-scoped ideas; public
+  exposure needs explicit community/public-RSVP action. Enforce server-side.
+- going_count dedup across direct RSVPs + brought-along "in" responders (distinct profiles).
+- event_ref must be read-only context; the brought-along activity is a separate record.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/server/src/contracts/activity.ts
+++ b/server/src/contracts/activity.ts
@@ -11,6 +11,8 @@ import {
   topic,
   squad,
   message,
+  communityEvent,
+  community,
 } from '../db/schema/index.ts'
 
 type ActivityRow = typeof activity.$inferSelect
@@ -57,6 +59,35 @@ export async function serializeActivities(
     .groupBy(message.threadTargetId)
   const threadCountById = new Map<string, number>()
   for (const t of threadRows) if (t.id) threadCountById.set(t.id, t.n)
+
+  // event_ref: the community event a brought-along idea embeds (read-only context).
+  const eventIds = [
+    ...new Set(rows.map((r) => r.communityEventId).filter((x): x is string => !!x)),
+  ]
+  const events = eventIds.length
+    ? await db.select().from(communityEvent).where(inArray(communityEvent.id, eventIds))
+    : []
+  const eventCommunityIds = [...new Set(events.map((e) => e.communityId))]
+  const eventCommunities = eventCommunityIds.length
+    ? await db.select().from(community).where(inArray(community.id, eventCommunityIds))
+    : []
+  const communityById = new Map(eventCommunities.map((c) => [c.id, c]))
+  const eventRefById = new Map(
+    events.map((e) => {
+      const c = communityById.get(e.communityId)
+      return [
+        e.id,
+        {
+          id: e.id,
+          title: e.title,
+          time: e.time,
+          recurrence: e.recurrence,
+          location: e.location,
+          community: c ? { id: c.id, name: c.name, icon: c.icon } : null,
+        },
+      ]
+    }),
+  )
 
   const captainById = new Map(captains.map((c) => [c.id, c]))
   const typeById = new Map(types.map((t) => [t.id, t]))
@@ -149,7 +180,7 @@ export async function serializeActivities(
       your_response: yourResponse.get(r.id) ?? null,
       counts,
       thread_count: threadCountById.get(r.id) ?? 0,
-      event_ref: null, // bring-friends/community link arrives in a later stage
+      event_ref: r.communityEventId ? (eventRefById.get(r.communityEventId) ?? null) : null,
       created_at: r.createdAt.toISOString(),
     }
   })

--- a/server/src/domain/activity/service.ts
+++ b/server/src/domain/activity/service.ts
@@ -10,6 +10,7 @@ import {
   friendship,
   topic,
   squadMembership,
+  communityEvent,
 } from '../../db/schema/index.ts'
 import { ApiError, errors } from '../../contracts/errors.ts'
 
@@ -99,8 +100,14 @@ export class ActivityService {
     if (scope !== 'friends' && scope !== 'squad') {
       throw errors.badRequest('unsupported_scope', 'Unsupported scope')
     }
+    // Bring-friends bridge: a friends/squad idea may embed a community event as
+    // read-only context (event_ref). The public event stays community-owned.
     if (input.communityEventId) {
-      throw errors.badRequest('unsupported', 'Community events are not available yet')
+      const [ev] = await this.db
+        .select()
+        .from(communityEvent)
+        .where(eq(communityEvent.id, input.communityEventId))
+      if (!ev) throw errors.badRequest('event_invalid', 'Unknown community event')
     }
     if (scope === 'squad') {
       if (!input.squadId) {
@@ -133,6 +140,7 @@ export class ActivityService {
           // default so the NOT NULL column is satisfied.
           audienceKind: isSquad ? 'all_friends' : input.audience.kind,
           allowSuggestions: input.allowSuggestions ?? false,
+          communityEventId: input.communityEventId ?? null,
         })
         .returning({ id: activity.id })
       const activityId = created!.id

--- a/server/src/domain/community/service.ts
+++ b/server/src/domain/community/service.ts
@@ -9,6 +9,8 @@ import {
   topic,
   profile,
   message,
+  activity,
+  response,
 } from '../../db/schema/index.ts'
 import { ApiError } from '../../contracts/errors.ts'
 
@@ -133,6 +135,21 @@ export class CommunityService {
         .groupBy(message.threadTargetId),
     ])
 
+    // Bring-friends attendance coupling: a friend who responded "I'm in" to a
+    // brought-along idea linked to this event is genuinely attending → counted in
+    // the anonymous headcount, but NEVER added to the public face-pile.
+    const broughtRows = await this.db
+      .select({ eventId: activity.communityEventId, profileId: response.profileId })
+      .from(response)
+      .innerJoin(activity, eq(activity.id, response.activityId))
+      .where(and(inArray(activity.communityEventId, ids), eq(response.value, 'in')))
+    const broughtByEvent = new Map<string, Set<string>>()
+    for (const r of broughtRows) {
+      if (!r.eventId) continue
+      ;(broughtByEvent.get(r.eventId) ?? broughtByEvent.set(r.eventId, new Set()).get(r.eventId)!)
+        .add(r.profileId)
+    }
+
     // public face-pile profiles
     const publicProfileIds = [...new Set(rsvps.filter((r) => r.public).map((r) => r.profileId))]
     const publicProfiles = publicProfileIds.length
@@ -146,10 +163,13 @@ export class CommunityService {
     return evs.map((e) => {
       const evRsvps = rsvps.filter((r) => r.eventId === e.id)
       const mine = evRsvps.find((r) => r.profileId === viewerId)
+      // distinct attendees: direct going RSVPs ∪ brought-along "in" responders
+      const attendees = new Set<string>(broughtByEvent.get(e.id) ?? [])
+      for (const r of evRsvps) if (r.going) attendees.add(r.profileId)
       return {
         event: e,
         activityTypeLabel: e.activityTypeId ? (typeById.get(e.activityTypeId) ?? null) : null,
-        goingCount: evRsvps.filter((r) => r.going).length,
+        goingCount: attendees.size,
         publicGoing: evRsvps
           .filter((r) => r.public)
           .map((r) => profileById.get(r.profileId))

--- a/server/test/bring-friends.test.ts
+++ b/server/test/bring-friends.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '0'
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+let topicId: string
+let communityId: string
+let eventId: string
+
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  const token = server.signAccessToken(row.id)
+  return { id: row.id, auth: { authorization: `Bearer ${token}` } }
+}
+async function befriend(a: string, b: string) {
+  await server.sql`insert into friendship (requester, requestee, status) values (${a}, ${b}, 'accepted')`
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  await server.sql`truncate community, community_event, community_event_rsvp, activity, friendship, profile, topic cascade`
+  const [t] = await server.sql<{ id: string }[]>`
+    insert into topic (noun, verb, label) values ('Bike Ride','Go on a','Go on a Bike Ride') returning id`
+  topicId = t.id
+  const [c] = await server.sql<{ id: string }[]>`insert into community (name) values ('Wednesday Night Rides') returning id`
+  communityId = c.id
+  const [e] = await server.sql<{ id: string }[]>`
+    insert into community_event (community_id, title, time, location)
+    values (${communityId}, ${'Cherry Blossoms Ride'}, ${'Wed 6:30pm'}, ${'Clark Park'}) returning id`
+  eventId = e.id
+})
+
+test('brought-along idea is a friends-scoped activity carrying event_ref', async () => {
+  const captain = await makeUser('+12150004000')
+  const friend = await makeUser('+12150004001')
+  await befriend(captain.id, friend.id)
+
+  const created = await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: captain.auth,
+    payload: {
+      activity_type_id: topicId,
+      audience: { kind: 'all_friends' },
+      community_event_id: eventId,
+    },
+  })
+  expect(created.statusCode).toBe(201)
+  const body = created.json()
+  expect(body.scope).toBe('friends')
+  expect(body.event_ref).toBeTruthy()
+  expect(body.event_ref.title).toBe('Cherry Blossoms Ride')
+  expect(body.event_ref.community.name).toBe('Wednesday Night Rides')
+
+  // it lands on the friend's My Friends timeline (a private envelope)…
+  const feed = await server.inject({ method: 'GET', url: '/v1/timeline/friends', headers: friend.auth })
+  const item = feed.json().items.find((a: { id: string }) => a.id === body.id)
+  expect(item).toBeTruthy()
+  expect(item.event_ref.id).toBe(eventId)
+
+  // …and the public event itself is unchanged (community events are leader-owned only)
+  const events = await server.inject({ method: 'GET', url: `/v1/communities/${communityId}/events`, headers: friend.auth })
+  expect(events.json().items).toHaveLength(1)
+  expect(events.json().items[0].id).toBe(eventId)
+})
+
+test('a brought-along "I\'m in" counts in the anonymous headcount, never the face-pile', async () => {
+  const captain = await makeUser('+12150004010')
+  const friend = await makeUser('+12150004011')
+  await befriend(captain.id, friend.id)
+
+  const idea = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/ideas',
+      headers: captain.auth,
+      payload: { activity_type_id: topicId, audience: { kind: 'all_friends' }, community_event_id: eventId },
+    })
+  ).json()
+
+  // before: nobody going
+  let ev = (await server.inject({ method: 'GET', url: `/v1/communities/${communityId}/events`, headers: friend.auth })).json().items[0]
+  expect(ev.going_count).toBe(0)
+
+  // friend says "I'm in" on the brought-along idea (a friends-scoped action)
+  const resp = await server.inject({
+    method: 'PUT',
+    url: `/v1/ideas/${idea.id}/response`,
+    headers: friend.auth,
+    payload: { value: 'in' },
+  })
+  expect(resp.statusCode).toBe(200)
+
+  // → counted in the event's anonymous headcount, but NOT in the public face-pile
+  ev = (await server.inject({ method: 'GET', url: `/v1/communities/${communityId}/events`, headers: captain.auth })).json().items[0]
+  expect(ev.going_count).toBe(1)
+  expect(ev.public_going).toHaveLength(0)
+})


### PR DESCRIPTION
Backend of the **bring-friends bridge** (builds on communities core #421). You bring friends to a community event by posting a **friends-scoped idea that embeds the event** — the public event stays community-owned.

Implements `specs/behaviors/bring-friends-bridge.md` + the `community_event_id` path of `specs/api/ideas-activities.md`.

## What's here
- **`createIdea` accepts `community_event_id`** (previously rejected): validates the event, stores it on the activity. The idea remains **friends/squad-scoped** — never shared onto the friends timeline; the event is read-only context.
- **`event_ref`** on the serialized activity (event title/time/recurrence/location + community {name,icon}) when linked.
- **Attendance coupling**: an event's anonymous `going_count` now = distinct **direct RSVPs (going)** ∪ **friends who responded "I'm in"** to a brought-along idea linked to it — and those friends are **never** added to `public_going`. This is the firewall invariant as a count: what crosses the fence is at most an anonymous +1, never identity.

## Tests (2; full suite 28/28)
brought-along idea is friends-scoped + carries `event_ref` + the public event is unchanged; a brought-along "I'm in" → event `going_count` +1 (anonymous), `public_going` unchanged.

## Scope
Client "Bring friends" action + event-ref chip + composer pre-fill are the companion PR. Leader tooling + community-event threads remain follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)