### PR TITLE
feat(server): community leader tooling

### DIFF
--- a/plans/v2-community-leader-tooling.md
+++ b/plans/v2-community-leader-tooling.md
@@ -1,0 +1,80 @@
+---
+status: in-progress
+depends: [v2-communities-core]
+specs:
+  - specs/api/communities.md
+  - specs/screens/communities.md
+issues: []
+pr:
+---
+
+# Plan: v2 community leader tooling
+
+## Scope
+
+Make communities **self-serve** instead of seed-only: let users **create** a community (the
+creator becomes its leader), **edit** it, and **post / edit / delete** its events — replacing
+the `seed-communities.ts` stand-in. Backend + client; styling deferred.
+
+**In:**
+
+- Backend: `POST /v1/communities` (creator → `leader`), `PATCH /v1/communities/:id`,
+  `POST /v1/communities/:id/events`, `PATCH`/`DELETE /v1/community-events/:id` — all
+  leader-gated; `your_role` on the community item. No migration (the `community_role` enum
+  - `community_membership.role` already exist).
+- Client: a "New community" entry on Discover → create form; leader-only **Post event** on a
+  community timeline + **edit community** title-bar action + event **edit/delete**; leader
+  controls gated on `your_role:"leader"`.
+
+**Out:** community **delete** (heavier — follower fan-out); leadership transfer / multi-leader
+invite; activity-type picker on events (optional field, deferred); photo/icon upload (storage).
+
+## Implements
+
+`specs/api/communities.md` (leader tooling section + `your_role`) and the leader actions in
+`specs/screens/communities.md`.
+
+## Approach
+
+- **Backend** (`server/`):
+  - `CommunityService`: `isLeader(communityId, profileId)`; `create` (insert community +
+    leader membership), `update` (leader-gated patch), `createEvent` / `updateEvent` /
+    `deleteEvent` (leader-gated). Thread `yourRole` through `discover`/`CommunitySummary`.
+  - routes `routes/v1/communities.ts` (extend) — `forbidden` via `errors.forbidden('forbidden', …)`.
+  - serializer: add `your_role` to `serializeCommunity`. Reuse `serializeCommunityEvent`.
+  - tests: create→leader, your_role surfaces, leader-only 403 on edit/post/delete, edits
+    persist, delete cascades RSVPs.
+- **Client** (`app/`):
+  - `Community` model gains `yourRole`; `CommunityRepository` gains create/update +
+    createEvent/updateEvent/deleteEvent; providers invalidate on mutate.
+  - Discover screen: "New community" → `CreateCommunityScreen` (name/tagline/icon/color) →
+    switch context to it.
+  - Community timeline (`_CommunityBody`): leader sees a **Post event** affordance (→
+    `CreateEventScreen`) instead of the follower banner; app-bar **edit community**; event
+    cards get edit/delete (leader only).
+
+## Validation
+
+- [ ] `bun run type-check` + `bun test` (create makes leader + your_role; non-leader 403 on
+      patch/post-event/patch-event/delete; edits persist; delete cascades RSVPs) green; CI.
+- [ ] client `flutter analyze` + widget tests (create-community form posts; leader sees Post
+      event, follower sees banner; post-event form) green; CI.
+- [ ] (machine free) MCP: create a community → become leader → post an event → it appears on
+      the timeline; a second account sees it as a plain follower (no leader controls).
+
+## Risks / unknowns
+
+- Leader vs follow interplay: leadership is a `role:"leader"` membership; **unfollow must not
+  strip leadership** (guard `toggleFollow`).
+- `your_role` plumbing through the existing `discover`/`myCommunities` aggregation without an
+  extra query per community.
+- Event edit/delete affordance placement on the card without crowding the RSVP gradient —
+  keep it a leader-only overflow menu.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/server/src/contracts/community.ts
+++ b/server/src/contracts/community.ts
@@ -10,6 +10,7 @@ export function serializeCommunity(s: CommunitySummary) {
     color: s.community.color,
     follower_count: s.followerCount,
     you_follow: s.youFollow,
+    your_role: s.yourRole === 'leader' ? 'leader' : null,
   }
 }
 

