### PR TITLE
feat(server,tf): storage foundation + profile photos (closes v2-storage)

### DIFF
--- a/plans/v2-storage-media.md
+++ b/plans/v2-storage-media.md
@@ -1,0 +1,78 @@
+---
+status: planned
+depends: [v2-storage]
+specs:
+  - specs/api/uploads.md
+  - specs/api/communities.md
+  - specs/api/messages.md
+issues: []
+pr:
+---
+
+# Plan: v2 storage media (community photos + message attachments)
+
+> Split out of [`v2-storage`](v2-storage.md), which built the reusable upload pipeline
+> (`POST /v1/uploads`) + profile photos. These two surfaces are thin consumers of it; they're
+> separated only because each needs a **schema migration**.
+
+## Scope
+
+Extend the (already-built) signed-URL upload pipeline to the two remaining image surfaces.
+
+**In:**
+
+- **Community photos:** `community.photo` column (migration); `POST`/`PATCH /v1/communities`
+  accept `photo`; serializer returns the public URL; leader create/edit form uploads (kind
+  `community`).
+- **Message attachments:** an attachments store (migration — `message.attachments` jsonb array
+  of `{key,url}`, or a `message_attachment` table); message-post + thread-reply accept attachment
+  keys; serializer returns real URLs (replacing the `attachments: [] // until storage lands` stub
+  in `contracts/message.ts`); composer attach (kind `message`).
+
+**Out:** image transforms/thumbnails; the upload pipeline itself (done in `v2-storage`); changing
+the public-key serving model.
+
+## Implements
+
+`specs/api/uploads.md` (reuses the endpoint), `specs/api/communities.md` (community `photo`),
+`specs/api/messages.md` (attachments). Spec touch-ups: document `photo` on community write/read
+and the attachments shape on messages.
+
+## Approach
+
+Absorbed from `v2-storage`'s deferral. Both surfaces just store an upload's `public_url` (or key)
+and serialize it back — no new storage code, only schema + route/serializer/client wiring per
+surface:
+
+- **Community:** migration adds `community.photo text`; thread it through `CommunityService`
+  create/update + `serializeCommunity`; client `CreateCommunityScreen` gains an image picker that
+  uploads (kind `community`) then sets `photo`.
+- **Messages:** migration adds attachments storage; `MessageService` post/reply accept
+  `attachment_keys`; `serializeMessage` returns `[{key,url}]` from stored keys (drop the stub);
+  client composer attaches images (kind `message`). Decide jsonb-column vs join-table in
+  `data-model.md` first (lean jsonb for simplicity given small N).
+
+## Validation
+
+- [ ] migrations apply (community.photo; message attachments) — `migrate-on-startup` stays green.
+- [ ] `bun test` + type-check: community create/edit with a photo serializes the URL; message
+      post with attachment keys serializes `[{key,url}]`; empty/no attachments → `[]`.
+- [ ] client: community form photo upload; message composer attach; both render.
+- [ ] CI green; deploy.
+
+## Risks / unknowns
+
+- **Attachments model** (jsonb vs join table) — settle in `data-model.md` before coding; jsonb is
+  simpler and matches the current serializer shape, a table is cleaner if attachments grow
+  metadata. Don't over-build.
+- **No ownership check on `kind`** (by design — see uploads.md); the owning endpoint must still
+  validate the caller may set the photo (leader for community, sender for message).
+- Two additive migrations — order them, keep startup migration happy.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-storage.md
+++ b/plans/v2-storage.md
@@ -1,0 +1,98 @@
+---
+status: in-progress
+depends: [v2-backend-infra]
+specs:
+  - specs/api/conventions.md
+  - specs/architecture.md
+issues: []
+pr:
+---
+
+# Plan: v2 storage (photo/media via GCS, signed-URL upload)
+
+## Scope
+
+Object storage for user-supplied images, per `conventions.md` §Storage: client requests an
+upload target from the API, **PUTs bytes directly** to GCS (the API never proxies bytes), then
+references the returned key; **reads are public-with-unguessable-key** URLs in serialized
+resources. Full scope: **profile photos, community photos, and message attachments**.
+
+**In:**
+
+- **Infra:** a public-read GCS bucket (`media.squadquest.app` or `squadquest-v2-media`) in `tf/`,
+  world-readable, with the Cloud Run runtime SA able to mint V4 signed PUT URLs (needs
+  `roles/iam.serviceAccountTokenCreator` on itself for keyless `signBlob` signing).
+- **Shared pipeline (foundation):** `POST /v1/uploads` → `{ key, upload_url, public_url }`
+  (signed V4 PUT, short expiry). A `StorageService` (wraps `@google-cloud/storage`) that signs
+  upload URLs and builds public URLs. Keys are `<kind>/<uuid>` (unguessable).
+- **Profile photos:** `PATCH /v1/me` accepts `photo` (a storage key/url); serialized profile
+  returns the public URL. Client: pick image → upload → PATCH.
+- **Community photos:** add a `photo` column (migration); `POST`/`PATCH /v1/communities` accept
+  it; serializer returns it; leader create/edit form uploads.
+- **Message attachments:** add an `attachments` column (migration — jsonb array of `{key,url}`,
+  or a `message_attachment` table); message post accepts attachment keys; serializer returns
+  real URLs (replacing the `[] until storage lands` stub); client composer attaches.
+- Spec: new `specs/api/uploads.md`; touch `profile.md`, `communities.md`, `messages.md`.
+
+**Out:** image resize/thumbnails/transforms; EXIF stripping; per-object signed *reads* (we use
+public keys); virus scanning; non-image media; rehosting v1 Supabase-stored avatars (separate
+migration concern). Client styling.
+
+## Implements
+
+`specs/api/conventions.md` §Storage (the signed-upload contract) + `architecture.md`
+(object store + keys). New `specs/api/uploads.md` for the endpoint.
+
+## Approach
+
+Phase the work so the reusable foundation lands first and each surface is independently
+shippable:
+
+- **Phase 1 — foundation (infra + pipeline):** tf bucket + IAM (`signBlob` self-grant on the
+  compute SA); `bun add @google-cloud/storage`; `StorageService` + `POST /v1/uploads`; env for
+  the bucket name (wired via tf). Tests: uploads returns a well-formed key + public URL; reject
+  disallowed content types.
+- **Phase 2 — profile photos:** `PATCH /v1/me` photo; client profile-photo picker → upload →
+  PATCH (likely a small add to the welcome/profile-edit surface). Proves the pipeline end-to-end.
+- **Phase 3 — community photos:** migration (`community.photo`); routes + serializer + leader
+  form upload.
+- **Phase 4 — message attachments:** migration (attachments); message post + serializer (drop
+  the stub) + composer attach.
+
+V4 signed PUT via `@google-cloud/storage` `file.getSignedUrl({version:'v4', action:'write',
+contentType, expires})` — works with ADC + IAM `signBlob` on Cloud Run (no key file). Public
+read URL: `https://storage.googleapis.com/<bucket>/<key>`. Validate content type
+(image/jpeg|png|webp) and cap size via the signed URL's conditions where practical.
+
+## Validation
+
+- [ ] `bun test` + type-check: `POST /v1/uploads` returns key/upload_url/public_url; content-type
+      allow-list enforced; StorageService builds correct public URLs.
+- [ ] tf: bucket public-read + SA `signBlob` self-grant applied; `tofu plan` clean.
+- [ ] profile: PATCH photo round-trips; serialized profile shows the public URL.
+- [ ] community photo + message attachments: migrations applied; create/post with an upload key
+      serializes the public URL; client uploads in each surface.
+- [ ] CI green; deploy; (live) upload a real image via the signed URL and load it back publicly.
+
+## Risks / unknowns
+
+- **Keyless signing**: V4 signing without a key file requires the runtime SA to sign via IAM
+  `signBlob` — grant `roles/iam.serviceAccountTokenCreator` to the compute SA *on itself*, and
+  ensure `@google-cloud/storage` uses it (it falls back to signBlob when no private key). Verify
+  on Cloud Run, not just locally (local ADC differs).
+- **Public bucket exposure**: world-readable means anyone with the key can fetch. Acceptable for
+  avatars/community/most attachments (unguessable uuid keys); do NOT put anything sensitive here.
+- **Two migrations** (community.photo, message attachments) — additive, low risk, but order them
+  and keep `migrate-on-startup` happy.
+- **`@google-cloud/storage` is a heavy dep** (vs the no-SDK Twilio approach). Justified: V4
+  signing + signBlob fallback is error-prone to hand-roll. Confirm it bundles cleanly in the
+  Bun/alpine image.
+- Scope is large — Phases 3–4 may split into their own plans if Phase 1–2 reveal friction.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-storage.md
+++ b/plans/v2-storage.md
@@ -1,21 +1,27 @@
 ---
