### PR TITLE
feat(server): friend connections + profile onboarding

### DIFF
--- a/plans/v2-friends-and-onboarding.md
+++ b/plans/v2-friends-and-onboarding.md
@@ -1,0 +1,75 @@
+---
+status: in-progress
+depends: [v2-communities-core]
+specs:
+  - specs/api/profile.md
+  - specs/api/friends.md
+  - specs/behaviors/friend-connections.md
+  - specs/screens/welcome-wizard.md
+issues: []
+pr:
+---
+
+# Plan: v2 friend connections + onboarding
+
+## Scope
+
+The two remaining "people" gaps so the app is self-serve: **onboarding** (a freshly
+claimed/created user sets their name) and **friend connections** (in-app double-opt-in
+requests, so the friend graph isn't seed/migration-only). Backend + client; styling deferred.
+
+**In:**
+
+- onboarding: `PATCH /v1/me` (set first/last name); client routes a null-name user to a
+  profile-setup step after login.
+- friend connections: `POST`/`GET /v1/friends/requests`, `PUT /v1/friends/requests/:id`
+  (send-by-phone w/ shell creation + idempotent/auto-accept, list incoming/outgoing, accept/
+  decline); client Friends screen (accepted + incoming requests + add-by-phone).
+
+**Out:** the 3-page welcome PageView intro copy (styling); photo upload (storage); QR /
+contact-based connection (future channels); blocking.
+
+## Implements
+
+`specs/api/profile.md` (PATCH /v1/me), `specs/api/friends.md` + `specs/behaviors/friend-connections.md`,
+and the profile-setup step of `specs/screens/welcome-wizard.md`.
+
+## Approach
+
+- **Backend** (`server/`):
+  - `PATCH /v1/me` in `routes/v1/me.ts` (update first/last name; non-empty first_name).
+  - `FriendService`: requestByPhone (normalize → resolve/​create shell → dedup / auto-accept /
+    create requested), listRequests (incoming/outgoing), respond (requestee-only accept/
+    decline). Reuse `normalizePhone`. Friend/request serializers.
+  - routes `routes/v1/friends.ts` (extend) + tests.
+- **Client** (`app/`):
+  - ProfileRepository.updateProfile (PATCH); AuthController exposes the current profile;
+    after sign-in, if `first_name == null` → route `/welcome` (name field → PATCH → go home).
+  - FriendRepository: requests(), sendRequest(phone), respond(id, accept). providers.
+  - Friends screen (`/friends`): accepted list + incoming requests (accept/decline) +
+    add-by-phone field. Reached from a People icon on the timeline app bar.
+
+## Validation
+
+- [ ] `bun run type-check` + `bun test` (PATCH sets name; send-by-phone creates shell +
+      requested; reciprocal request auto-accepts; accept connects → appears in GET /friends;
+      decline leaves no edge; non-requestee 404; self-request 400) green; CI.
+- [ ] client `flutter analyze` + widget tests green; CI.
+- [ ] (machine free) MCP: new login → profile-setup sets name; send request by phone →
+      pending; accept from the other account → both connected, timeline visible.
+
+## Risks / unknowns
+
+- Shell creation + claim-on-login interplay (a pending request must survive until the
+  invitee claims) — reuse the existing shell/claim path.
+- One-edge-per-pair idempotency + auto-accept on reciprocal request (don't duplicate edges).
+- Onboarding gate: route on null first_name without trapping users who skip (allow a name,
+  required to proceed this stage).
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/server/src/contracts/friend.ts
+++ b/server/src/contracts/friend.ts
@@ -14,3 +14,17 @@ export function serializeFriend(row: ProfileRow) {
     on_v2: row.claimedAt !== null,
   }
 }
+
+// A pending connection request. `profile` is the *other* party (the sender for an
+// incoming request, the target for an outgoing one). See specs/api/friends.md.
+export function serializeFriendRequest(view: {
+  id: string
+  profile: ProfileRow
+  createdAt: Date
+}) {
+  return {
+    id: view.id,
+    profile: serializeFriend(view.profile),
+    created_at: view.createdAt.toISOString(),
+  }
+}

--- a/server/src/domain/friend/service.ts
+++ b/server/src/domain/friend/service.ts
@@ -1,0 +1,130 @@
+import { and, eq, or } from 'drizzle-orm'
+
+import type { Database } from '../../db/index.ts'
+import { profile, friendship } from '../../db/schema/index.ts'
+import { ApiError, errors } from '../../contracts/errors.ts'
+import { normalizePhone } from '../auth/phone.ts'
+
+type ProfileRow = typeof profile.$inferSelect
+
+export interface FriendRequestView {
+  id: string
+  profile: ProfileRow // the *other* party (sender for incoming, target for outgoing)
+  createdAt: Date
+}
+
+// The double-opt-in friend graph: send-by-phone requests, accept/decline.
+// See specs/behaviors/friend-connections.md + specs/api/friends.md.
+export class FriendService {
+  constructor(private readonly db: Database) {}
+
+  // Send a connection request by phone. Resolves the phone to a profile (creating
+  // an unclaimed shell if none — same mechanism as v1 migration), then applies the
+  // one-edge-per-pair / idempotent / auto-accept rules. Returns the resulting status.
+  async requestByPhone(me: string, rawPhone: string): Promise<'requested' | 'accepted'> {
+    const phone = normalizePhone(rawPhone)
+
+    let [target] = await this.db.select().from(profile).where(eq(profile.phone, phone))
+    if (target && target.id === me) {
+      throw errors.badRequest('cannot_self_request', 'You cannot friend yourself')
+    }
+    if (!target) {
+      // Unclaimed shell — the pending request waits until they claim on login.
+      const [created] = await this.db.insert(profile).values({ phone }).returning()
+      target = created!
+    }
+    const targetId = target.id
+
+    // The single edge for this unordered pair, in either direction.
+    const [edge] = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        or(
+          and(eq(friendship.requester, me), eq(friendship.requestee, targetId)),
+          and(eq(friendship.requester, targetId), eq(friendship.requestee, me)),
+        ),
+      )
+
+    if (edge) {
+      if (edge.status === 'accepted') return 'accepted'
+      if (edge.status === 'requested') {
+        if (edge.requester === targetId) {
+          // They already requested me → my "send" is an accept.
+          await this.db
+            .update(friendship)
+            .set({ status: 'accepted' })
+            .where(eq(friendship.id, edge.id))
+          return 'accepted'
+        }
+        return 'requested' // I already requested them — idempotent.
+      }
+      // declined → re-open as a fresh request from me (decline is not a block).
+      await this.db
+        .update(friendship)
+        .set({ requester: me, requestee: targetId, status: 'requested' })
+        .where(eq(friendship.id, edge.id))
+      return 'requested'
+    }
+
+    await this.db
+      .insert(friendship)
+      .values({ requester: me, requestee: targetId, status: 'requested' })
+    return 'requested'
+  }
+
+  // Pending requests involving the caller, split by direction. `profile` on each
+  // view is the *other* party — never the caller.
+  async listRequests(
+    me: string,
+  ): Promise<{ incoming: FriendRequestView[]; outgoing: FriendRequestView[] }> {
+    const edges = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          eq(friendship.status, 'requested'),
+          or(eq(friendship.requester, me), eq(friendship.requestee, me)),
+        ),
+      )
+    if (edges.length === 0) return { incoming: [], outgoing: [] }
+
+    const otherIds = edges.map((e) => (e.requester === me ? e.requestee : e.requester))
+    const profiles = await this.db
+      .select()
+      .from(profile)
+      .where(or(...otherIds.map((id) => eq(profile.id, id))))
+    const byId = new Map(profiles.map((p) => [p.id, p]))
+
+    const incoming: FriendRequestView[] = []
+    const outgoing: FriendRequestView[] = []
+    for (const e of edges) {
+      const otherId = e.requester === me ? e.requestee : e.requester
+      const other = byId.get(otherId)
+      if (!other) continue
+      const view = { id: e.id, profile: other, createdAt: e.createdAt }
+      if (e.requestee === me) incoming.push(view)
+      else outgoing.push(view)
+    }
+    return { incoming, outgoing }
+  }
+
+  // Accept/decline an incoming request. Requestee-only; a non-requestee (or a
+  // missing / already-resolved edge) is indistinguishable from not-found → 404.
+  async respond(
+    me: string,
+    requestId: string,
+    accept: boolean,
+  ): Promise<'accepted' | 'declined'> {
+    const [edge] = await this.db
+      .select()
+      .from(friendship)
+      .where(eq(friendship.id, requestId))
+    if (!edge || edge.requestee !== me || edge.status !== 'requested') {
+      throw new ApiError(404, 'not_found', 'Request not found')
+    }
+    const status = accept ? 'accepted' : 'declined'
+    await this.db.update(friendship).set({ status }).where(eq(friendship.id, edge.id))
+    return status
+  }
+}