--- a/server/src/domain/community/service.ts
+++ b/server/src/domain/community/service.ts
@@ -22,6 +22,7 @@ export interface CommunitySummary {
   community: CommunityRow
   followerCount: number
   youFollow: boolean
+  yourRole: 'leader' | 'follower' | null
 }
 
 export interface EventView {
@@ -57,16 +58,80 @@ export class CommunityService {
       .where(inArray(communityMembership.communityId, ids))
 
     const followerCount = new Map<string, number>()
-    const youFollow = new Set<string>()
+    const yourRole = new Map<string, 'leader' | 'follower'>()
     for (const m of memberships) {
       followerCount.set(m.communityId, (followerCount.get(m.communityId) ?? 0) + 1)
-      if (m.profileId === viewerId) youFollow.add(m.communityId)
+      if (m.profileId === viewerId) yourRole.set(m.communityId, m.role)
     }
     return rows.map((c) => ({
       community: c,
       followerCount: followerCount.get(c.id) ?? 0,
-      youFollow: youFollow.has(c.id),
+      youFollow: yourRole.has(c.id),
+      yourRole: yourRole.get(c.id) ?? null,
     }))
+  }
+
+  // A single community as the viewer sees it (follower count + their role).
+  private async summary(viewerId: string, communityId: string): Promise<CommunitySummary> {
+    const [c] = await this.db.select().from(community).where(eq(community.id, communityId))
+    if (!c) throw new ApiError(404, 'not_found', 'Community not found')
+    const members = await this.db
+      .select()
+      .from(communityMembership)
+      .where(eq(communityMembership.communityId, communityId))
+    const mine = members.find((m) => m.profileId === viewerId)
+    return {
+      community: c,
+      followerCount: members.length,
+      youFollow: !!mine,
+      yourRole: mine?.role ?? null,
+    }
+  }
+
+  async isLeader(communityId: string, profileId: string): Promise<boolean> {
+    const [m] = await this.db
+      .select()
+      .from(communityMembership)
+      .where(
+        and(
+          eq(communityMembership.communityId, communityId),
+          eq(communityMembership.profileId, profileId),
+        ),
+      )
+    return m?.role === 'leader'
+  }
+
+  // Create a community; the creator becomes its first leader (and a follower).
+  async create(
+    creatorId: string,
+    input: { name: string; tagline?: string; icon?: string; color?: string },
+  ): Promise<CommunitySummary> {
+    const [c] = await this.db
+      .insert(community)
+      .values({
+        name: input.name,
+        tagline: input.tagline ?? null,
+        icon: input.icon ?? null,
+        color: input.color ?? null,
+      })
+      .returning()
+    await this.db
+      .insert(communityMembership)
+      .values({ communityId: c!.id, profileId: creatorId, role: 'leader' })
+    return this.summary(creatorId, c!.id)
+  }
+
+  // Edit a community. Leader-only.
+  async update(
+    viewerId: string,
+    communityId: string,
+    patch: { name?: string; tagline?: string | null; icon?: string | null; color?: string | null },
+  ): Promise<CommunitySummary> {
+    await this.assertLeader(communityId, viewerId)
+    if (Object.keys(patch).length > 0) {
+      await this.db.update(community).set(patch).where(eq(community.id, communityId))
+    }
+    return this.summary(viewerId, communityId)
   }
 
   async myCommunities(viewerId: string): Promise<CommunitySummary[]> {
@@ -93,7 +158,8 @@ export class CommunityService {
         .insert(communityMembership)
         .values({ communityId, profileId: viewerId, role: 'follower' })
         .onConflictDoNothing()
-    } else {
+    } else if (!(await this.isLeader(communityId, viewerId))) {
+      // Unfollowing never strips leadership — a leader stays a member.
       await this.db
         .delete(communityMembership)
         .where(
@@ -103,11 +169,96 @@ export class CommunityService {
           ),
         )
     }
-    const [{ count }] = await this.db
-      .select({ count: sql<number>`count(*)::int` })
+    const members = await this.db
+      .select()
       .from(communityMembership)
       .where(eq(communityMembership.communityId, communityId))
-    return { youFollow: follow, followerCount: count }
+    const youFollow = members.some((m) => m.profileId === viewerId)
+    return { youFollow, followerCount: members.length }
+  }
+
+  private async assertLeader(communityId: string, profileId: string): Promise<void> {
+    if (!(await this.isLeader(communityId, profileId))) {
+      throw new ApiError(403, 'forbidden', 'Only a leader can do that')
+    }
+  }
+
+  // Author a born-confirmed event on the community. Leader-only.
+  async createEvent(
+    viewerId: string,
+    communityId: string,
+    input: {
+      title: string
+      activityTypeId?: string | null
+      time?: string | null
+      recurrence?: string | null
+      location?: string | null
+    },
+  ): Promise<EventView> {
+    await this.assertLeader(communityId, viewerId)
+    const [ev] = await this.db
+      .insert(communityEvent)
+      .values({
+        communityId,
+        title: input.title,
+        activityTypeId: input.activityTypeId ?? null,
+        time: input.time ?? null,
+        recurrence: input.recurrence ?? null,
+        location: input.location ?? null,
+      })
+      .returning()
+    return this.eventView(viewerId, ev!.id)
+  }
+
+  // Edit an event. Leader-only (of the owning community).
+  async updateEvent(
+    viewerId: string,
+    eventId: string,
+    patch: {
+      title?: string
+      activityTypeId?: string | null
+      time?: string | null
+      recurrence?: string | null
+      location?: string | null
+    },
+  ): Promise<EventView> {
+    const [ev] = await this.db
+      .select()
+      .from(communityEvent)
+      .where(eq(communityEvent.id, eventId))
+    if (!ev) throw new ApiError(404, 'not_found', 'Event not found')
+    await this.assertLeader(ev.communityId, viewerId)
+    const set = Object.fromEntries(
+      Object.entries(patch).filter(([, v]) => v !== undefined),
+    )
+    if (Object.keys(set).length > 0) {
+      await this.db.update(communityEvent).set(set).where(eq(communityEvent.id, eventId))
+    }
+    return this.eventView(viewerId, eventId)
+  }
+
+  // Cancel an event (cascades its RSVPs). Leader-only.
+  async deleteEvent(viewerId: string, eventId: string): Promise<void> {
+    const [ev] = await this.db
+      .select()
+      .from(communityEvent)
+      .where(eq(communityEvent.id, eventId))
+    if (!ev) throw new ApiError(404, 'not_found', 'Event not found')
+    await this.assertLeader(ev.communityId, viewerId)
+    await this.db.delete(communityEvent).where(eq(communityEvent.id, eventId))
+  }
+
+  // A single event as the viewer sees it.
+  private async eventView(viewerId: string, eventId: string): Promise<EventView> {
+    const [ev] = await this.db
+      .select()
+      .from(communityEvent)
+      .where(eq(communityEvent.id, eventId))
+    if (!ev) throw new ApiError(404, 'not_found', 'Event not found')
+    const [view] = (await this.events(viewerId, ev.communityId)).filter(
+      (v) => v.event.id === eventId,
+    )
+    return view!
   }
 
   async events(viewerId: string, communityId: string): Promise<EventView[]> {

--- a/server/src/routes/v1/communities.ts
+++ b/server/src/routes/v1/communities.ts
@@ -6,8 +6,8 @@ import {
   serializeCommunityEvent,
 } from '../../contracts/community.ts'
 
-// Communities: open, followable groups; followers discover/follow/RSVP. Leader
-// tooling (create/edit, post events) is deferred. See specs/api/communities.md.
+// Communities: open, followable groups. Followers discover/follow/RSVP; leaders
+// create/edit communities and post/edit/delete events. See specs/api/communities.md.
 const communityRoutes: FastifyPluginAsync = async (fastify) => {
   const communities = new CommunityService(fastify.db)
 
@@ -17,6 +17,155 @@ const communityRoutes: FastifyPluginAsync = async (fastify) => {
     async (request) => {
       const items = await communities.discover(request.profileId!, request.query.search)
       return { items: items.map(serializeCommunity) }
+    },
+  )
+
+  // Create a community — the caller becomes its first leader.
+  fastify.post<{
+    Body: { name: string; tagline?: string; icon?: string; color?: string }
+  }>(
+    '/communities',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: { type: 'string', minLength: 1 },
+            tagline: { type: 'string' },
+            icon: { type: 'string' },
+            color: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const summary = await communities.create(request.profileId!, request.body)
+      reply.code(201)
+      return serializeCommunity(summary)
+    },
+  )
+
+  // Edit a community — leader-only.
+  fastify.patch<{
+    Params: { id: string }
+    Body: { name?: string; tagline?: string; icon?: string; color?: string }
+  }>(
+    '/communities/:id',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', minLength: 1 },
+            tagline: { type: 'string' },
+            icon: { type: 'string' },
+            color: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const summary = await communities.update(
+        request.profileId!,
+        request.params.id,
+        request.body,
+      )
+      return serializeCommunity(summary)
+    },
+  )
+
+  // Post an event — leader-only.
+  fastify.post<{
+    Params: { id: string }
+    Body: {
+      title: string
+      activity_type_id?: string
+      time?: string
+      recurrence?: string
+      location?: string
+    }
+  }>(
+    '/communities/:id/events',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['title'],
+          properties: {
+            title: { type: 'string', minLength: 1 },
+            activity_type_id: { type: 'string' },
+            time: { type: 'string' },
+            recurrence: { type: 'string' },
+            location: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const view = await communities.createEvent(request.profileId!, request.params.id, {
+        title: request.body.title,
+        activityTypeId: request.body.activity_type_id,
+        time: request.body.time,
+        recurrence: request.body.recurrence,
+        location: request.body.location,
+      })
+      const c = await communities.get(view.event.communityId)
+      reply.code(201)
+      return serializeCommunityEvent(view, c)
+    },
+  )
+
+  // Edit an event — leader-only.
+  fastify.patch<{
+    Params: { id: string }
+    Body: {
+      title?: string
+      activity_type_id?: string
+      time?: string
+      recurrence?: string
+      location?: string
+    }
+  }>(
+    '/community-events/:id',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', minLength: 1 },
+            activity_type_id: { type: 'string' },
+            time: { type: 'string' },
+            recurrence: { type: 'string' },
+            location: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const view = await communities.updateEvent(request.profileId!, request.params.id, {
+        title: request.body.title,
+        activityTypeId: request.body.activity_type_id,
+        time: request.body.time,
+        recurrence: request.body.recurrence,
+        location: request.body.location,
+      })
+      const c = await communities.get(view.event.communityId)
+      return serializeCommunityEvent(view, c)
+    },
+  )
+
+  // Cancel an event — leader-only.
+  fastify.delete<{ Params: { id: string } }>(
+    '/community-events/:id',
+    { preHandler: fastify.authenticate },
+    async (request, reply) => {
+      await communities.deleteEvent(request.profileId!, request.params.id)
+      reply.code(204)
     },
   )
 