-status: in-progress
+status: done
 depends: [v2-backend-infra]
 specs:
   - specs/api/conventions.md
+  - specs/api/uploads.md
   - specs/architecture.md
 issues: []
-pr:
+pr: 437
 ---
 
-# Plan: v2 storage (photo/media via GCS, signed-URL upload)
+# Plan: v2 storage foundation + profile photos (GCS, signed-URL upload)
+
+> Originally scoped for full media (profile + community + message attachments). Split at
+> implementation: this plan delivers the **reusable upload pipeline + profile photos**; the
+> two migration-bearing surfaces (community photos, message attachments) moved to
+> [`v2-storage-media`](v2-storage-media.md).
 
 ## Scope
 
 Object storage for user-supplied images, per `conventions.md` §Storage: client requests an
 upload target from the API, **PUTs bytes directly** to GCS (the API never proxies bytes), then
 references the returned key; **reads are public-with-unguessable-key** URLs in serialized
-resources. Full scope: **profile photos, community photos, and message attachments**.
+resources. **Delivered here:** the shared upload pipeline + **profile photos**.
 
 **In:**
 
@@ -66,13 +72,16 @@ read URL: `https://storage.googleapis.com/<bucket>/<key>`. Validate content type
 
 ## Validation
 
-- [ ] `bun test` + type-check: `POST /v1/uploads` returns key/upload_url/public_url; content-type
-      allow-list enforced; StorageService builds correct public URLs.
-- [ ] tf: bucket public-read + SA `signBlob` self-grant applied; `tofu plan` clean.
-- [ ] profile: PATCH photo round-trips; serialized profile shows the public URL.
-- [ ] community photo + message attachments: migrations applied; create/post with an upload key
-      serializes the public URL; client uploads in each surface.
-- [ ] CI green; deploy; (live) upload a real image via the signed URL and load it back publicly.
+- [x] `bun test` + type-check: `POST /v1/uploads` requires auth, enforces kind +
+      content-type allow-list, 503s without a bucket; `PATCH /v1/me` photo round-trips.
+      Suite 47/47; `@google-cloud/storage` imports cleanly under Bun.
+- [x] tf: public-read bucket + CORS + runtime-SA objectAdmin + `signBlob`-on-self applied;
+      `MEDIA_BUCKET` wired into Cloud Run; `tofu plan` clean.
+- [x] profile: `PATCH /v1/me { photo }` round-trips; serialized profile shows the URL.
+- [→] community photo + message attachments — **moved to [`v2-storage-media`](v2-storage-media.md)**
+      (each needs a migration; deferred at the split).
+- [ ] CI green; deploy; (live, manual) upload a real image via the signed URL on Cloud Run and
+      load it back publicly — confirms keyless signBlob works in prod (ADC differs from local).
 
 ## Risks / unknowns
 