--- a/server/src/routes/v1/friends.ts
+++ b/server/src/routes/v1/friends.ts
@@ -2,11 +2,16 @@ import type { FastifyPluginAsync } from 'fastify'
 import { and, eq, or, inArray } from 'drizzle-orm'
 
 import { profile, friendship } from '../../db/schema/index.ts'
-import { serializeFriend } from '../../contracts/friend.ts'
+import { FriendService } from '../../domain/friend/service.ts'
+import { serializeFriend, serializeFriendRequest } from '../../contracts/friend.ts'
 
-// GET /v1/friends — the authenticated user's accepted friend graph (includes
-// not-yet-claimed friends, flagged on_v2:false). See specs/behaviors/v1-migration.md.
+// The accepted friend graph + double-opt-in connection requests.
+// See specs/api/friends.md + specs/behaviors/friend-connections.md.
 const friendsRoutes: FastifyPluginAsync = async (fastify) => {
+  const friends = new FriendService(fastify.db)
+
+  // GET /v1/friends — the caller's accepted friend graph (includes not-yet-claimed
+  // friends, flagged on_v2:false). See specs/behaviors/v1-migration.md.
   fastify.get('/friends', { preHandler: fastify.authenticate }, async (request) => {
     const me = request.profileId!
 
@@ -30,6 +35,62 @@ const friendsRoutes: FastifyPluginAsync = async (fastify) => {
 
     return { items: rows.map(serializeFriend) }
   })
+
+  // GET /v1/friends/requests — pending requests involving the caller, by direction.
+  fastify.get(
+    '/friends/requests',
+    { preHandler: fastify.authenticate },
+    async (request) => {
+      const { incoming, outgoing } = await friends.listRequests(request.profileId!)
+      return {
+        incoming: incoming.map(serializeFriendRequest),
+        outgoing: outgoing.map(serializeFriendRequest),
+      }
+    },
+  )
+
+  // POST /v1/friends/requests — send a request by phone. 201 requested | 200 accepted.
+  fastify.post<{ Body: { phone: string } }>(
+    '/friends/requests',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['phone'],
+          properties: { phone: { type: 'string' } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const status = await friends.requestByPhone(request.profileId!, request.body.phone)
+      reply.code(status === 'accepted' ? 200 : 201)
+      return { status }
+    },
+  )
+
+  // PUT /v1/friends/requests/:id — accept/decline an incoming request (requestee only).
+  fastify.put<{ Params: { id: string }; Body: { accept: boolean } }>(
+    '/friends/requests/:id',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['accept'],
+          properties: { accept: { type: 'boolean' } },
+        },
+      },
+    },
+    async (request) => {
+      const status = await friends.respond(
+        request.profileId!,
+        request.params.id,
+        request.body.accept,
+      )
+      return { status }
+    },
+  )
 }
 
 export default friendsRoutes