--- a/server/test/community-leader.test.ts
+++ b/server/test/community-leader.test.ts
@@ -1,0 +1,254 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL ??=
+  'postgres://squadquest:squadquest@localhost:5532/squadquest_v2'
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+process.env.MIN_SUPPORTED_BUILD = '0'
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  return { id: row.id, auth: { authorization: `Bearer ${server.signAccessToken(row.id)}` } }
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  await server.sql`truncate community, community_membership, community_event, community_event_rsvp, profile cascade`
+})
+
+test('creating a community makes you its leader; others see your_role null', async () => {
+  const leader = await makeUser('+12150010000')
+  const other = await makeUser('+12150010001')
+
+  const created = await server.inject({
+    method: 'POST',
+    url: '/v1/communities',
+    headers: leader.auth,
+    payload: { name: 'Wednesday Night Rides', tagline: 'ride bikes', icon: '🚲' },
+  })
+  expect(created.statusCode).toBe(201)
+  expect(created.json()).toMatchObject({
+    name: 'Wednesday Night Rides',
+    you_follow: true,
+    your_role: 'leader',
+    follower_count: 1,
+  })
+  const cid = created.json().id
+
+  // The leader sees their role in discover; a stranger sees null.
+  const leaderList = (
+    await server.inject({ method: 'GET', url: '/v1/communities', headers: leader.auth })
+  ).json().items;
+  expect(leaderList.find((c: { id: string }) => c.id === cid).your_role).toBe('leader')
+
+  const otherList = (
+    await server.inject({ method: 'GET', url: '/v1/communities', headers: other.auth })
+  ).json().items;
+  expect(otherList.find((c: { id: string }) => c.id === cid).your_role).toBeNull()
+})
+
+test('leader can edit the community; a non-leader gets 403', async () => {
+  const leader = await makeUser('+12150010010')
+  const other = await makeUser('+12150010011')
+  const cid = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/communities',
+      headers: leader.auth,
+      payload: { name: 'Trail Club' },
+    })
+  ).json().id
+
+  const edited = await server.inject({
+    method: 'PATCH',
+    url: `/v1/communities/${cid}`,
+    headers: leader.auth,
+    payload: { tagline: 'trail running + social' },
+  })
+  expect(edited.statusCode).toBe(200)
+  expect(edited.json().tagline).toBe('trail running + social')
+
+  const forbidden = await server.inject({
+    method: 'PATCH',
+    url: `/v1/communities/${cid}`,
+    headers: other.auth,
+    payload: { name: 'Hijacked' },
+  })
+  expect(forbidden.statusCode).toBe(403)
+  expect(forbidden.json().error.code).toBe('forbidden')
+})
+
+test('leader posts an event; it appears on the timeline; non-leader cannot post', async () => {
+  const leader = await makeUser('+12150010020')
+  const other = await makeUser('+12150010021')
+  const cid = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/communities',
+      headers: leader.auth,
+      payload: { name: 'River Flow' },
+    })
+  ).json().id
+
+  const posted = await server.inject({
+    method: 'POST',
+    url: `/v1/communities/${cid}/events`,
+    headers: leader.auth,
+    payload: {
+      title: 'Morning Paddle',
+      time: 'Sun · 9am',
+      recurrence: 'Every Sun',
+      location: "Bartram's Dock",
+    },
+  })
+  expect(posted.statusCode).toBe(201)
+  expect(posted.json()).toMatchObject({
+    title: 'Morning Paddle',
+    recurrence: 'Every Sun',
+    going_count: 0,
+  })
+
+  const events = (
+    await server.inject({
+      method: 'GET',
+      url: `/v1/communities/${cid}/events`,
+      headers: other.auth,
+    })
+  ).json().items
+  expect(events).toHaveLength(1)
+  expect(events[0].title).toBe('Morning Paddle')
+
+  // A follower (non-leader) cannot post.
+  const forbidden = await server.inject({
+    method: 'POST',
+    url: `/v1/communities/${cid}/events`,
+    headers: other.auth,
+    payload: { title: 'Sneaky Event' },
+  })
+  expect(forbidden.statusCode).toBe(403)
+})
+
+test('leader edits + deletes an event (cascading RSVPs); non-leader is blocked', async () => {
+  const leader = await makeUser('+12150010030')
+  const other = await makeUser('+12150010031')
+  const cid = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/communities',
+      headers: leader.auth,
+      payload: { name: 'Night Rides' },
+    })
+  ).json().id
+  const eid = (
+    await server.inject({
+      method: 'POST',
+      url: `/v1/communities/${cid}/events`,
+      headers: leader.auth,
+      payload: { title: 'Cherry Blossoms Ride', time: 'Wed · 6:30pm' },
+    })
+  ).json().id
+
+  // Someone RSVPs.
+  await server.inject({
+    method: 'PUT',
+    url: `/v1/community-events/${eid}/rsvp`,
+    headers: other.auth,
+    payload: { going: true },
+  })
+
+  // Edit (leader).
+  const edited = await server.inject({
+    method: 'PATCH',
+    url: `/v1/community-events/${eid}`,
+    headers: leader.auth,
+    payload: { title: 'Cherry Blossoms Ride (rescheduled)' },
+  })
+  expect(edited.statusCode).toBe(200)
+  expect(edited.json().title).toBe('Cherry Blossoms Ride (rescheduled)')
+
+  // Non-leader cannot edit or delete.
+  expect(
+    (
+      await server.inject({
+        method: 'PATCH',
+        url: `/v1/community-events/${eid}`,
+        headers: other.auth,
+        payload: { title: 'nope' },
+      })
+    ).statusCode,
+  ).toBe(403)
+  expect(
+    (
+      await server.inject({
+        method: 'DELETE',
+        url: `/v1/community-events/${eid}`,
+        headers: other.auth,
+      })
+    ).statusCode,
+  ).toBe(403)
+
+  // Delete (leader) → 204; event + its RSVPs gone.
+  const deleted = await server.inject({
+    method: 'DELETE',
+    url: `/v1/community-events/${eid}`,
+    headers: leader.auth,
+  })
+  expect(deleted.statusCode).toBe(204)
+  const events = (
+    await server.inject({
+      method: 'GET',
+      url: `/v1/communities/${cid}/events`,
+      headers: leader.auth,
+    })
+  ).json().items
+  expect(events).toHaveLength(0)
+  const [{ count }] = await server.sql<{ count: number }[]>`
+    select count(*)::int as count from community_event_rsvp where event_id = ${eid}`
+  expect(count).toBe(0)
+})
+
+test('a leader unfollowing keeps their leadership (no-op)', async () => {
+  const leader = await makeUser('+12150010040')
+  const cid = (
+    await server.inject({
+      method: 'POST',
+      url: '/v1/communities',
+      headers: leader.auth,
+      payload: { name: 'Persistent Club' },
+    })
+  ).json().id
+
+  const unfollow = await server.inject({
+    method: 'PUT',
+    url: `/v1/communities/${cid}/follow`,
+    headers: leader.auth,
+    payload: { follow: false },
+  })
+  // Still a member (leadership implies following).
+  expect(unfollow.json()).toEqual({ you_follow: true, follower_count: 1 })
+
+  // Can still post events.
+  expect(
+    (
+      await server.inject({
+        method: 'POST',
+        url: `/v1/communities/${cid}/events`,
+        headers: leader.auth,
+        payload: { title: 'Still leading' },
+      })
+    ).statusCode,
+  ).toBe(201)
+})