@@ -91,8 +100,30 @@ read URL: `https://storage.googleapis.com/<bucket>/<key>`. Validate content type
 
 ## Notes
 
-(closeout)
+PR #437. Delivered the **reusable upload pipeline** (the foundation all media surfaces reuse)
+- **profile photos** as its first consumer. Public-read bucket `squadquest-v2-media` with
+unguessable uuid keys; `StorageService` mints V4 signed PUT URLs via `@google-cloud/storage`,
+which falls back to IAM `signBlob` on Cloud Run (keyless — granted `serviceAccountTokenCreator`
+on the runtime SA *to itself*). `POST /v1/uploads` is auth'd and 503s when `MEDIA_BUCKET` is
+unset (local dev / tests need no GCS). Env + bucket wired into the live service via tf.
+
+**Split decision:** community photos + message attachments each need a schema migration + route
+- serializer + client work, so rather than balloon this plan they moved to `v2-storage-media`
+(an unstarted plan). The pipeline is built and proven on profiles; those surfaces are now thin
+consumers of it.
+
+Latent test-infra note surfaced (not fixed here): `auth.test.ts` sets `MIN_SUPPORTED_BUILD=500`
+process-wide and it leaks across the shared bun-test process — new auth-touching tests must use
+a high client build. Worth a proper fix (per-suite env reset) someday.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred to plan [`v2-storage-media`](v2-storage-media.md)** — community photos
+  (`community.photo` migration) + message attachments (attachments migration); both thin
+  consumers of `POST /v1/uploads`. (That plan absorbs this deferral in its Approach/Validation.)
+- **Verification owed (manual):** one live signed-URL upload on Cloud Run, to confirm keyless
+  `signBlob` works in prod (local ADC ≠ Cloud Run SA). In Validation above.
+- **Tracked as:** profile-photo *client* UI (picker → upload → PATCH) — server is ready; the
+  Flutter side rides whenever we next touch the profile/welcome surface.
+- **Deferred:** rehosting v1 Supabase-stored avatars (a v1-migration concern); image
+  resize/EXIF-strip/thumbnails.

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@fastify/cors": "^11.0.0",
         "@fastify/env": "^5.0.0",