--- a/server/src/routes/v1/me.ts
+++ b/server/src/routes/v1/me.ts
@@ -5,8 +5,9 @@ import { profile } from '../../db/schema/index.ts'
 import { serializeProfile } from '../../contracts/profile.ts'
 import { errors } from '../../contracts/errors.ts'
 
-// GET /v1/me — the authenticated user's profile.
+// The authenticated user's own profile. See specs/api/profile.md.
 const meRoutes: FastifyPluginAsync = async (fastify) => {
+  // GET /v1/me — the caller's profile (null first_name = needs onboarding).
   fastify.get('/me', { preHandler: fastify.authenticate }, async (request) => {
     const [row] = await fastify.db
       .select()
@@ -15,6 +16,46 @@ const meRoutes: FastifyPluginAsync = async (fastify) => {
     if (!row) throw errors.unauthorized()
     return serializeProfile(row)
   })
+
+  // PATCH /v1/me — update own profile (onboarding profile-setup + later edits).
+  // Only provided fields change; first_name must be non-empty when present.
+  fastify.patch<{ Body: { first_name?: string; last_name?: string } }>(
+    '/me',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            first_name: { type: 'string' },
+            last_name: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const { first_name, last_name } = request.body
+      const updates: { firstName?: string; lastName?: string | null } = {}
+
+      if (first_name !== undefined) {
+        if (first_name.trim() === '') {
+          throw errors.badRequest('first_name_required', 'first_name must be non-empty')
+        }
+        updates.firstName = first_name.trim()
+      }
+      if (last_name !== undefined) {
+        updates.lastName = last_name.trim() === '' ? null : last_name.trim()
+      }
+
+      const [row] = await fastify.db
+        .update(profile)
+        .set(updates)
+        .where(eq(profile.id, request.profileId!))
+        .returning()
+      if (!row) throw errors.unauthorized()
+      return serializeProfile(row)
+    },
+  )
 }
 
 export default meRoutes

