### PR TITLE
feat(app): photo upload UI — profile + community

### DIFF
--- a/app/lib/models/community.dart
+++ b/app/lib/models/community.dart
@@ -6,6 +6,7 @@ class Community {
     this.tagline,
     this.icon,
     this.color,
+    this.photo,
     this.followerCount = 0,
     this.youFollow = false,
     this.yourRole,
@@ -16,6 +17,7 @@ class Community {
   final String? tagline;
   final String? icon;
   final String? color;
+  final String? photo;
   final int followerCount;
   final bool youFollow;
 
@@ -30,6 +32,7 @@ class Community {
     tagline: json['tagline'] as String?,
     icon: json['icon'] as String?,
     color: json['color'] as String?,
+    photo: json['photo'] as String?,
     followerCount: (json['follower_count'] as num?)?.toInt() ?? 0,
     youFollow: json['you_follow'] as bool? ?? false,
     yourRole: json['your_role'] as String?,

--- a/app/lib/providers/auth_controller.dart
+++ b/app/lib/providers/auth_controller.dart
@@ -83,12 +83,13 @@ class AuthController extends Notifier<AuthState> {
   /// Set/update the signed-in user's profile (onboarding name-setup + edits).
   /// Swapping the profile drives the onboarding redirect (null first_name → /welcome).
   Future<void> updateProfile({
-    required String firstName,
+    String? firstName,
     String? lastName,
+    String? photo,
   }) async {
     final updated = await ref
         .read(profileRepositoryProvider)
-        .updateProfile(firstName: firstName, lastName: lastName);
+        .updateProfile(firstName: firstName, lastName: lastName, photo: photo);
     state = SignedIn(updated);
   }
 

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -17,6 +17,7 @@ import '../repositories/squad_repository.dart';
 import '../repositories/timeline_repository.dart';
 import '../repositories/token_store.dart';
 import '../repositories/topic_repository.dart';
+import '../repositories/upload_repository.dart';
 import 'auth_controller.dart';
 
 /// Dependency-injection providers. Repositories expose abstract types so tests
@@ -39,6 +40,10 @@ final authRepositoryProvider = Provider<AuthRepository>(
     apiClient: ref.watch(apiClientProvider),
     tokens: ref.watch(tokenStoreProvider),
   ),
+);
+
+final uploadRepositoryProvider = Provider<UploadRepository>(
+  (ref) => ApiUploadRepository(apiClient: ref.watch(apiClientProvider)),
 );
 
 final profileRepositoryProvider = Provider<ProfileRepository>(

--- a/app/lib/repositories/community_repository.dart
+++ b/app/lib/repositories/community_repository.dart
@@ -19,6 +19,7 @@ abstract class CommunityRepository {
     String? tagline,
     String? icon,
     String? color,
+    String? photo,
   });
 
   /// Edit a community (leader-only). Only non-null fields are sent.
@@ -28,6 +29,7 @@ abstract class CommunityRepository {
     String? tagline,
     String? icon,
     String? color,
+    String? photo,
   });
 
   /// Post an event to a community (leader-only).
@@ -110,10 +112,17 @@ class ApiCommunityRepository implements CommunityRepository {
     String? tagline,
     String? icon,
     String? color,
+    String? photo,
   }) async {
     final res = await apiClient.post(
       '/v1/communities',
-      body: {'name': name, 'tagline': ?tagline, 'icon': ?icon, 'color': ?color},
+      body: {
+        'name': name,
+        'tagline': ?tagline,
+        'icon': ?icon,
+        'color': ?color,
+        'photo': ?photo,
+      },
     );
     return Community.fromJson(res);
   }
@@ -125,6 +134,7 @@ class ApiCommunityRepository implements CommunityRepository {
     String? tagline,
     String? icon,
     String? color,
+    String? photo,
   }) async {
     final res = await apiClient.patch(
       '/v1/communities/$communityId',
@@ -133,6 +143,7 @@ class ApiCommunityRepository implements CommunityRepository {
         'tagline': ?tagline,
         'icon': ?icon,
         'color': ?color,
+        'photo': ?photo,
       },
     );
     return Community.fromJson(res);

--- a/app/lib/repositories/profile_repository.dart
+++ b/app/lib/repositories/profile_repository.dart
@@ -6,7 +6,11 @@ abstract class ProfileRepository {
 
   /// Update own profile (onboarding name-setup + later edits). Only non-null
   /// fields are sent. See specs/api/profile.md.
-  Future<Profile> updateProfile({String? firstName, String? lastName});
+  Future<Profile> updateProfile({
+    String? firstName,
+    String? lastName,
+    String? photo,
+  });
 }
 
 class ApiProfileRepository implements ProfileRepository {
@@ -18,10 +22,15 @@ class ApiProfileRepository implements ProfileRepository {
   Future<Profile> me() async => Profile.fromJson(await apiClient.get('/v1/me'));
 
   @override
-  Future<Profile> updateProfile({String? firstName, String? lastName}) async {
+  Future<Profile> updateProfile({
+    String? firstName,
+    String? lastName,
+    String? photo,
+  }) async {
     final body = <String, dynamic>{
       'first_name': ?firstName,
       'last_name': ?lastName,
+      'photo': ?photo,
     };
     return Profile.fromJson(await apiClient.patch('/v1/me', body: body));
   }

--- a/app/lib/repositories/upload_repository.dart
+++ b/app/lib/repositories/upload_repository.dart
@@ -1,0 +1,64 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
+import '../api/api_client.dart';
+
+/// The result of uploading an image: the public URL to store on a resource
+/// (profile.photo, community.photo, a message attachment) plus its key.
+class Upload {
+  const Upload({required this.key, required this.url});
+  final String key;
+  final String url;
+}
+
+/// Two-step image upload (specs/api/uploads.md): ask the API for a signed PUT
+/// target, then PUT the bytes straight to object storage. The API never proxies
+/// bytes, so the PUT uses a bare Dio (no `/v1` interceptors / auth header — the
+/// signed URL carries its own auth).
+abstract class UploadRepository {
+  /// [kind] ∈ {profile, community, message}. Returns the stored public URL + key.
+  Future<Upload> uploadImage({
+    required String kind,
+    required Uint8List bytes,
+    required String contentType,
+  });
+}
+
+class ApiUploadRepository implements UploadRepository {
+  ApiUploadRepository({required this.apiClient, Dio? rawClient})
+    : _raw = rawClient ?? Dio();
+
+  final ApiClient apiClient;
+  final Dio _raw;
+
+  @override
+  Future<Upload> uploadImage({
+    required String kind,
+    required Uint8List bytes,
+    required String contentType,
+  }) async {
+    // 1. Signed target from our API.
+    final res = await apiClient.post(
+      '/v1/uploads',
+      body: {'kind': kind, 'content_type': contentType},
+    );
+    final uploadUrl = res['upload_url'] as String;
+    final publicUrl = res['public_url'] as String;
+    final key = res['key'] as String;
+
+    // 2. PUT the bytes directly to storage with the same content type.
+    await _raw.put<void>(
+      uploadUrl,
+      data: Stream.fromIterable([bytes]),
+      options: Options(
+        headers: {
+          'Content-Type': contentType,
+          Headers.contentLengthHeader: bytes.length,
+        },
+      ),
+    );
+
+    return Upload(key: key, url: publicUrl);
+  }
+}

--- a/app/lib/screens/communities/create_community_screen.dart
+++ b/app/lib/screens/communities/create_community_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../models/community.dart';
 import '../../providers/active_context.dart';
 import '../../providers/providers.dart';
+import '../../widgets/photo_picker.dart';
 
 /// Create or edit a community (leader tooling — specs/screens/communities.md).
 /// Create: the caller becomes leader and the new community becomes the active
@@ -25,6 +26,7 @@ class _CreateCommunityScreenState extends ConsumerState<CreateCommunityScreen> {
   late final TextEditingController _icon;
   bool _busy = false;
   String? _error;
+  String? _photoUrl;
 
   bool get _isEdit => widget.existing != null;
 
@@ -35,6 +37,7 @@ class _CreateCommunityScreenState extends ConsumerState<CreateCommunityScreen> {
     _name = TextEditingController(text: e?.name ?? '');
     _tagline = TextEditingController(text: e?.tagline ?? '');
     _icon = TextEditingController(text: e?.icon ?? '');
+    _photoUrl = e?.photo;
   }
 
   @override
@@ -65,6 +68,7 @@ class _CreateCommunityScreenState extends ConsumerState<CreateCommunityScreen> {
           name: name,
           tagline: tagline.isEmpty ? null : tagline,
           icon: icon.isEmpty ? null : icon,
+          photo: _photoUrl,
         );
         ref.invalidate(communitiesProvider);
         if (mounted) context.pop();
@@ -73,6 +77,7 @@ class _CreateCommunityScreenState extends ConsumerState<CreateCommunityScreen> {
           name: name,
           tagline: tagline.isEmpty ? null : tagline,
           icon: icon.isEmpty ? null : icon,
+          photo: _photoUrl,
         );
         ref.invalidate(communitiesProvider);
         if (mounted) {
@@ -103,6 +108,15 @@ class _CreateCommunityScreenState extends ConsumerState<CreateCommunityScreen> {
             key: const Key('communityForm'),
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              Center(
+                child: PhotoPicker(
+                  kind: 'community',
+                  currentUrl: _photoUrl,
+                  fallbackIcon: Icons.image_outlined,
+                  onUploaded: (url) => setState(() => _photoUrl = url),
+                ),
+              ),
+              const SizedBox(height: 16),
               TextField(
                 key: const Key('communityNameField'),
                 controller: _name,

--- a/app/lib/screens/welcome/welcome_screen.dart
+++ b/app/lib/screens/welcome/welcome_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/auth_controller.dart';
+import '../../widgets/photo_picker.dart';
 
 /// Onboarding profile-setup: a freshly-claimed/created user (null first_name)
 /// sets their name before reaching the app. Saving swaps the signed-in profile,
@@ -19,6 +20,7 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
   final _lastName = TextEditingController();
   bool _busy = false;
   String? _error;
+  String? _photoUrl; // public URL once uploaded
 
   @override
   void dispose() {
@@ -44,6 +46,7 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
           .updateProfile(
             firstName: first,
             lastName: last.isEmpty ? null : last,
+            photo: _photoUrl,
           );
       // The router redirect takes over once the profile has a name.
     } catch (_) {
@@ -82,6 +85,19 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
                     textAlign: TextAlign.center,
                   ),
                   const SizedBox(height: 24),
+                  Center(
+                    child: PhotoPicker(
+                      kind: 'profile',
+                      onUploaded: (url) => setState(() => _photoUrl = url),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Add a photo (optional)',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: 12),
+                  ),
+                  const SizedBox(height: 16),
                   TextField(
                     key: const Key('firstNameField'),
                     controller: _firstName,

--- a/app/lib/widgets/photo_picker.dart
+++ b/app/lib/widgets/photo_picker.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../providers/providers.dart';
+
+/// A tappable circular photo picker: pick an image → upload (kind-scoped) →
+/// report the stored public URL via [onUploaded]. Reusable across profile,
+/// community, and message-attachment surfaces (the shared upload primitive).
+class PhotoPicker extends ConsumerStatefulWidget {
+  const PhotoPicker({
+    super.key,
+    required this.kind,
+    required this.onUploaded,
+    this.currentUrl,
+    this.radius = 48,
+    this.fallbackIcon = Icons.add_a_photo_outlined,
+  });
+
+  /// Upload kind: 'profile' | 'community' | 'message' (see specs/api/uploads.md).
+  final String kind;
+  final ValueChanged<String> onUploaded;
+  final String? currentUrl;
+  final double radius;
+  final IconData fallbackIcon;
+
+  @override
+  ConsumerState<PhotoPicker> createState() => _PhotoPickerState();
+}
+
+class _PhotoPickerState extends ConsumerState<PhotoPicker> {
+  bool _busy = false;
+  String? _url;
+
+  @override
+  void initState() {
+    super.initState();
+    _url = widget.currentUrl;
+  }
+
+  Future<void> _pick() async {
+    if (_busy) return;
+    final picked = await ImagePicker().pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 1280,
+      maxHeight: 1280,
+      imageQuality: 85,
+    );
+    if (picked == null) return;
+
+    setState(() => _busy = true);
+    try {
+      final bytes = await picked.readAsBytes();
+      // image_picker gives a path/mime; default to jpeg when unknown.
+      final contentType = picked.mimeType ?? _guessType(picked.name);
+      final upload = await ref
+          .read(uploadRepositoryProvider)
+          .uploadImage(
+            kind: widget.kind,
+            bytes: bytes,
+            contentType: contentType,
+          );
+      if (!mounted) return;
+      setState(() => _url = upload.url);
+      widget.onUploaded(upload.url);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Couldn\'t upload that image. Try again.'),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  static String _guessType(String name) {
+    final n = name.toLowerCase();
+    if (n.endsWith('.png')) return 'image/png';
+    if (n.endsWith('.webp')) return 'image/webp';
+    return 'image/jpeg';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Semantics(
+      button: true,
+      label: 'Choose a photo',
+      child: InkWell(
+        key: const Key('photoPicker'),
+        onTap: _busy ? null : _pick,
+        customBorder: const CircleBorder(),
+        child: CircleAvatar(
+          radius: widget.radius,
+          backgroundColor: scheme.surfaceContainerHighest,
+          foregroundImage: _url != null ? NetworkImage(_url!) : null,
+          child: _busy
+              ? const CircularProgressIndicator(strokeWidth: 2)
+              : (_url == null
+                    ? Icon(widget.fallbackIcon, size: widget.radius * 0.6)
+                    : null),
+        ),
+      ),
+    );
+  }
+}

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import flutter_secure_storage_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -161,6 +169,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -179,6 +219,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -282,6 +330,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -298,6 +354,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   io:
     dependency: transitive
     description:
@@ -761,4 +881,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.1 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   flutter_riverpod: ^3.3.1
   go_router: ^17.3.0
   flutter_secure_storage: ^10.3.1
+  image_picker: ^1.2.2
 
 dev_dependencies:
   flutter_test:

--- a/app/test/community_leader_test.dart
+++ b/app/test/community_leader_test.dart
@@ -35,6 +35,7 @@ class FakeCommunityRepository implements CommunityRepository {
     String? tagline,
     String? icon,
     String? color,
+    String? photo,
   }) async {
     createdName = name;
     return Community(id: 'c-new', name: name, yourRole: 'leader');
@@ -47,6 +48,7 @@ class FakeCommunityRepository implements CommunityRepository {
     String? tagline,
     String? icon,
     String? color,
+    String? photo,
   }) async => Community(id: communityId, name: name ?? '');
 
   @override

--- a/app/test/photo_picker_test.dart
+++ b/app/test/photo_picker_test.dart
@@ -1,0 +1,68 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/upload_repository.dart';
+import 'package:squadquest/widgets/photo_picker.dart';
+
+class FakeUploadRepository implements UploadRepository {
+  String? lastKind;
+  @override
+  Future<Upload> uploadImage({
+    required String kind,
+    required Uint8List bytes,
+    required String contentType,
+  }) async {
+    lastKind = kind;
+    return const Upload(key: 'profile/x.jpg', url: 'https://cdn/x.jpg');
+  }
+}
+
+void main() {
+  testWidgets('renders a tappable picker with the fallback icon when empty', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          uploadRepositoryProvider.overrideWithValue(FakeUploadRepository()),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: PhotoPicker(kind: 'profile', onUploaded: (_) {}),
+          ),
+        ),
+      ),
+    );
+    expect(find.byKey(const Key('photoPicker')), findsOneWidget);
+    expect(find.byIcon(Icons.add_a_photo_outlined), findsOneWidget);
+  });
+
+  testWidgets('uses the given fallback icon for non-profile kinds', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          uploadRepositoryProvider.overrideWithValue(FakeUploadRepository()),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: PhotoPicker(
+              kind: 'community',
+              fallbackIcon: Icons.image_outlined,
+              onUploaded: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.byKey(const Key('photoPicker')), findsOneWidget);
+    expect(find.byIcon(Icons.image_outlined), findsOneWidget);
+  });
+}
+
+// Note: the populated-image path uses NetworkImage, which Flutter's test harness
+// can't load (HTTP 400) without an image mock — covered by MCP/manual instead.

--- a/app/test/welcome_screen_test.dart
+++ b/app/test/welcome_screen_test.dart
@@ -15,7 +15,11 @@ class FakeProfileRepository implements ProfileRepository {
   Future<Profile> me() async => const Profile(id: 'me');
 
   @override
-  Future<Profile> updateProfile({String? firstName, String? lastName}) async {
+  Future<Profile> updateProfile({
+    String? firstName,
+    String? lastName,
+    String? photo,
+  }) async {
     lastFirstName = firstName;
     lastLastName = lastName;
     return Profile(id: 'me', firstName: firstName, lastName: lastName);

--- a/plans/v2-storage-media.md
+++ b/plans/v2-storage-media.md
@@ -1,12 +1,12 @@
 ---
-status: planned
+status: done
 depends: [v2-storage]
 specs:
   - specs/api/uploads.md
   - specs/api/communities.md
   - specs/api/messages.md
 issues: []
-pr:
+pr: 439
 ---
 
 # Plan: v2 storage media (community photos + message attachments)
@@ -54,11 +54,14 @@ surface:
 
 ## Validation
 
-- [ ] migrations apply (community.photo; message attachments) — `migrate-on-startup` stays green.
-- [ ] `bun test` + type-check: community create/edit with a photo serializes the URL; message
-      post with attachment keys serializes `[{key,url}]`; empty/no attachments → `[]`.
-- [ ] client: community form photo upload; message composer attach; both render.
-- [ ] CI green; deploy.
+- [x] migration 0005 (community.photo; message.attachments jsonb) applies — verified clean on
+      prod via migrate-on-startup (deploy green, `/v1/health` 200 after).
+- [x] `bun test` + type-check: community create/edit photo round-trips + serializes; squad
+      message with attachments serializes `[{key,url}]`; photo-only allowed, empty → `empty_message`.
+      Suite **50/50**. [PR #439]
+- [x] client: community form photo upload (PR #440). **Message composer attach deferred** —
+      see Follow-ups.
+- [x] CI green; deployed (migration ran on prod).
 
 ## Risks / unknowns
 
@@ -71,8 +74,23 @@ surface:
 
 ## Notes
 
-(closeout)
+Backend in **PR #439** (migration 0005 + community.photo + message.attachments jsonb; serializer
+drops the `[]` stub; a message now needs text-or-attachment). Settled the attachments model as a
+**jsonb column** `[{key,url}]` (not a join table) — matches the serializer shape, simplest for
+small N; `data-model.md` already anticipated object-store keys. Client community-photo + the
+shared `PhotoPicker`/`UploadRepository` primitive in **PR #440** (alongside profile photos, which
+were `v2-storage`'s client side).
+
+The signed PUT goes direct to GCS via a **bare Dio** (no `/v1` interceptors) — the signed URL
+self-authenticates; routing it through the normal ApiClient would wrongly stamp the auth/build
+headers.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred (client):** the **message-attachment composer**. Backend + the `PhotoPicker`
+  primitive are done; the squad composer is an inline `_SquadComposer` (and thread replies a
+  separate input) that needs more UI surgery to add an attach affordance + render attachment
+  thumbnails on message tiles. Its own follow-up; not blocking — text messaging is unaffected.
+- **Tracked as:** rendering attachment thumbnails in the thread/timeline message tiles (read
+  path) pairs with the composer work above.
+- **None** else — community photos + the attachments contract are complete and deployed.


### PR DESCRIPTION
Client side of the storage pipeline: a shared **`PhotoPicker`** primitive plus its first two consumers (profile avatar, community cover). Pairs with the storage backends (#437 profile, #439 community/message).

## Shared primitive
- **`UploadRepository`** — two-step upload per `specs/api/uploads.md`: `POST /v1/uploads` for a signed target, then PUT bytes **directly to GCS** via a bare `Dio` (no `/v1` interceptors/auth — the signed URL self-authenticates).
- **`PhotoPicker`** widget — tappable circular avatar → `image_picker` → `uploadImage(kind)` → `onUploaded(url)`; per-surface `fallbackIcon`. Reused by both surfaces below.

## Surfaces
- **Profile** (welcome screen): avatar picker (kind `profile`) → `PATCH /v1/me { photo }`.
- **Community** (create/edit form): cover picker (kind `community`) → create/update `photo`; `Community` model + repo gain `photo`.

## Tests
`photo_picker_test.dart` (empty state + per-kind fallback icon) + updated repo fakes. 22 widget tests; `flutter analyze` clean. (The populated-`NetworkImage` path isn't unit-testable without an HTTP mock — covered via MCP/manual.)

## Deferred
**Message-attachment composer** — the squad composer is inline and needs more UI surgery; its own follow-up (backend already supports it). Tracked in `v2-storage-media`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)