+        "@google-cloud/storage": "^7.21.0",
         "drizzle-orm": "^0.45.2",
         "fastify": "^5.2.0",
         "fastify-plugin": "^5.0.0",
@@ -96,9 +97,23 @@
 
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
 
+    "@google-cloud/paginator": ["@google-cloud/paginator@5.0.2", "", { "dependencies": { "arrify": "^2.0.0", "extend": "^3.0.2" } }, "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg=="],
+
+    "@google-cloud/projectify": ["@google-cloud/projectify@4.0.0", "", {}, "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA=="],
+
+    "@google-cloud/promisify": ["@google-cloud/promisify@4.0.0", "", {}, "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="],
+
+    "@google-cloud/storage": ["@google-cloud/storage@7.21.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0" } }, "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
+    "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 
@@ -106,15 +121,35 @@
 
     "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
+    "@types/request": ["@types/request@2.48.13", "", { "dependencies": { "@types/caseless": "*", "@types/node": "*", "@types/tough-cookie": "*", "form-data": "^2.5.5" } }, "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "anynum": ["anynum@1.0.0", "", {}, "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA=="],
+
+    "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -122,7 +157,15 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -134,11 +177,29 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "env-schema": ["env-schema@6.1.0", "", { "dependencies": { "ajv": "^8.12.0", "dotenv": "^17.0.0", "dotenv-expand": "10.0.0" } }, "sha512-TWtYV2jKe7bd/19kzvNGa8GRRrSwmIMarhcWBzuZYPbHtdlUdjYhnaFvxrO4+GvcwF10sEeVGzf9b/wqLIyf9A=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -150,6 +211,10 @@
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.8.0", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.2.0", "path-expression-matcher": "^1.5.0", "strnum": "^2.3.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg=="],
+
     "fastify": ["fastify@5.8.5", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q=="],
 
     "fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
@@ -158,11 +223,49 @@
 
     "find-my-way": ["find-my-way@9.6.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ=="],
 
+    "form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
@@ -190,9 +293,25 @@
 
     "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 
@@ -206,6 +325,8 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
@@ -213,6 +334,10 @@
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "retry-request": ["retry-request@7.0.2", "", { "dependencies": { "@types/request": "^2.48.8", "extend": "^3.0.2", "teeny-request": "^9.0.0" } }, "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -238,9 +363,23 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "stream-events": ["stream-events@1.0.5", "", { "dependencies": { "stubs": "^3.0.0" } }, "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg=="],
+
+    "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strnum": ["strnum@2.4.0", "", { "dependencies": { "anynum": "^1.0.0" } }, "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg=="],
+
+    "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
+
+    "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
+
     "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "toad-cache": ["toad-cache@3.7.1", "", {}, "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
 
@@ -248,9 +387,27 @@
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
+    "teeny-request/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
@@ -299,6 +456,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "teeny-request/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@fastify/cors": "^11.0.0",
     "@fastify/env": "^5.0.0",
+    "@google-cloud/storage": "^7.21.0",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.2.0",
     "fastify-plugin": "^5.0.0",

--- a/server/src/domain/storage/service.ts
+++ b/server/src/domain/storage/service.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto'
+import { Storage } from '@google-cloud/storage'
+
+import { errors } from '../../contracts/errors.ts'
+
+// Allowed upload content types → file extension. Keep narrow; this is user media.
+const CONTENT_TYPES: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+}
+
+// Upload "kinds" map to key prefixes so objects are loosely organized + so a
+// caller can't smuggle a weird prefix. Reads are public (unguessable uuid keys).
+const KINDS = new Set(['profile', 'community', 'message'])
+
+const UPLOAD_URL_TTL_MS = 10 * 60 * 1000
+
+export interface UploadTarget {
+  key: string
+  upload_url: string
+  public_url: string
+}
+
+// Mints V4 signed PUT URLs for direct-to-GCS uploads and builds public read URLs.
+// On Cloud Run it signs keylessly via IAM signBlob (ADC, no key file). See
+// specs/api/uploads.md + conventions.md §Storage.
+export class StorageService {
+  private readonly storage: Storage
+  constructor(private readonly bucketName: string) {
+    this.storage = new Storage()
+  }
+
+  publicUrl(key: string): string {
+    return `https://storage.googleapis.com/${this.bucketName}/${key}`
+  }
+
+  // Validate the requested upload and return a signed PUT target.
+  async createUploadTarget(kind: string, contentType: string): Promise<UploadTarget> {
+    if (!KINDS.has(kind)) {
+      throw errors.badRequest('invalid_upload_kind', `Unknown upload kind: ${kind}`)
+    }
+    const ext = CONTENT_TYPES[contentType]
+    if (!ext) {
+      throw errors.badRequest(
+        'unsupported_content_type',
+        `Unsupported content type: ${contentType}`,
+      )
+    }
+
+    const key = `${kind}/${randomUUID()}.${ext}`
+    const file = this.storage.bucket(this.bucketName).file(key)
+    const [uploadUrl] = await file.getSignedUrl({
+      version: 'v4',
+      action: 'write',
+      expires: Date.now() + UPLOAD_URL_TTL_MS,
+      contentType,
+    })
+
+    return { key, upload_url: uploadUrl, public_url: this.publicUrl(key) }
+  }
+}

--- a/server/src/plugins/env.ts
+++ b/server/src/plugins/env.ts
@@ -28,6 +28,9 @@ const schema = {
     TWILIO_ACCOUNT_SID: { type: 'string', default: '' },
     TWILIO_AUTH_TOKEN: { type: 'string', default: '' },
     TWILIO_VERIFY_SERVICE_SID: { type: 'string', default: '' },
+    // GCS bucket for user media (signed-URL uploads, public-key reads). Empty
+    // disables the uploads endpoint (local dev without GCS creds).
+    MEDIA_BUCKET: { type: 'string', default: '' },
   },
 }
 
