### PR TITLE
feat(app): friend connections + onboarding

### DIFF
--- a/app/lib/api/api_client.dart
+++ b/app/lib/api/api_client.dart
@@ -52,6 +52,9 @@ class ApiClient {
   Future<Map<String, dynamic>> put(String path, {Object? body}) =>
       _send(() => _dio.put(path, data: body));
 
+  Future<Map<String, dynamic>> patch(String path, {Object? body}) =>
+      _send(() => _dio.patch(path, data: body));
+
   Future<Map<String, dynamic>> delete(String path, {Object? body}) =>
       _send(() => _dio.delete(path, data: body));
 

--- a/app/lib/models/friend.dart
+++ b/app/lib/models/friend.dart
@@ -22,4 +22,46 @@ class Friend {
     photo: json['photo'] as String?,
     onV2: json['on_v2'] as bool? ?? false,
   );
+
+  String get displayName =>
+      [firstName, lastName].whereType<String>().join(' ').trim();
+}
+
+/// A pending connection request (specs/api/friends.md). `profile` is the *other*
+/// party — the sender for an incoming request, the target for an outgoing one.
+class FriendRequest {
+  const FriendRequest({
+    required this.id,
+    required this.profile,
+    this.createdAt,
+  });
+
+  final String id;
+  final Friend profile;
+  final DateTime? createdAt;
+
+  factory FriendRequest.fromJson(Map<String, dynamic> json) => FriendRequest(
+    id: json['id'] as String,
+    profile: Friend.fromJson(json['profile'] as Map<String, dynamic>),
+    createdAt: json['created_at'] == null
+        ? null
+        : DateTime.tryParse(json['created_at'] as String),
+  );
+}
+
+/// The caller's pending requests, split by direction.
+class FriendRequests {
+  const FriendRequests({this.incoming = const [], this.outgoing = const []});
+
+  final List<FriendRequest> incoming;
+  final List<FriendRequest> outgoing;
+
+  factory FriendRequests.fromJson(Map<String, dynamic> json) => FriendRequests(
+    incoming: ((json['incoming'] as List<dynamic>?) ?? const [])
+        .map((e) => FriendRequest.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    outgoing: ((json['outgoing'] as List<dynamic>?) ?? const [])
+        .map((e) => FriendRequest.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
 }

--- a/app/lib/providers/auth_controller.dart
+++ b/app/lib/providers/auth_controller.dart
@@ -74,6 +74,24 @@ class AuthController extends Notifier<AuthState> {
     state = SignedIn(result.profile);
   }
 
+  /// The signed-in profile, or null when not signed in.
+  Profile? get currentProfile => switch (state) {
+    SignedIn(:final profile) => profile,
+    _ => null,
+  };
+
+  /// Set/update the signed-in user's profile (onboarding name-setup + edits).
+  /// Swapping the profile drives the onboarding redirect (null first_name → /welcome).
+  Future<void> updateProfile({
+    required String firstName,
+    String? lastName,
+  }) async {
+    final updated = await ref
+        .read(profileRepositoryProvider)
+        .updateProfile(firstName: firstName, lastName: lastName);
+    state = SignedIn(updated);
+  }
+
   /// Return to the phone-entry step.
   void cancelOtp() => state = const SignedOut();
 

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -101,9 +101,14 @@ final topicsProvider = FutureProvider<List<Topic>>(
   (ref) => ref.watch(topicRepositoryProvider).list(),
 );
 
-/// The user's accepted friends (for squad member selection).
+/// The user's accepted friends (for squad member selection + the Friends screen).
 final friendsProvider = FutureProvider<List<Friend>>(
   (ref) => ref.watch(friendRepositoryProvider).list(),
+);
+
+/// Pending connection requests (incoming + outgoing) for the Friends screen.
+final friendRequestsProvider = FutureProvider<FriendRequests>(
+  (ref) => ref.watch(friendRepositoryProvider).requests(),
 );
 
 /// Communities to discover (all, with you_follow), optional search query.

--- a/app/lib/repositories/friend_repository.dart
+++ b/app/lib/repositories/friend_repository.dart
@@ -2,7 +2,18 @@ import '../api/api_client.dart';
 import '../models/friend.dart';
 
 abstract class FriendRepository {
+  /// The caller's accepted friends.
   Future<List<Friend>> list();
+
+  /// Pending connection requests involving the caller (incoming + outgoing).
+  Future<FriendRequests> requests();
+
+  /// Send a request by phone. Returns the resulting status:
+  /// `'requested'` or `'accepted'` (reciprocal/idempotent). See specs/api/friends.md.
+  Future<String> sendRequest(String phone);
+
+  /// Accept/decline an incoming request (requestee only).
+  Future<void> respond(String requestId, {required bool accept});
 }
 
 class ApiFriendRepository implements FriendRepository {
@@ -16,5 +27,26 @@ class ApiFriendRepository implements FriendRepository {
     return ((res['items'] as List<dynamic>?) ?? const [])
         .map((e) => Friend.fromJson(e as Map<String, dynamic>))
         .toList();
+  }
+
+  @override
+  Future<FriendRequests> requests() async =>
+      FriendRequests.fromJson(await apiClient.get('/v1/friends/requests'));
+
+  @override
+  Future<String> sendRequest(String phone) async {
+    final res = await apiClient.post(
+      '/v1/friends/requests',
+      body: {'phone': phone},
+    );
+    return res['status'] as String? ?? 'requested';
+  }
+
+  @override
+  Future<void> respond(String requestId, {required bool accept}) async {
+    await apiClient.put(
+      '/v1/friends/requests/$requestId',
+      body: {'accept': accept},
+    );
   }
 }

--- a/app/lib/repositories/profile_repository.dart
+++ b/app/lib/repositories/profile_repository.dart
@@ -3,6 +3,10 @@ import '../models/profile.dart';
 
 abstract class ProfileRepository {
   Future<Profile> me();
+
+  /// Update own profile (onboarding name-setup + later edits). Only non-null
+  /// fields are sent. See specs/api/profile.md.
+  Future<Profile> updateProfile({String? firstName, String? lastName});
 }
 
 class ApiProfileRepository implements ProfileRepository {
@@ -12,4 +16,13 @@ class ApiProfileRepository implements ProfileRepository {
 
   @override
   Future<Profile> me() async => Profile.fromJson(await apiClient.get('/v1/me'));
+
+  @override
+  Future<Profile> updateProfile({String? firstName, String? lastName}) async {
+    final body = <String, dynamic>{
+      'first_name': ?firstName,
+      'last_name': ?lastName,
+    };
+    return Profile.fromJson(await apiClient.patch('/v1/me', body: body));
+  }
 }

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -8,13 +8,16 @@ import 'providers/auth_controller.dart';
 import 'screens/activity/activity_detail_screen.dart';
 import 'screens/compose/compose_idea_screen.dart';
 import 'screens/communities/discover_screen.dart';
+import 'screens/friends/friends_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
 import 'screens/thread/thread_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
+import 'screens/welcome/welcome_screen.dart';
 
 /// Auth-gated router. Redirects to /login until signed in, to /splash while the
-/// persisted session resolves, and to / once signed in.
+/// persisted session resolves, to /welcome when a signed-in user still needs
+/// onboarding (null first_name), and to / once signed in + named.
 final routerProvider = Provider<GoRouter>((ref) {
   final refresh = ValueNotifier(0);
   ref.listen(authControllerProvider, (_, _) => refresh.value++);
@@ -28,13 +31,18 @@ final routerProvider = Provider<GoRouter>((ref) {
       final loc = state.matchedLocation;
       if (auth is AuthLoading) return loc == '/splash' ? null : '/splash';
       if (auth is! SignedIn) return loc == '/login' ? null : '/login';
-      if (loc == '/login' || loc == '/splash') return '/';
+      // Onboarding gate: a freshly-claimed/created profile has no name yet.
+      final needsName = auth.profile.firstName?.isEmpty ?? true;
+      if (needsName) return loc == '/welcome' ? null : '/welcome';
+      if (loc == '/login' || loc == '/splash' || loc == '/welcome') return '/';
       return null;
     },
     routes: [
       GoRoute(path: '/splash', builder: (_, _) => const _Splash()),
       GoRoute(path: '/login', builder: (_, _) => const LoginScreen()),
+      GoRoute(path: '/welcome', builder: (_, _) => const WelcomeScreen()),
       GoRoute(path: '/', builder: (_, _) => const TimelineScreen()),
+      GoRoute(path: '/friends', builder: (_, _) => const FriendsScreen()),
       GoRoute(
         path: '/ideas/new',
         builder: (_, state) =>

--- a/app/lib/screens/friends/friends_screen.dart
+++ b/app/lib/screens/friends/friends_screen.dart
@@ -1,0 +1,285 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/friend.dart';
+import '../../providers/providers.dart';
+
+/// The People screen: the accepted friend graph, pending connection requests
+/// (incoming accept/decline + outgoing), and add-by-phone. Double opt-in — see
+/// specs/behaviors/friend-connections.md + specs/api/friends.md.
+class FriendsScreen extends ConsumerWidget {
+  const FriendsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final friends = ref.watch(friendsProvider);
+    final requests = ref.watch(friendRequestsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('People')),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          ref.invalidate(friendsProvider);
+          ref.invalidate(friendRequestsProvider);
+          await Future.wait([
+            ref.read(friendsProvider.future),
+            ref.read(friendRequestsProvider.future),
+          ]);
+        },
+        child: ListView(
+          key: const Key('friendsList'),
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          children: [
+            const _AddByPhone(),
+            const Divider(height: 1),
+
+            // Incoming requests — actionable first.
+            ...requests.maybeWhen(
+              data: (r) => r.incoming.isEmpty
+                  ? const <Widget>[]
+                  : [
+                      const _SectionHeader('REQUESTS'),
+                      for (final req in r.incoming) _IncomingTile(req),
+                    ],
+              orElse: () => const <Widget>[],
+            ),
+
+            // Accepted friends.
+            const _SectionHeader('FRIENDS'),
+            friends.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (e, _) => Padding(
+                padding: const EdgeInsets.all(24),
+                child: Center(child: Text('Couldn\'t load friends.\n$e')),
+              ),
+              data: (list) => list.isEmpty
+                  ? const Padding(
+                      key: Key('friendsEmpty'),
+                      padding: EdgeInsets.fromLTRB(24, 16, 24, 16),
+                      child: Text(
+                        'No friends yet. Add someone by phone number above.',
+                        textAlign: TextAlign.center,
+                      ),
+                    )
+                  : Column(children: [for (final f in list) _FriendTile(f)]),
+            ),
+
+            // Outgoing (pending) requests.
+            ...requests.maybeWhen(
+              data: (r) => r.outgoing.isEmpty
+                  ? const <Widget>[]
+                  : [
+                      const _SectionHeader('PENDING'),
+                      for (final req in r.outgoing) _OutgoingTile(req),
+                    ],
+              orElse: () => const <Widget>[],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label);
+  final String label;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+    child: Text(
+      label,
+      style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+    ),
+  );
+}
+
+CircleAvatar _avatar(BuildContext context, String? name, {Color? color}) =>
+    CircleAvatar(
+      backgroundColor: color,
+      child: Text((name == null || name.isEmpty ? '?' : name).characters.first),
+    );
+
+class _FriendTile extends StatelessWidget {
+  const _FriendTile(this.friend);
+  final Friend friend;
+  @override
+  Widget build(BuildContext context) {
+    final name = friend.displayName;
+    return ListTile(
+      key: Key('friend_${friend.id}'),
+      leading: _avatar(context, name.isEmpty ? null : name),
+      title: Text(name.isEmpty ? 'Friend' : name),
+      subtitle: friend.onV2
+          ? null
+          : const Text('Not on SquadQuest yet · invited'),
+    );
+  }
+}
+
+class _IncomingTile extends ConsumerStatefulWidget {
+  const _IncomingTile(this.request);
+  final FriendRequest request;
+  @override
+  ConsumerState<_IncomingTile> createState() => _IncomingTileState();
+}
+
+class _IncomingTileState extends ConsumerState<_IncomingTile> {
+  bool _busy = false;
+
+  Future<void> _respond(bool accept) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(friendRepositoryProvider)
+          .respond(widget.request.id, accept: accept);
+      ref.invalidate(friendRequestsProvider);
+      if (accept) ref.invalidate(friendsProvider);
+    } catch (_) {
+      if (mounted) {
+        setState(() => _busy = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t respond. Try again.')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final name = widget.request.profile.displayName;
+    return ListTile(
+      key: Key('incoming_${widget.request.id}'),
+      leading: _avatar(
+        context,
+        name.isEmpty ? null : name,
+        color: Theme.of(context).colorScheme.secondaryContainer,
+      ),
+      title: Text(name.isEmpty ? 'Someone' : name),
+      subtitle: const Text('wants to connect'),
+      trailing: _busy
+          ? const SizedBox(
+              height: 20,
+              width: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  key: Key('decline_${widget.request.id}'),
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Decline',
+                  onPressed: () => _respond(false),
+                ),
+                IconButton(
+                  key: Key('accept_${widget.request.id}'),
+                  icon: const Icon(Icons.check),
+                  tooltip: 'Accept',
+                  onPressed: () => _respond(true),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _OutgoingTile extends StatelessWidget {
+  const _OutgoingTile(this.request);
+  final FriendRequest request;
+  @override
+  Widget build(BuildContext context) {
+    final name = request.profile.displayName;
+    return ListTile(
+      key: Key('outgoing_${request.id}'),
+      leading: _avatar(context, name.isEmpty ? null : name),
+      title: Text(name.isEmpty ? 'Invited' : name),
+      subtitle: const Text('Request sent'),
+      trailing: const Icon(Icons.schedule),
+    );
+  }
+}
+
+class _AddByPhone extends ConsumerStatefulWidget {
+  const _AddByPhone();
+  @override
+  ConsumerState<_AddByPhone> createState() => _AddByPhoneState();
+}
+
+class _AddByPhoneState extends ConsumerState<_AddByPhone> {
+  final _controller = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final phone = _controller.text.trim();
+    if (phone.isEmpty || _busy) return;
+    setState(() => _busy = true);
+    try {
+      final status = await ref
+          .read(friendRepositoryProvider)
+          .sendRequest(phone);
+      _controller.clear();
+      ref.invalidate(friendRequestsProvider);
+      if (status == 'accepted') ref.invalidate(friendsProvider);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              status == 'accepted' ? 'Connected!' : 'Request sent.',
+            ),
+          ),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t send. Check the number.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              key: const Key('addFriendPhoneField'),
+              controller: _controller,
+              keyboardType: TextInputType.phone,
+              textInputAction: TextInputAction.send,
+              onSubmitted: (_) => _send(),
+              decoration: const InputDecoration(
+                labelText: 'Add a friend by phone',
+                hintText: '+1 555 555 1000',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+            ),
+          ),
+          IconButton(
+            key: const Key('addFriendSend'),
+            icon: const Icon(Icons.person_add),
+            tooltip: 'Send request',
+            onPressed: _busy ? null : _send,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -42,6 +42,12 @@ class TimelineScreen extends ConsumerWidget {
         ),
         actions: [
           IconButton(
+            key: const Key('peopleButton'),
+            icon: const Icon(Icons.people_outline),
+            tooltip: 'People',
+            onPressed: () => context.push('/friends'),
+          ),
+          IconButton(
             key: const Key('logoutButton'),
             icon: const Icon(Icons.logout),
             tooltip: 'Sign out',

--- a/app/lib/screens/welcome/welcome_screen.dart
+++ b/app/lib/screens/welcome/welcome_screen.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/auth_controller.dart';
+
+/// Onboarding profile-setup: a freshly-claimed/created user (null first_name)
+/// sets their name before reaching the app. Saving swaps the signed-in profile,
+/// which clears the router's onboarding gate. See specs/api/profile.md +
+/// specs/screens/welcome-wizard.md (intro PageView copy is deferred styling).
+class WelcomeScreen extends ConsumerStatefulWidget {
+  const WelcomeScreen({super.key});
+
+  @override
+  ConsumerState<WelcomeScreen> createState() => _WelcomeScreenState();
+}
+
+class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
+  final _firstName = TextEditingController();
+  final _lastName = TextEditingController();
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _firstName.dispose();
+    _lastName.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final first = _firstName.text.trim();
+    if (first.isEmpty || _busy) {
+      setState(() => _error = 'Please enter your first name.');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final last = _lastName.text.trim();
+      await ref
+          .read(authControllerProvider.notifier)
+          .updateProfile(
+            firstName: first,
+            lastName: last.isEmpty ? null : last,
+          );
+      // The router redirect takes over once the profile has a name.
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _error = 'Couldn\'t save. Try again.';
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Welcome to SquadQuest')),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Column(
+                key: const Key('welcomeForm'),
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'What should friends call you?',
+                    style: Theme.of(context).textTheme.titleLarge,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Your name appears on the ideas and plans you share.',
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  TextField(
+                    key: const Key('firstNameField'),
+                    controller: _firstName,
+                    autofocus: true,
+                    textCapitalization: TextCapitalization.words,
+                    textInputAction: TextInputAction.next,
+                    decoration: const InputDecoration(
+                      labelText: 'First name',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    key: const Key('lastNameField'),
+                    controller: _lastName,
+                    textCapitalization: TextCapitalization.words,
+                    textInputAction: TextInputAction.done,
+                    onSubmitted: (_) => _save(),
+                    decoration: const InputDecoration(
+                      labelText: 'Last name (optional)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    key: const Key('welcomeContinue'),
+                    onPressed: _busy ? null : _save,
+                    child: _busy
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Continue'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/create_squad_test.dart
+++ b/app/test/create_squad_test.dart
@@ -11,6 +11,12 @@ class FakeFriendRepository implements FriendRepository {
   final List<Friend> _friends;
   @override
   Future<List<Friend>> list() async => _friends;
+  @override
+  Future<FriendRequests> requests() async => const FriendRequests();
+  @override
+  Future<String> sendRequest(String phone) async => 'requested';
+  @override
+  Future<void> respond(String requestId, {required bool accept}) async {}
 }
 
 void main() {

--- a/app/test/friends_screen_test.dart
+++ b/app/test/friends_screen_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/friend.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/friend_repository.dart';
+import 'package:squadquest/screens/friends/friends_screen.dart';
+
+/// In-memory fake: serves friends + requests, records sends/responses.
+class FakeFriendRepository implements FriendRepository {
+  FakeFriendRepository({
+    this.friends = const [],
+    this.incoming = const [],
+    this.outgoing = const [],
+  });
+
+  List<Friend> friends;
+  List<FriendRequest> incoming;
+  List<FriendRequest> outgoing;
+
+  String? sentPhone;
+  String? respondedId;
+  bool? respondedAccept;
+
+  @override
+  Future<List<Friend>> list() async => friends;
+
+  @override
+  Future<FriendRequests> requests() async =>
+      FriendRequests(incoming: incoming, outgoing: outgoing);
+
+  @override
+  Future<String> sendRequest(String phone) async {
+    sentPhone = phone;
+    return 'requested';
+  }
+
+  @override
+  Future<void> respond(String requestId, {required bool accept}) async {
+    respondedId = requestId;
+    respondedAccept = accept;
+  }
+}
+
+Widget _app(FakeFriendRepository fake) => ProviderScope(
+  overrides: [friendRepositoryProvider.overrideWithValue(fake)],
+  child: const MaterialApp(home: FriendsScreen()),
+);
+
+void main() {
+  testWidgets('renders accepted friends, incoming + outgoing requests', (
+    tester,
+  ) async {
+    final fake = FakeFriendRepository(
+      friends: const [Friend(id: 'f1', firstName: 'Katie', onV2: true)],
+      incoming: const [
+        FriendRequest(
+          id: 'r1',
+          profile: Friend(id: 'p1', firstName: 'Sam'),
+        ),
+      ],
+      outgoing: const [
+        FriendRequest(
+          id: 'r2',
+          profile: Friend(id: 'p2', firstName: 'Jordan'),
+        ),
+      ],
+    );
+    await tester.pumpWidget(_app(fake));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Katie'), findsOneWidget);
+    expect(find.byKey(const Key('incoming_r1')), findsOneWidget);
+    expect(find.text('Sam'), findsOneWidget);
+    expect(find.byKey(const Key('outgoing_r2')), findsOneWidget);
+    expect(find.text('Jordan'), findsOneWidget);
+  });
+
+  testWidgets('accepting an incoming request calls respond(accept:true)', (
+    tester,
+  ) async {
+    final fake = FakeFriendRepository(
+      incoming: const [
+        FriendRequest(
+          id: 'r1',
+          profile: Friend(id: 'p1', firstName: 'Sam'),
+        ),
+      ],
+    );
+    await tester.pumpWidget(_app(fake));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('accept_r1')));
+    // Don't pumpAndSettle: the tile shows a transient spinner while responding.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(fake.respondedId, 'r1');
+    expect(fake.respondedAccept, true);
+  });
+
+  testWidgets('add-by-phone sends a request with the entered number', (
+    tester,
+  ) async {
+    final fake = FakeFriendRepository();
+    await tester.pumpWidget(_app(fake));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('addFriendPhoneField')),
+      '+12155551000',
+    );
+    await tester.tap(find.byKey(const Key('addFriendSend')));
+    await tester.pumpAndSettle();
+
+    expect(fake.sentPhone, '+12155551000');
+  });
+
+  testWidgets('empty state when there are no friends', (tester) async {
+    final fake = FakeFriendRepository();
+    await tester.pumpWidget(_app(fake));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('friendsEmpty')), findsOneWidget);
+  });
+}

--- a/app/test/welcome_screen_test.dart
+++ b/app/test/welcome_screen_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/profile.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/profile_repository.dart';
+import 'package:squadquest/screens/welcome/welcome_screen.dart';
+
+/// Records the name passed to updateProfile and echoes back a named profile.
+class FakeProfileRepository implements ProfileRepository {
+  String? lastFirstName;
+  String? lastLastName;
+
+  @override
+  Future<Profile> me() async => const Profile(id: 'me');
+
+  @override
+  Future<Profile> updateProfile({String? firstName, String? lastName}) async {
+    lastFirstName = firstName;
+    lastLastName = lastName;
+    return Profile(id: 'me', firstName: firstName, lastName: lastName);
+  }
+}
+
+void main() {
+  testWidgets('entering a name calls updateProfile with the trimmed values', (
+    tester,
+  ) async {
+    final fake = FakeProfileRepository();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [profileRepositoryProvider.overrideWithValue(fake)],
+        child: const MaterialApp(home: WelcomeScreen()),
+      ),
+    );
+
+    expect(find.byKey(const Key('welcomeForm')), findsOneWidget);
+
+    await tester.enterText(find.byKey(const Key('firstNameField')), 'Chris');
+    await tester.enterText(find.byKey(const Key('lastNameField')), 'Alfano');
+    await tester.tap(find.byKey(const Key('welcomeContinue')));
+    // Don't pumpAndSettle: on success the button shows an indefinite spinner
+    // (the real app's router redirects away; there's no router here).
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(fake.lastFirstName, 'Chris');
+    expect(fake.lastLastName, 'Alfano');
+  });
+
+  testWidgets('a blank first name is rejected without calling the repo', (
+    tester,
+  ) async {
+    final fake = FakeProfileRepository();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [profileRepositoryProvider.overrideWithValue(fake)],
+        child: const MaterialApp(home: WelcomeScreen()),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('welcomeContinue')));
+    await tester.pumpAndSettle();
+
+    expect(fake.lastFirstName, isNull);
+    expect(find.text('Please enter your first name.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Client half of **v2-friends-and-onboarding** (backend landed in #425). Makes the people-graph self-serve and kills the nameless "Someone"/empty-face-pile artifact for real users.

## Onboarding gate
A signed-in user whose `first_name` is null is routed to a new **`/welcome`** profile-setup screen (first/last name → `PATCH /v1/me` → home). The router redirect derives this from the signed-in profile, so setting a name clears the gate automatically. (The 3-page intro PageView copy stays deferred styling.)

## People screen (`/friends`)
Reached from a new **people icon** on the timeline app bar:
- **Friends** — the accepted graph (carried/unclaimed friends flagged "not on SquadQuest yet · invited").
- **Requests** — incoming, with accept/decline.
- **Pending** — outgoing requests you've sent.
- **Add by phone** — sends a request; toast reflects `requested` vs reciprocal `accepted`.

## Plumbing
`FriendRepository` gains `requests()` / `sendRequest()` / `respond()`; `ProfileRepository` gains `updateProfile()`; `ApiClient` gains a `patch()` verb; `FriendRequest` / `FriendRequests` models; `friendRequestsProvider`; `AuthController.updateProfile` swaps the signed-in profile.

## Tests
16 widget tests green (welcome ×2, friends ×4, + updated fakes); `flutter analyze` clean.

Implements `specs/screens/welcome-wizard.md` (profile-setup), `specs/api/profile.md`, `specs/api/friends.md`, `specs/behaviors/friend-connections.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)