--- a/specs/api/communities.md
+++ b/specs/api/communities.md
@@ -10,7 +10,9 @@ Authenticated.
 
 List/discover communities. `?search=`, cursor-paginated.
 
-- **Item:** `{ "id", "name", "tagline", "icon", "color", "follower_count", "you_follow": bool }`.
+- **Item:** `{ "id", "name", "tagline", "icon", "color", "follower_count", "you_follow": bool, "your_role": "leader" | null }`.
+- `your_role:"leader"` means the caller may post/edit this community's events (drives the
+  client's leader controls). It implies `you_follow:true`. A plain follower has `your_role:null`.
 
 ## PUT /v1/communities/:id/follow
 
@@ -52,11 +54,49 @@ Set the caller's attendance — the **visibility gradient**.
 - A separate explicit act is required to go from counted-anonymous to public — the API
   never sets `public` as a side effect of anything else.
 
-## Leader-only (deferred to a later plan)
+## Leader tooling
 
-Creating/editing communities and posting/scheduling events is **leader tooling**, not in
-the first contract. Noted here so the read/RSVP/follow surface is understood as
-follower-facing. Tracked as a follow-up.
+Creating/editing communities and posting events. **Creating a community makes you its first
+leader**; only a leader may edit the community or author/edit/delete its events. Leadership is
+a `community_membership` with `role:"leader"` (it also counts as following).
+
+### POST /v1/communities
+
+Create a community; the caller becomes its `leader` (and a follower).
+
+- **Request:** `{ "name": "…", "tagline"?, "icon"?, "color"? }` — `name` non-empty.
+- **Response:** `201 <community item>` with `you_follow:true`, `your_role:"leader"`.
+
+### PATCH /v1/communities/:id
+
+Edit a community. **Leader-only** (non-leader → `403 forbidden`).
+
+- **Request:** `{ "name"?, "tagline"?, "icon"?, "color"? }` — only provided fields change;
+  `name` non-empty when present.
+- **Response:** `200 <community item>`.
+
+### POST /v1/communities/:id/events
+
+Author a born-confirmed event on the community. **Leader-only** (non-leader → `403`).
+
+- **Request:** `{ "title": "…", "activity_type_id"?, "time"?, "recurrence"?, "location"? }` —
+  `title` non-empty; `time`/`recurrence`/`location` are display strings (see data-model).
+- **Response:** `201 <community_event>` (zeroed counts, empty face-pile).
+
+### PATCH /v1/community-events/:id
+
+Edit an event. **Leader-only** (of the owning community; otherwise `403`).
+
+- **Request:** `{ "title"?, "activity_type_id"?, "time"?, "recurrence"?, "location"? }` — only
+  provided fields change; `title` non-empty when present.
+- **Response:** `200 <community_event>`.
+
+### DELETE /v1/community-events/:id
+
+Cancel an event (cascades its RSVPs). **Leader-only** (otherwise `403`).
+
+- **Response:** `204`. Brought-along friends' ideas keep their own life; the `event_ref` they
+  embedded simply no longer resolves (tolerant-reader — the idea still shows).
 
 ## Notes
 