@@ -44,6 +47,7 @@ declare module 'fastify' {
       TWILIO_ACCOUNT_SID: string
       TWILIO_AUTH_TOKEN: string
       TWILIO_VERIFY_SERVICE_SID: string
+      MEDIA_BUCKET: string
     }
   }
 }

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -10,6 +10,7 @@ import topicRoutes from './topics.ts'
 import squadRoutes from './squads.ts'
 import messageRoutes from './messages.ts'
 import communityRoutes from './communities.ts'
+import uploadRoutes from './uploads.ts'
 
 // The /v1 contract surface. All client-facing endpoints register under here so
 // the URL major version is the coarse contract boundary (see
@@ -25,6 +26,7 @@ const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(squadRoutes)
   await fastify.register(messageRoutes)
   await fastify.register(communityRoutes)
+  await fastify.register(uploadRoutes)
 }
 
 export default v1Routes

--- a/server/src/routes/v1/me.ts
+++ b/server/src/routes/v1/me.ts
@@ -19,7 +19,7 @@ const meRoutes: FastifyPluginAsync = async (fastify) => {
 
   // PATCH /v1/me — update own profile (onboarding profile-setup + later edits).
   // Only provided fields change; first_name must be non-empty when present.
-  fastify.patch<{ Body: { first_name?: string; last_name?: string } }>(
+  fastify.patch<{ Body: { first_name?: string; last_name?: string; photo?: string } }>(
     '/me',
     {
       preHandler: fastify.authenticate,
@@ -29,13 +29,14 @@ const meRoutes: FastifyPluginAsync = async (fastify) => {
           properties: {
             first_name: { type: 'string' },
             last_name: { type: 'string' },
+            photo: { type: 'string' },
           },
         },
       },
     },
     async (request) => {
-      const { first_name, last_name } = request.body
-      const updates: { firstName?: string; lastName?: string | null } = {}
+      const { first_name, last_name, photo } = request.body
+      const updates: { firstName?: string; lastName?: string | null; photo?: string | null } = {}
 
       if (first_name !== undefined) {
         if (first_name.trim() === '') {
@@ -45,6 +46,9 @@ const meRoutes: FastifyPluginAsync = async (fastify) => {
       }
       if (last_name !== undefined) {
         updates.lastName = last_name.trim() === '' ? null : last_name.trim()
+      }
+      if (photo !== undefined) {
+        updates.photo = photo.trim() === '' ? null : photo.trim()
       }
 
       const [row] = await fastify.db

--- a/server/src/routes/v1/uploads.ts
+++ b/server/src/routes/v1/uploads.ts
@@ -1,0 +1,40 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+import { StorageService } from '../../domain/storage/service.ts'
+import { ApiError } from '../../contracts/errors.ts'
+
+// POST /v1/uploads — request a signed target to PUT an image directly to storage,
+// then reference the returned key (the API never proxies bytes). The public URL is
+// what gets stored on the resource (profile.photo, community.photo, attachments).
+// See specs/api/uploads.md + conventions.md §Storage.
+const uploadRoutes: FastifyPluginAsync = async (fastify) => {
+  const bucket = fastify.config.MEDIA_BUCKET
+  // No bucket configured (local dev without GCS) → the endpoint 503s rather than
+  // crashing the server at boot.
+  const storage = bucket ? new StorageService(bucket) : null
+
+  fastify.post<{ Body: { kind: string; content_type: string } }>(
+    '/uploads',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['kind', 'content_type'],
+          properties: {
+            kind: { type: 'string' },
+            content_type: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (request) => {
+      if (!storage) {
+        throw new ApiError(503, 'storage_unavailable', 'Uploads are not configured')
+      }
+      return storage.createUploadTarget(request.body.kind, request.body.content_type)
+    },
+  )
+}
+
+export default uploadRoutes

--- a/server/test/otp-provider.test.ts
+++ b/server/test/otp-provider.test.ts
@@ -19,7 +19,9 @@ beforeEach(async () => {
   await server.sql`truncate otp_code, refresh_token, profile cascade`
 })
 
-const auth = { 'x-squadquest-client': 'web/1.0.0+1' }
+// Build kept high: a sibling suite (auth.test.ts) sets MIN_SUPPORTED_BUILD=500
+// process-wide, and these files share one bun-test process.
+const auth = { 'x-squadquest-client': 'web/9.9.9+999' }
 
 test('console OTP: request then verify with the logged code logs in', async () => {
   // request → row created in otp_code

--- a/server/test/uploads.test.ts
+++ b/server/test/uploads.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// No MEDIA_BUCKET in the test env → the uploads endpoint should 503 rather than
+// attempt to sign (which would need GCS creds). Validation + auth still apply.
+// (A live signed-URL round-trip is covered manually against the deployed service.)
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  return { auth: { authorization: `Bearer ${server.signAccessToken(row.id)}` } }
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  await server.sql`truncate profile cascade`
+})
+
+test('POST /v1/uploads requires auth', async () => {
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/uploads',
+    payload: { kind: 'profile', content_type: 'image/jpeg' },
+  })
+  expect(res.statusCode).toBe(401)
+})
+
+test('POST /v1/uploads returns 503 when storage is not configured (no MEDIA_BUCKET)', async () => {
+  const user = await makeUser('+12155558000')
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/uploads',
+    headers: user.auth,
+    payload: { kind: 'profile', content_type: 'image/jpeg' },
+  })
+  expect(res.statusCode).toBe(503)
+  expect(res.json().error.code).toBe('storage_unavailable')
+})
+
+test('PATCH /v1/me accepts a photo URL/key and serializes it', async () => {
+  const user = await makeUser('+12155558010')
+  const url = 'https://storage.googleapis.com/squadquest-v2-media/profile/abc.jpg'
+  const res = await server.inject({
+    method: 'PATCH',
+    url: '/v1/me',
+    headers: user.auth,
+    payload: { photo: url },
+  })
+  expect(res.statusCode).toBe(200)
+  expect(res.json().photo).toBe(url)
+
+  // clearing
+  const cleared = await server.inject({
+    method: 'PATCH',
+    url: '/v1/me',
+    headers: user.auth,
+    payload: { photo: '' },
+  })
+  expect(cleared.json().photo).toBeNull()
+})

--- a/specs/api/uploads.md
+++ b/specs/api/uploads.md
@@ -1,0 +1,43 @@
+# API: Uploads
+
+Signed-URL image uploads. The client requests an upload target, **PUTs the bytes directly to
+the object store** (the API never proxies image bytes — see
+[conventions §Storage](conventions.md#storage-photos)), then references the returned key/URL on
+the owning resource. Reads are **public, unguessable-key** URLs. Authenticated.
+
+## POST /v1/uploads
+
+Request a signed target for one image.
+
+- **Request:** `{ "kind": "profile" | "community" | "message", "content_type": "image/jpeg" | "image/png" | "image/webp" }`
+- **Response:** `200`
+
+  ```jsonc
+  {
+    "key": "profile/3f2a…​.jpg",                                   // store this on the resource (or its public_url)
+    "upload_url": "https://storage.googleapis.com/…X-Goog-Signature=…", // V4 signed PUT, ~10 min TTL
+    "public_url": "https://storage.googleapis.com/<bucket>/<key>"  // stable, world-readable
+  }
+  ```
+
+- **Client flow:** `PUT` the bytes to `upload_url` with the same `Content-Type`, then set the
+  resource's photo/attachment to `public_url` (e.g. `PATCH /v1/me { "photo": "<public_url>" }`).
+- **Errors:** `invalid_upload_kind`, `unsupported_content_type` (400); `storage_unavailable`
+  (503, when the server has no bucket configured — local dev without GCS).
+
+## Notes
+
+- **Public-with-unguessable-key**, not signed reads: keys embed a uuid, objects are
+  world-readable, serialized resources return the plain `public_url`. No per-request read
+  signing. Don't store anything sensitive here.
+- `kind` only scopes the key prefix (`profile/`, `community/`, `message/`); it doesn't grant or
+  check ownership of the eventual resource — the owning endpoint does that when the key is set.
+- Allowed types are a narrow image allow-list; widen deliberately.
+
+## Principles
+
+**Inherited:**
+
+- [The client binds to the versioned API, never the schema](../principles.md#the-client-binds-to-the-versioned-api-never-the-schema)
+  — clients talk to `/v1/uploads` + the owning resource, not to GCS APIs; the storage backend
+  (GCS today) is swappable behind this contract.

--- a/tf/cloudrun.tf
+++ b/tf/cloudrun.tf
@@ -104,6 +104,12 @@ resource "google_cloud_run_v2_service" "backend" {
         }
       }
 
+      # Media bucket for signed-URL uploads (not a secret — a plain bucket name).
+      env {
+        name  = "MEDIA_BUCKET"
+        value = google_storage_bucket.media.name
+      }
+
       startup_probe {
         http_get {
           path = "/v1/health"

--- a/tf/storage.tf
+++ b/tf/storage.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# Media storage — user-supplied images (profile/community photos, attachments)
+# =============================================================================
+# Public-read bucket with unguessable (uuid) keys: serialized resources return a
+# plain public URL, no per-request signing. Uploads use V4 signed PUT URLs minted
+# by the Cloud Run runtime SA (keyless, via IAM signBlob). See specs/api/uploads.md
+# + conventions.md §Storage.
+
+resource "google_storage_bucket" "media" {
+  name                        = "squadquest-v2-media"
+  location                    = "us-central1"
+  uniform_bucket_level_access = true
+
+  # Browser uploads via signed PUT need CORS for the app origins.
+  cors {
+    origin          = ["https://v2.squadquest.app", "http://localhost:*"]
+    method          = ["GET", "PUT"]
+    response_header = ["Content-Type"]
+    max_age_seconds = 3600
+  }
+}
+
+# World-readable objects (keys are unguessable uuids).
+resource "google_storage_bucket_iam_member" "media_public" {
+  bucket = google_storage_bucket.media.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# The Cloud Run runtime SA reads/writes objects (signed-URL minting is done with
+# its own identity; this also lets it manage objects directly if ever needed).
+resource "google_storage_bucket_iam_member" "media_runtime_admin" {
+  bucket = google_storage_bucket.media.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
+}
+
+# Keyless V4 signing: the runtime SA must be able to sign blobs AS ITSELF
+# (@google-cloud/storage falls back to the IAM signBlob API when no private key
+# is present, which is the case on Cloud Run with ADC).
+resource "google_service_account_iam_member" "media_signer" {
+  service_account_id = "projects/squadquest-d8665/serviceAccounts/${data.google_project.current.number}-compute@developer.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
+}


### PR DESCRIPTION
GCS object storage with signed-URL uploads, per `conventions.md` §Storage. Delivers the **reusable upload pipeline** + **profile photos** (the first consumer). Community photos + message attachments are split to **`v2-storage-media`** (each needs a migration).

## Infra (`tf/storage.tf`)
- Public-read bucket `squadquest-v2-media` (+ CORS for browser PUTs); unguessable uuid keys.
- Runtime SA: `objectAdmin` + **`serviceAccountTokenCreator` on itself** → keyless **V4 signBlob** signing on Cloud Run (no key file).
- `MEDIA_BUCKET` wired into the live service.

## Pipeline + profile (server)
- `StorageService` (`@google-cloud/storage`): V4 signed PUT URLs + public URLs; narrow image content-type allow-list (`jpeg/png/webp`); kind-prefixed (`profile/community/message`) uuid keys.
- **`POST /v1/uploads`** (auth'd) → `{key, upload_url, public_url}`; **503** when no bucket (local dev/tests need no GCS).
- **`PATCH /v1/me`** accepts `photo`.
- New `specs/api/uploads.md`.

## Tests
`test/uploads.test.ts` (auth required, 503 unconfigured, profile photo round-trip) + verified `@google-cloud/storage` imports under Bun. Suite **47/47**; type-check clean.

## Split
Community photos + message attachments → **`v2-storage-media`** (planned, absorbs the deferral). They're thin consumers of `POST /v1/uploads`; separated only because each needs a schema migration.

**Owed (manual):** one live signed-URL upload on Cloud Run to confirm keyless signBlob in prod (ADC differs from local). Profile-photo client UI rides the next profile-surface touch.

Implements `specs/api/uploads.md` + `conventions.md` §Storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)