### PR TITLE
chore(dev): per-worktree backend ports

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,16 +35,20 @@ public events reintroduced only inside opt-in Communities.
 ### Local dev (`bin/` scripts)
 
 A single shared Postgres container (`squadquest-v2-postgres`, host port 5532) hosts a
-**separate database per context**, so nothing clobbers anything:
+**separate database per context**, and `bin/dev` picks a **free backend port per context**, so
+many worktrees run concurrently without clobbering each other:
 
-- **Main worktree** → `squadquest_v2` (your canonical dev data).
-- **Each agent worktree** → `sq_<hash>` (isolated; many worktrees run at once).
+- **Main worktree** → `squadquest_v2` (your canonical dev data), backend on `4000`.
+- **Each agent worktree** → `sq_<hash>` (isolated), backend on the next free port (`4001-4099`).
 - **The test runner** → `squadquest_test` — so `bun test` **never** touches your dev data.
+
+`bin/dev`/`bin/setup` print the chosen `PORT`; point the Flutter app at it with
+`--dart-define=API_BASE_URL=http://localhost:<PORT>`. Override with `PORT=…`.
 
 | Script | Does |
 |---|---|
-| `bin/setup` | ensure container + this context's DB + `bun install` + migrate |
-| `bin/dev` | run the backend with an auto-derived `DATABASE_URL` |
+| `bin/setup` | ensure container + this context's DB + `bun install` + migrate; prints `PORT` |
+| `bin/dev` | run the backend on an auto-picked free port with an auto-derived `DATABASE_URL` |
 | `bin/test` | run the server suite against `squadquest_test` (ensures + migrates first) |
 | `bin/reset-db` | drop + recreate + migrate this context's DB |
 | `bin/db "SQL"` | run SQL (or open psql) against this context's DB |

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -25,6 +25,61 @@ sq_pg_port() {
   echo "${SQ_PG_PORT:-5532}"
 }
 
+# Is a TCP port already being listened on? Uses lsof on macOS, ss on Linux —
+# `ss` does NOT exist on macOS and fails *silently*, which would make every port
+# look free and let concurrent worktrees collide on the same port. If neither
+# tool is present we assume "in use" so we skip the port rather than double-bind.
+port_in_use() {
+  if command -v lsof &>/dev/null; then
+    lsof -iTCP:"$1" -sTCP:LISTEN -P -n &>/dev/null
+  elif command -v ss &>/dev/null; then
+    ss -tlnp 2>/dev/null | grep -q ":$1 "
+  else
+    return 0
+  fi
+}
+
+# First free port in [start, end]. Always scans from the default so the main
+# worktree's port is reused when free (rather than skipped).
+find_available_port() {
+  local start="${1:-4001}" end="${2:-4099}" port
+  for port in $(seq "$start" "$end"); do
+    if ! port_in_use "$port"; then
+      echo "$port"
+      return
+    fi
+  done
+  echo "ERROR: no available backend port in range ${start}-${end}" >&2
+  return 1
+}
+
+# The backend port for this context:
+#   PORT set        → that port (orchestrator/explicit wins)
+#   port 4000 free  → 4000 (the canonical default; reused whenever available)
+#   otherwise       → first free port in 4001-4099 (concurrent worktrees)
+# Scanning always starts at 4000 so we never skip it just because we're in a
+# worktree — collisions are detected by actual listen-state, not worktree identity.
+sq_pick_port() {
+  if [ -n "${PORT:-}" ]; then
+    echo "$PORT"
+    return
+  fi
+  if ! port_in_use 4000; then
+    echo "4000"
+    return
+  fi
+  find_available_port 4001 4099
+}
+
+# Portable 8-char hex hash of a string (md5sum on Linux/coreutils, md5 on BSD/macOS).
+sq_hash() {
+  if command -v md5sum &>/dev/null; then
+    echo -n "$1" | md5sum | head -c 8
+  else
+    echo -n "$1" | md5 -q | head -c 8
+  fi
+}
+
 # Portable 8-char hex hash of a string (md5sum on Linux/coreutils, md5 on BSD/macOS).
 sq_hash() {
   if command -v md5sum &>/dev/null; then

--- a/bin/dev
+++ b/bin/dev
@@ -3,8 +3,11 @@
 #
 # Usage: bin/dev
 #
-# Env overrides: DATABASE_URL, PORT (default 4000), SQ_DATABASE, SQ_PG_PORT.
+# Env overrides: DATABASE_URL, PORT, SQ_DATABASE, SQ_PG_PORT.
+# Port defaults to 4000 if free, else the next free port in 4001-4099 — so a
+# second worktree's backend doesn't collide with the first. Override with PORT.
 # The Flutter app is run separately: cd app && flutter run
+#   (point it at this backend with --dart-define=API_BASE_URL=http://localhost:<PORT>)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
@@ -14,8 +17,10 @@ if [ -z "${DATABASE_URL:-}" ]; then
   DATABASE_URL="$(sq_database_url)"
 fi
 
-echo "Backend:      http://localhost:${PORT:-4000}" >&2
+PORT="$(sq_pick_port)"
+
+echo "Backend:      http://localhost:${PORT}" >&2
 echo "DATABASE_URL: ${DATABASE_URL}" >&2
 
 cd "$(sq_server_dir)"
-exec env DATABASE_URL="$DATABASE_URL" PORT="${PORT:-4000}" bun run dev
+exec env DATABASE_URL="$DATABASE_URL" PORT="$PORT" bun run dev

--- a/bin/setup
+++ b/bin/setup
@@ -32,7 +32,7 @@ fi
 url="$(sq_database_url)"
 sq_migrate "$url"
 
-# 6. Emit env for orchestrators
+# 6. Emit env for orchestrators (PORT is this context's free backend port)
 echo "DATABASE_URL=${url}"
 echo "SQ_DATABASE=${db}"
-echo "PORT=${PORT:-4000}"
+echo "PORT=$(sq_pick_port)"


### PR DESCRIPTION
Follow-up to #431 — the `bin/` system isolated databases per worktree but the backend still hard-coded port 4000, so two worktrees' APIs collided. Now `bin/dev` picks a free port per context.

- **Port picking:** `sq_pick_port` → `PORT` if set, else `4000` when free (canonical default, reused whenever available), else next free in `4001-4099`. `bin/setup` prints the chosen `PORT` for orchestrators.
- **macOS-safe detection:** `port_in_use` uses `lsof` on macOS / `ss` on Linux. `ss` doesn't exist on macOS and fails *silently* — which would make every port read "free" and let concurrent worktrees (e.g. under Conductor) all collide. This is the exact bug the jarvus-hq origin hit; pre-empted here. Scanning always starts at 4000 so we never skip it on worktree identity alone — collisions are detected by real listen-state.
- Flutter app points at the chosen port via `--dart-define=API_BASE_URL=http://localhost:<PORT>`; documented in `CLAUDE.md`.

Verified locally: 4000 → 4001 → 4002 as contexts stack, back to 4000 when freed; `PORT=` override wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)