--- a/specs/screens/communities.md
+++ b/specs/screens/communities.md
@@ -24,6 +24,9 @@ Title bar shows the community icon + name, tappable to switch context.
   The gap between them is intentional and reassuring.
 - The input area is **replaced by a read-only follower banner** ("Following · only leaders
   post events here") — followers don't post to the community timeline.
+- **For a leader** (`your_role:"leader"`), the follower banner is replaced by a **"Post event"**
+  affordance, and the title bar exposes an **edit-community** action. Leader-authored event
+  cards carry **edit/delete** affordances. A non-leader never sees these.
 
 ## Actions
 
@@ -34,8 +37,15 @@ Title bar shows the community icon + name, tappable to switch context.
 - **Bring friends:** opens the idea composer pre-filled with the event (switches to My
   Friends), posting a friends-scoped idea referencing it. See
   [bring-friends-bridge](../behaviors/bring-friends-bridge.md).
-- **Follow / unfollow** the community.
+- **Follow / unfollow** the community. (A leader stays a member — unfollow never strips
+  leadership.)
 - **Open an event** → thread (chat + RSVP in header). [thread-drawer](../behaviors/thread-drawer.md).
+- **Leader — create a community:** from Discover, a "New community" entry opens a create form
+  (`POST /v1/communities`); on success the new community becomes the active context, with the
+  caller as leader. `screens/discover-communities` hosts the entry.
+- **Leader — post / edit / delete events** and **edit the community** (`POST`/`PATCH`/`DELETE`
+  per [`api/communities.md`](../api/communities.md)). These affordances appear only when
+  `your_role:"leader"`.
 
 ## Navigation
 


### PR DESCRIPTION
Backend half of **v2-community-leader-tooling** — makes communities self-serve instead of seed-only. No migration (the `community_role` enum + `community_membership.role` already exist).

## Endpoints (all leader-gated where noted)
- **`POST /v1/communities`** `{name, tagline?, icon?, color?}` — create; the caller becomes the first **leader** (a `role:"leader"` membership, which also follows). `201` with `you_follow:true, your_role:"leader"`.
- **`PATCH /v1/communities/:id`** — edit community. Leader-only (`403` otherwise).
- **`POST /v1/communities/:id/events`** `{title, activity_type_id?, time?, recurrence?, location?}` — post a born-confirmed event. Leader-only, `201`.
- **`PATCH /v1/community-events/:id`** — edit event. Leader-only.
- **`DELETE /v1/community-events/:id`** — cancel event, cascades RSVPs. Leader-only, `204`.

`your_role:"leader"|null` now rides on the community item (`GET /v1/communities`) so the client knows when to show leader controls. `isLeader`/`assertLeader` guards; **unfollow never strips leadership** (a leader stays a member).

## Tests
5 new (`test/community-leader.test.ts`): create→leader + your_role visibility, leader edit vs non-leader 403, post event + non-leader 403, edit/delete event (cascade) + non-leader blocked, leader-unfollow no-op. Full suite **41/41**; `tsc --noEmit` clean.

Implements `specs/api/communities.md` (leader tooling section + `your_role`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)