### PR TITLE
v2 client: bring-friends bridge

### DIFF
--- a/app/lib/models/activity.dart
+++ b/app/lib/models/activity.dart
@@ -17,6 +17,7 @@ class Activity {
     this.interestedCount = 0,
     this.timeOptions = const [],
     this.locationOptions = const [],
+    this.eventRef,
   });
 
   final String id;
@@ -33,6 +34,7 @@ class Activity {
   final int interestedCount;
   final List<ActivityOption> timeOptions;
   final List<ActivityOption> locationOptions;
+  final EventRef? eventRef; // the community event a brought-along idea embeds
 
   bool get isConfirmed => state == 'confirmed';
 
@@ -61,6 +63,9 @@ class Activity {
       interestedCount: (counts['interested'] as num?)?.toInt() ?? 0,
       timeOptions: opts('time_options'),
       locationOptions: opts('location_options'),
+      eventRef: json['event_ref'] == null
+          ? null
+          : EventRef.fromJson(json['event_ref'] as Map<String, dynamic>),
     );
   }
 }
@@ -84,4 +89,36 @@ class ActivityOption {
     votes: (json['votes'] as num?)?.toInt() ?? 0,
     youVoted: json['you_voted'] as bool? ?? false,
   );
+}
+
+/// Read-only reference to the community event a brought-along idea embeds
+/// (specs/behaviors/bring-friends-bridge.md).
+class EventRef {
+  const EventRef({
+    required this.id,
+    required this.title,
+    this.time,
+    this.location,
+    this.communityName,
+    this.communityIcon,
+  });
+
+  final String id;
+  final String title;
+  final String? time;
+  final String? location;
+  final String? communityName;
+  final String? communityIcon;
+
+  factory EventRef.fromJson(Map<String, dynamic> json) {
+    final c = json['community'] as Map<String, dynamic>?;
+    return EventRef(
+      id: json['id'] as String,
+      title: json['title'] as String? ?? '',
+      time: json['time'] as String?,
+      location: json['location'] as String?,
+      communityName: c?['name'] as String?,
+      communityIcon: c?['icon'] as String?,
+    );
+  }
 }

--- a/app/lib/repositories/activity_repository.dart
+++ b/app/lib/repositories/activity_repository.dart
@@ -13,6 +13,7 @@ abstract class ActivityRepository {
     List<String> timeOptions,
     List<String> locationOptions,
     String? squadId,
+    String? communityEventId,
   });
 
   Future<Activity> setResponse(String activityId, String value);