--- a/server/test/friends.test.ts
+++ b/server/test/friends.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '0'
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+
+async function makeUser(phone: string, firstName: string | null = phone) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${firstName}, now()) returning id`
+  const token = server.signAccessToken(row.id)
+  return { id: row.id, auth: { authorization: `Bearer ${token}` } }
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  await server.sql`truncate profile cascade`
+})
+
+test('send-by-phone to a stranger creates an unclaimed shell + a requested edge', async () => {
+  const alice = await makeUser('+12150001000')
+
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150009999' },
+  })
+  expect(res.statusCode).toBe(201)
+  expect(res.json()).toEqual({ status: 'requested' })
+
+  // A shell was created (on_v2:false in the outgoing request view).
+  const reqs = (
+    await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: alice.auth })
+  ).json()
+  expect(reqs.incoming).toHaveLength(0)
+  expect(reqs.outgoing).toHaveLength(1)
+  expect(reqs.outgoing[0].profile.on_v2).toBe(false)
+
+  // Not yet connected.
+  const friends = (
+    await server.inject({ method: 'GET', url: '/v1/friends', headers: alice.auth })
+  ).json()
+  expect(friends.items).toHaveLength(0)
+})
+
+test('a request is incoming for the target; accepting connects both ways', async () => {
+  const alice = await makeUser('+12150001010')
+  const bob = await makeUser('+12150001011')
+
+  await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001011' },
+  })
+
+  const bobReqs = (
+    await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth })
+  ).json()
+  expect(bobReqs.incoming).toHaveLength(1)
+  expect(bobReqs.incoming[0].profile.id).toBe(alice.id)
+  const requestId = bobReqs.incoming[0].id
+
+  const accepted = await server.inject({
+    method: 'PUT',
+    url: `/v1/friends/requests/${requestId}`,
+    headers: bob.auth,
+    payload: { accept: true },
+  })
+  expect(accepted.statusCode).toBe(200)
+  expect(accepted.json()).toEqual({ status: 'accepted' })
+
+  // Both see each other in GET /friends.
+  const aliceFriends = (
+    await server.inject({ method: 'GET', url: '/v1/friends', headers: alice.auth })
+  ).json()
+  expect(aliceFriends.items.map((f: { id: string }) => f.id)).toEqual([bob.id])
+  const bobFriends = (
+    await server.inject({ method: 'GET', url: '/v1/friends', headers: bob.auth })
+  ).json()
+  expect(bobFriends.items.map((f: { id: string }) => f.id)).toEqual([alice.id])
+
+  // The request is no longer pending for either side.
+  const bobReqsAfter = (
+    await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth })
+  ).json()
+  expect(bobReqsAfter.incoming).toHaveLength(0)
+})
+
+test('a reciprocal send auto-accepts (no duplicate edge)', async () => {
+  const alice = await makeUser('+12150001020')
+  const bob = await makeUser('+12150001021')
+
+  await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001021' },
+  })
+
+  // Bob "sends" to Alice → treated as accept.
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: bob.auth,
+    payload: { phone: '+12150001020' },
+  })
+  expect(res.statusCode).toBe(200)
+  expect(res.json()).toEqual({ status: 'accepted' })
+
+  const bobFriends = (
+    await server.inject({ method: 'GET', url: '/v1/friends', headers: bob.auth })
+  ).json()
+  expect(bobFriends.items.map((f: { id: string }) => f.id)).toEqual([alice.id])
+
+  // Exactly one edge for the pair.
+  const [{ count }] = await server.sql<{ count: number }[]>`
+    select count(*)::int as count from friendship`
+  expect(count).toBe(1)
+})
+
+test('re-sending an existing request is idempotent (still one requested edge)', async () => {
+  const alice = await makeUser('+12150001030')
+  await makeUser('+12150001031')
+
+  for (let i = 0; i < 2; i++) {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/v1/friends/requests',
+      headers: alice.auth,
+      payload: { phone: '+12150001031' },
+    })
+    expect(res.json()).toEqual({ status: 'requested' })
+  }
+  const [{ count }] = await server.sql<{ count: number }[]>`
+    select count(*)::int as count from friendship`
+  expect(count).toBe(1)
+})
+
+test('declining leaves no connection; the pair can re-request later', async () => {
+  const alice = await makeUser('+12150001040')
+  const bob = await makeUser('+12150001041')
+
+  await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001041' },
+  })
+  const reqId = (
+    await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth })
+  ).json().incoming[0].id
+
+  const declined = await server.inject({
+    method: 'PUT',
+    url: `/v1/friends/requests/${reqId}`,
+    headers: bob.auth,
+    payload: { accept: false },
+  })
+  expect(declined.json()).toEqual({ status: 'declined' })
+
+  // No connection, nothing pending.
+  expect(
+    (await server.inject({ method: 'GET', url: '/v1/friends', headers: alice.auth })).json()
+      .items,
+  ).toHaveLength(0)
+  expect(
+    (await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: alice.auth }))
+      .json().outgoing,
+  ).toHaveLength(0)
+
+  // Re-request reopens it (decline is not a block) — still one edge.
+  const reopened = await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001041' },
+  })
+  expect(reopened.json()).toEqual({ status: 'requested' })
+  const [{ count }] = await server.sql<{ count: number }[]>`
+    select count(*)::int as count from friendship`
+  expect(count).toBe(1)
+})
+
+test('only the requestee may respond; others get 404', async () => {
+  const alice = await makeUser('+12150001050')
+  const bob = await makeUser('+12150001051')
+  const carol = await makeUser('+12150001052')
+
+  await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001051' },
+  })
+  const reqId = (
+    await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth })
+  ).json().incoming[0].id
+
+  // Carol (uninvolved) cannot respond.
+  expect(
+    (
+      await server.inject({
+        method: 'PUT',
+        url: `/v1/friends/requests/${reqId}`,
+        headers: carol.auth,
+        payload: { accept: true },
+      })
+    ).statusCode,
+  ).toBe(404)
+
+  // The requester (Alice) cannot accept her own outgoing request either.
+  expect(
+    (
+      await server.inject({
+        method: 'PUT',
+        url: `/v1/friends/requests/${reqId}`,
+        headers: alice.auth,
+        payload: { accept: true },
+      })
+    ).statusCode,
+  ).toBe(404)
+})
+
+test('cannot friend yourself', async () => {
+  const alice = await makeUser('+12150001060')
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001060' },
+  })
+  expect(res.statusCode).toBe(400)
+  expect(res.json().error.code).toBe('cannot_self_request')
+})
+
+test('PATCH /v1/me sets the name; GET reflects it; blank first_name is rejected', async () => {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, claimed_at) values (${'+12150001070'}, now()) returning id`
+  const auth = { authorization: `Bearer ${server.signAccessToken(row.id)}` }
+
+  // Fresh profile needs onboarding.
+  expect(
+    (await server.inject({ method: 'GET', url: '/v1/me', headers: auth })).json().first_name,
+  ).toBeNull()
+
+  const patched = await server.inject({
+    method: 'PATCH',
+    url: '/v1/me',
+    headers: auth,
+    payload: { first_name: 'Chris', last_name: 'Alfano' },
+  })
+  expect(patched.statusCode).toBe(200)
+  expect(patched.json().first_name).toBe('Chris')
+  expect(patched.json().last_name).toBe('Alfano')
+
+  // Persisted.
+  expect(
+    (await server.inject({ method: 'GET', url: '/v1/me', headers: auth })).json().first_name,
+  ).toBe('Chris')
+
+  // Blank first_name is rejected.
+  const blank = await server.inject({
+    method: 'PATCH',
+    url: '/v1/me',
+    headers: auth,
+    payload: { first_name: '   ' },
+  })
+  expect(blank.statusCode).toBe(400)
+  expect(blank.json().error.code).toBe('first_name_required')
+})