@@ -42,6 +43,7 @@ class ApiActivityRepository implements ActivityRepository {
     List<String> timeOptions = const [],
     List<String> locationOptions = const [],
     String? squadId,
+    String? communityEventId,
   }) async {
     final res = await apiClient.post(
       '/v1/ideas',
@@ -49,6 +51,7 @@ class ApiActivityRepository implements ActivityRepository {
         'activity_type_id': activityTypeId,
         if (squadId != null) 'scope': 'squad',
         'squad_id': ?squadId,
+        'community_event_id': ?communityEventId,
         'audience': {'kind': 'all_friends'},
         'allow_suggestions': allowSuggestions,
         if (timeOptions.isNotEmpty) 'time_options': timeOptions,

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -35,7 +35,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/splash', builder: (_, _) => const _Splash()),
       GoRoute(path: '/login', builder: (_, _) => const LoginScreen()),
       GoRoute(path: '/', builder: (_, _) => const TimelineScreen()),
-      GoRoute(path: '/ideas/new', builder: (_, _) => const ComposeIdeaScreen()),
+      GoRoute(
+        path: '/ideas/new',
+        builder: (_, state) =>
+            ComposeIdeaScreen(broughtEvent: state.extra as EventRef?),
+      ),
       GoRoute(
         path: '/squads/new',
         builder: (_, _) => const CreateSquadScreen(),

--- a/app/lib/screens/activity/activity_detail_screen.dart
+++ b/app/lib/screens/activity/activity_detail_screen.dart
@@ -82,6 +82,30 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
                       ? 'Confirmed · ${[a.confirmedTime, a.confirmedLocation].whereType<String>().join(' · ')}'
                       : 'Idea · ${a.audienceSummary ?? ''}',
                 ),
+                if (a.eventRef != null) ...[
+                  const SizedBox(height: 8),
+                  Card(
+                    key: const Key('eventRefChip'),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
+                    child: ListTile(
+                      dense: true,
+                      leading: Text(
+                        a.eventRef!.communityIcon ?? '📣',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                      title: Text(a.eventRef!.title),
+                      subtitle: Text(
+                        [
+                          a.eventRef!.communityName,
+                          a.eventRef!.time,
+                          a.eventRef!.location,
+                        ].whereType<String>().join(' · '),
+                      ),
+                    ),
+                  ),
+                ],
                 const Divider(height: 32),
 
                 // Your response

--- a/app/lib/screens/compose/compose_idea_screen.dart
+++ b/app/lib/screens/compose/compose_idea_screen.dart
@@ -3,15 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../api/api_exception.dart';
+import '../../models/activity.dart';
 import '../../models/topic.dart';
 import '../../providers/active_context.dart';
 import '../../providers/providers.dart';
 
-/// Compose a new idea (specs/api/ideas-activities.md). Friends/all_friends audience
-/// this stage: pick an activity type, optionally allow suggestions and seed a couple
-/// of time/location options, then POST /v1/ideas.
+/// Compose a new idea (specs/api/ideas-activities.md). When [broughtEvent] is set
+/// (the bring-friends bridge), the idea embeds that community event as read-only
+/// context and is posted friends-scoped.
 class ComposeIdeaScreen extends ConsumerStatefulWidget {
-  const ComposeIdeaScreen({super.key});
+  const ComposeIdeaScreen({super.key, this.broughtEvent});
+
+  final EventRef? broughtEvent;
 
   @override
   ConsumerState<ComposeIdeaScreen> createState() => _ComposeIdeaScreenState();
@@ -57,6 +60,7 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
               SquadContext(:final id) => id,
               _ => null,
             },
+            communityEventId: widget.broughtEvent?.id,
           );
       switch (ctx) {
         case SquadContext(:final id):
@@ -84,13 +88,34 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
       _ => 'Visible to all your friends',
     };
 
+    final event = widget.broughtEvent;
     return Scaffold(
-      appBar: AppBar(title: const Text('New idea')),
+      appBar: AppBar(title: Text(event == null ? 'New idea' : 'Bring friends')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            if (event != null)
+              Card(
+                key: const Key('broughtEventChip'),
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                child: ListTile(
+                  leading: Text(
+                    event.communityIcon ?? '📣',
+                    style: const TextStyle(fontSize: 22),
+                  ),
+                  title: Text(event.title),
+                  subtitle: Text(
+                    [
+                      event.communityName,
+                      event.time,
+                      event.location,
+                    ].whereType<String>().join(' · '),
+                  ),
+                ),
+              ),
+            if (event != null) const SizedBox(height: 12),
             Container(
               key: const Key('composeDestination'),
               padding: const EdgeInsets.all(12),

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -328,9 +328,13 @@ class _ActivityTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final a = activity;
-    final subtitle = a.isConfirmed
+    final base = a.isConfirmed
         ? [a.confirmedTime, a.confirmedLocation].whereType<String>().join(' · ')
         : 'Idea · ${a.audienceSummary ?? ''}';
+    // Brought-along ideas show the embedded community event.
+    final subtitle = a.eventRef != null
+        ? '$base · ${a.eventRef!.communityIcon ?? '📣'} ${a.eventRef!.communityName ?? 'Community'}'
+        : base;
     return ListTile(
       onTap: () => context.push('/activity/${a.id}', extra: a),
       leading: CircleAvatar(

--- a/app/lib/widgets/community_event_card.dart
+++ b/app/lib/widgets/community_event_card.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import '../models/activity.dart';
 import '../models/community.dart';
+import '../providers/active_context.dart';
 import '../providers/providers.dart';
 
 /// A born-confirmed community event card with the dual-attendance display and the
@@ -100,6 +103,31 @@ class _CommunityEventCardState extends ConsumerState<CommunityEventCard> {
                       : (sel) => _rsvp(going: true, public: sel),
                 ),
               ],
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: Key('bring_friends_${e.id}'),
+                icon: const Icon(Icons.group_add, size: 18),
+                label: const Text('Bring friends'),
+                // Switch to My Friends + open the composer pre-filled with this event
+                // (bring-friends bridge): posts a friends-scoped idea, never the public event.
+                onPressed: () {
+                  ref.read(activeContextProvider.notifier).toFriends();
+                  context.push(
+                    '/ideas/new',
+                    extra: EventRef(
+                      id: e.id,
+                      title: e.title,
+                      time: e.time,
+                      location: e.location,
+                      communityName: e.communityName,
+                      communityIcon: e.communityIcon,
+                    ),
+                  );
+                },
+              ),
             ),
           ],
         ),

--- a/app/test/activity_detail_test.dart
+++ b/app/test/activity_detail_test.dart
@@ -19,6 +19,7 @@ class FakeActivityRepository implements ActivityRepository {
     List<String> timeOptions = const [],
     List<String> locationOptions = const [],
     String? squadId,
+    String? communityEventId,
   }) async => result;
 
   @override

--- a/app/test/bring_friends_test.dart
+++ b/app/test/bring_friends_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/activity.dart';
+import 'package:squadquest/models/topic.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/topic_repository.dart';
+import 'package:squadquest/screens/compose/compose_idea_screen.dart';
+
+class FakeTopicRepository implements TopicRepository {
+  @override
+  Future<List<Topic>> list() async => const [
+    Topic(id: 't1', label: 'Go on a Bike Ride'),
+  ];
+}
+
+void main() {
+  testWidgets(
+    'composer pre-filled from a community event shows the event chip',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            topicRepositoryProvider.overrideWithValue(FakeTopicRepository()),
+          ],
+          child: const MaterialApp(
+            home: ComposeIdeaScreen(
+              broughtEvent: EventRef(
+                id: 'e1',
+                title: 'Cherry Blossoms Ride',
+                time: 'Wed 6:30pm',
+                communityName: 'Wednesday Night Rides',
+                communityIcon: '🚲',
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Bring friends'), findsOneWidget); // app bar title
+      expect(find.byKey(const Key('broughtEventChip')), findsOneWidget);
+      expect(find.text('Cherry Blossoms Ride'), findsOneWidget);
+      // a brought idea is still friends-scoped
+      expect(find.byKey(const Key('composeDestination')), findsOneWidget);
+      expect(find.textContaining('all your friends'), findsOneWidget);
+    },
+  );
+}

--- a/plans/v2-bring-friends-bridge.md
+++ b/plans/v2-bring-friends-bridge.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-communities-core]
 specs:
   - specs/behaviors/bring-friends-bridge.md
@@ -7,7 +7,7 @@ specs:
   - specs/api/communities.md
   - specs/screens/communities.md
 issues: []
-pr:
+pr: 424
 ---
 
 # Plan: v2 bring-friends bridge
@@ -57,11 +57,13 @@ nuance (brought-along idea follows the normal lifecycle with the event providing
 
 ## Validation
 
-- [ ] `bun run type-check` + `bun test` (brought-along idea: event_ref + friends-scoped +
-      absent from community feed; "I'm in" → anonymous headcount +1, not public) green; CI.
-- [ ] client `flutter analyze` + widget tests green; CI.
-- [ ] (when machine free) MCP: Bring friends on an event → idea on My Friends w/ event chip;
-      friend responds "I'm in" → event going_count +1, face-pile unchanged.
+- [x] `bun run type-check` + `bun test` — 2 tests (brought-along idea: event_ref +
+      friends-scoped + public event unchanged; "I'm in" → anonymous headcount +1, face-pile
+      unchanged); full suite 28/28; backend CI green (#423, merged).
+- [x] client `flutter analyze` clean + 10 widget tests (composer prefilled-from-event chip);
+      client CI on #424.
+- [~] MCP visual walkthrough deferred (window-foreground conflict); backend invariants
+      unit-tested.
 
 ## Risks / unknowns
 
@@ -72,8 +74,18 @@ nuance (brought-along idea follows the normal lifecycle with the event providing
 
 ## Notes
 
-(closeout)
+Two PRs: **#423** (backend — createIdea accepts community_event_id, activity serializer
+event_ref, attendance coupling in CommunityService going_count) merged; **#424** (client —
+Bring-friends action, composer pre-fill + event chip, event_ref on tiles/detail). The
+firewall invariant holds end-to-end: the composer only emits friends-scoped ideas; a
+brought-along "I'm in" adds at most an anonymous +1 to the event headcount, never identity.
+Completes **communities** (core + bridge).
 
 ## Follow-ups
 
-(closeout)
+- **Deferred to plan:** the destination picker (My Friends vs a squad) in the bring-friends
+  composer — currently posts to My Friends; community-event **threads** (the event_ref's
+  thread); leader tooling; photos; SSE.
+- **Deferred (UX):** a public RSVP / face-pile entry for a profile with no name (onboarding/
+  welcome-wizard sets names; until then nameless public attendees are dropped from the
+  face-pile though still counted).


### PR DESCRIPTION
Client half of the **bring-friends bridge** (backend #423) — the marquee communities interaction. Styling deferred.

Implements `specs/behaviors/bring-friends-bridge.md` (client).

## What's here
- **"Bring friends"** on a `CommunityEventCard` → switches the active context to **My Friends** and opens the composer **pre-filled with the event** (passed as `EventRef`).
- **Composer** with a brought event: shows a read-only **event chip**, titles itself "Bring friends", keeps the audience friends-scoped, and posts with `community_event_id`.
- **`event_ref`** parsed onto the Activity model → the activity **detail** shows an event chip; the **timeline tile** notes the embedded community.
- `ActivityRepository.createIdea` gains `communityEventId`.

The firewall holds on the client too: the composer only emits a friends-scoped idea; the public event is read-only context.

## Verification
`flutter analyze` clean; **10 widget tests** (added composer-prefilled-from-event chip + friends-scoped). Backend attendance-coupling/firewall invariants unit-tested in #423.

This completes **communities** (core #421/#422 + bridge #423/this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)