--- a/specs/api/friends.md
+++ b/specs/api/friends.md
@@ -1,0 +1,56 @@
+# API: Friends
+
+The accepted friend graph + connection requests (double opt-in). Authenticated. Connection
+model in [`behaviors/friend-connections.md`](../behaviors/friend-connections.md).
+
+## Serialized friend / requester
+
+```jsonc
+{ "id", "first_name", "last_name", "photo", "on_v2": bool }
+```
+
+`on_v2:false` = a carried/pre-migration friend (or a shell) who hasn't claimed v2 yet.
+
+## GET /v1/friends
+
+The caller's **accepted** friends.
+
+- **Response:** `200 { "items": [<friend>…] }`.
+
+## GET /v1/friends/requests
+
+Pending connection requests involving the caller.
+
+- **Response:** `200 { "incoming": [<request>…], "outgoing": [<request>…] }`
+  where a request is `{ "id", "profile": <friend>, "created_at" }` — `profile` is the *other*
+  party (the sender for incoming, the target for outgoing).
+
+## POST /v1/friends/requests
+
+Send a connection request by phone.
+
+- **Request:** `{ "phone": "+1…" }`.
+- Resolve the phone → profile (create an unclaimed shell if none). Then:
+  - already `accepted` → `200 { "status": "accepted" }` (idempotent),
+  - they already requested you → auto-accept → `200 { "status": "accepted" }`,
+  - otherwise create/keep a `requested` edge → `201 { "status": "requested" }`.
+- Cannot request yourself → `400 cannot_self_request`.
+
+## PUT /v1/friends/requests/:id
+
+Respond to an **incoming** request (requestee only).
+
+- **Request:** `{ "accept": true }` → `accepted`; `{ "accept": false }` → `declined`.
+- **Response:** `200 { "status": "accepted" | "declined" }`. Non-requestee → `404`.
+
+## Notes
+
+- Only `accepted` edges grant timeline/detail visibility (see friend-connections).
+- QR / contact-based connection are future channels; phone is the first.
+
+## Principles
+
+**Inherited:**
+
+- [Private-first](../principles.md#private-first-public-never-touches-the-friends-surface) —
+  a one-sided request grants no access; only acceptance opens the private surface.

--- a/specs/api/profile.md
+++ b/specs/api/profile.md
@@ -1,0 +1,33 @@
+# API: Profile (me)
+
+The authenticated user's own profile. Authenticated.
+
+## GET /v1/me
+
+The caller's profile.
+
+- **Response:** `200 { "id", "first_name", "last_name", "photo", "phone", "claimed_at" }`.
+
+## PATCH /v1/me
+
+Update the caller's own profile (the onboarding profile-setup + later profile edits).
+
+- **Request:** `{ "first_name"?: "string", "last_name"?: "string" }` — only provided fields
+  change. `first_name` must be non-empty when present.
+- **Response:** `200 <profile>`.
+- **`needs_onboarding`:** a freshly-claimed/created profile has `first_name = null`. Clients
+  treat a null `first_name` as "needs onboarding" and route to the welcome/profile-setup step.
+  Photo upload is deferred to storage.
+
+## Notes
+
+- A fresh phone-OTP user (or a claimed pre-migration shell) starts with no name; PATCH is how
+  the welcome wizard sets it. See [`screens/welcome-wizard.md`](../screens/welcome-wizard.md).
+
+## Principles
+
+**Inherited:**
+
+- [Audience clarity at the moment of action](../principles.md#audience-clarity-at-the-moment-of-action)
+  — a real name is what makes a public face-pile / captain line meaningful; onboarding sets it
+  before those surfaces show "Someone".

--- a/specs/behaviors/friend-connections.md
+++ b/specs/behaviors/friend-connections.md
@@ -1,0 +1,51 @@
+# Behavior: Friend Connections
+
+## Rule
+
+The friend graph is **double opt-in**: a connection exists only when both people have
+agreed (`friendship.status = accepted`). You build it by **sending a request** (by phone
+now; QR and other channels are future), and the other person **accepting**. Either side may
+decline; absence of acceptance is not a connection.
+
+## Applies To
+
+`screens/friends-timeline.md` (whose audience is the accepted graph), `api/friends.md`,
+`behaviors/v1-migration.md` (the pre-migrated graph arrives already-accepted; claim-on-login
+surfaces pending requests).
+
+## Details
+
+- **Send by phone:** you request a friend by E.164 phone. Resolve the phone to a profile;
+  if none exists, create an **unclaimed shell** (phone only) and attach the request to it —
+  so when that person joins and claims (claim-on-login), the pending request is waiting.
+  This is the same shell mechanism as the v1 migration.
+- **One edge per pair:** a `friendship` row is unique per unordered pair. If an edge already
+  exists (requested or accepted, either direction), sending is idempotent — never a duplicate.
+  If *they* already requested *you*, your "send" is treated as an accept.
+- **States:** `requested → accepted` (both connected) or `requested → declined` (no
+  connection; may be re-requested later). A decline is not a block.
+- **Respond:** only the **requestee** may accept/decline a `requested` edge.
+- **Self:** you cannot friend yourself.
+- **Visibility of details:** only `accepted` friends see each other's activity/timeline
+  (the friends-timeline audience). A merely-`requested` edge grants nothing.
+
+## The firewall / privacy note
+
+Sending a request by phone reveals only that *you* reached out; it does not expose the
+target's activity to you, nor yours to them, until accepted. Pending requests carry just
+identity (name/photo when available), never timeline content.
+
+## Principles
+
+**Inherited:**
+
+- [Private-first](../principles.md#private-first-public-never-touches-the-friends-surface) —
+  the accepted graph is the entire private surface's gate; nothing is shared on a one-sided edge.
+- [Preserve the social graph; archive the content](../principles.md#preserve-the-social-graph-archive-the-content)
+  — shells + claim-on-login mean a request survives until the invitee joins.
+
+## Local
+
+- **Double opt-in, decline ≠ block.** v2 keeps v1's mutual-confirmation model (no one-way
+  follows among friends; that's what communities are for). Declining simply leaves no edge;
+  it isn't a permanent block (a future plan may add blocking). Promote if blocking arrives.


### PR DESCRIPTION
Backend half of **v2-friends-and-onboarding** — onboarding profile-setup + in-app double-opt-in friend connections. No migration (the `friendship` table + status enum already exist).

## Endpoints
- **`PATCH /v1/me`** — update own profile name (only provided fields change; `first_name` must be non-empty). Pairs with the null-`first_name` ⇒ needs-onboarding signal.
- **`GET /v1/friends/requests`** — pending requests split into `incoming` / `outgoing`; `profile` is always the *other* party.
- **`POST /v1/friends/requests`** `{phone}` — send by phone. Resolves the phone → profile, **creating an unclaimed shell** if none (same mechanism as v1 migration, so the request waits for claim-on-login). One-edge-per-pair: idempotent re-send, and a reciprocal send **auto-accepts**. `201 requested` | `200 accepted`; `400 cannot_self_request`.
- **`PUT /v1/friends/requests/:id`** `{accept}` — requestee-only accept/decline; a non-requestee or already-resolved edge is `404` (indistinguishable from missing). Decline ≠ block — the pair can re-request.

## Tests
8 new (`test/friends.test.ts`): shell creation, incoming/outgoing split, accept connects both ways, reciprocal auto-accept (one edge), idempotent re-send, decline→re-request, requestee-only 404, self-request 400, PATCH sets/persists name + rejects blank. Full suite **36/36** green; `tsc --noEmit` clean.

Implements `specs/api/profile.md`, `specs/api/friends.md`, `specs/behaviors/friend-connections.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)