### PR TITLE
docs(plans): backlog stubs (attachments-UI, realtime-SSE, styling-pass)

### DIFF
--- a/plans/v2-message-attachments-ui.md
+++ b/plans/v2-message-attachments-ui.md
@@ -1,0 +1,62 @@
+---
+status: planned
+depends: [v2-storage-media]
+specs: []
+issues: []
+pr:
+---
+
+# Plan: v2 message-attachments client UI
+
+> **Backlog stub** (`status: planned`). The backend + shared upload primitive already exist
+> (`v2-storage-media`, `v2-storage`); this is the deferred *client* half. Specs are unchanged
+> (`api/messages.md` already documents `attachments`) — this is UI only.
+
+## Scope
+
+Let users attach images to messages and see them, completing the message-attachment surface
+whose backend shipped in `v2-storage-media`.
+
+**In:**
+
+- **Compose:** an attach affordance on the squad composer (the inline `_SquadComposer` in
+  `timeline_screen.dart`) and on thread replies (`thread_screen.dart`) — reuse the existing
+  `PhotoPicker` / `UploadRepository`; pass `attachments: [{key,url}]` to the message post.
+- **Render (read path):** show attachment thumbnails on message tiles in the squad timeline +
+  thread view (tap to view full).
+- Allow **photo-only** messages (backend already permits text-or-attachment).
+
+**Out:** multi-image galleries beyond a simple row; video/non-image; image editing/cropping.
+
+## Implements
+
+No spec change — `specs/api/messages.md` already specifies `attachments`. Pure client wiring
+to the existing contract.
+
+## Approach (rough — refine at pickup)
+
+- `MessageRepository.postSquadMessage` / thread reply gain an optional `attachments` arg
+  (model already can carry them; confirm the `Message` model parses `attachments`).
+- Composer: an image button → `PhotoPicker`-style pick+upload (kind `message`) → hold the
+  resulting `{key,url}` until send; show a pending-thumbnail strip.
+- Tiles: render `message.attachments` as thumbnails (the read path — needs `Message.attachments`
+  in the client model if not already there).
+
+## Validation
+
+- [ ] client: attach an image to a squad message + a thread reply; both post with attachments;
+      thumbnails render on the tile; photo-only (no text) works. `flutter analyze` + widget tests.
+
+## Risks / unknowns
+
+- The squad composer is inline + stateless-ish; adding pending-attachment state is the main
+  surgery. Thread reply input is separate — do both or sequence them.
+- Confirm the client `Message` model carries `attachments` (server returns them now).
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-realtime-sse.md
+++ b/plans/v2-realtime-sse.md
@@ -1,0 +1,68 @@
+---
+status: planned
+depends: [v2-backend-infra]
+specs: []
+issues: []
+pr:
+---
+
+# Plan: v2 realtime (SSE + Postgres LISTEN/NOTIFY)
+
+> **Backlog stub** (`status: planned`). Realtime has been named as the intended path since the
+> architecture spec; many done plans note "SSE is an enhancement, never load-bearing." This is
+> its first living home. Specs-first at pickup.
+
+## Scope
+
+Push live updates to clients instead of pull-to-refresh, as an **enhancement layer** — the app
+must stay fully functional if the stream drops (architecture principle). First surfaces: the
+friends/squad timelines and open threads (new messages/replies appear without manual refresh).
+
+**In (anticipated):**
+
+- Server: an SSE endpoint (e.g. `GET /v1/stream`) that fans out events sourced from Postgres
+  `LISTEN/NOTIFY`; emit on the writes that matter (new activity, new message/reply, RSVP/face-pile
+  change). Auth'd; scoped so a client only receives events it may see (reuse `canView`/membership).
+- Client: an SSE consumer that invalidates the relevant Riverpod providers on an event (or merges
+  the payload), with reconnect/backoff; pull-to-refresh stays as the fallback.
+
+**Out:** typing indicators / presence; a generic pub/sub for all resources (start with the few
+high-value surfaces); Redis fan-out (only if/when multi-instance — `min_instances=1` today keeps
+a single `LISTEN` connection simple, noted in `v2-backend-infra`).
+
+## Implements
+
+New `specs/behaviors/realtime.md` (the event set, delivery guarantees = best-effort, the
+"never load-bearing" rule) + touches to the screen specs that consume it. Written first at pickup.
+
+## Approach (rough — refine at pickup)
+
+- One Postgres `LISTEN` connection on the server; domain writes `NOTIFY` a channel with a small
+  JSON payload (kind + ids). The SSE handler filters per-subscriber by visibility and streams.
+- Cloud Run: `min_instances=1` + a generous request timeout already set; validate long-lived SSE
+  there (the `v2-backend-infra` plan flagged this as the thing to confirm for real).
+- Client: a thin SSE client feeding `ref.invalidate(...)`; treat the stream as a *nudge to
+  refetch*, not the source of truth, so a dropped stream just means staler-until-refresh.
+
+## Validation
+
+- [ ] server: NOTIFY on key writes; SSE delivers only visible events; suite + type-check.
+- [ ] client: a second session sees a new message/activity appear without manual refresh;
+      stream drop → app still works via pull-to-refresh.
+- [ ] (prod) SSE holds open on Cloud Run without premature timeout.
+
+## Risks / unknowns
+
+- **SSE on Cloud Run**: request timeouts + scaling vs long-lived streams — the open question
+  from `v2-backend-infra`. Validate before building much on it.
+- **Visibility filtering** per subscriber must reuse the same gates as the REST reads, or
+  realtime becomes a privacy leak. Spec the event→audience mapping explicitly.
+- Keep it an enhancement: never let a screen *require* the stream to function.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-styling-pass.md
+++ b/plans/v2-styling-pass.md
@@ -1,0 +1,71 @@
+---
+status: planned
+depends: []
+specs: []
+issues: []
+pr:
+---
+
+# Plan: v2 styling pass (re-port the polished mock UI)
+
+> **Backlog stub** (`status: planned`). The whole v2 client was built **functionality-first,
+> styling deferred** — nearly every done client plan says so. This is where that debt gets paid:
+> bring the screens up to the polished v2 mock UI. Best done once the feature surface stops
+> moving. Specs are largely unaffected (specs declare *what*, not visual design — see
+> `principles.md`/SpecOps); this is a UI/theme effort, not a contract change.
+
+## Scope
+
+Re-port the polished v2 mock UI (cards, thread drawer, composer, timeline tiles, context
+selector, communities) from the `v1` branch's `lib/v2` mock into the live client, replacing the
+current plain/functional screens. Establish shared theme constants (color, type, spacing) and
+reusable widgets so it's consistent, not per-screen one-offs.
+
+**In (anticipated):**
+
+- Theme/constants foundation (`constants/` — colors, typography, spacing) + a few shared widgets
+  (activity card, message tile, section headers, the thread drawer surface).
+- Screen-by-screen restyle: timeline (friends/squad/community), activity detail, compose, squads,
+  communities + leader forms, friends/People, welcome, thread view.
+- Wire in the **photo** surfaces now that they exist (avatars on tiles/face-piles, community
+  cover images, message thumbnails).
+
+**Out:** new behavior or endpoints (pure presentation); animations/motion polish beyond the mock;
+icon/illustration asset production.
+
+## Implements
+
+No API/behavior spec changes expected. If a screen spec's *Display Rules* turn out to under- or
+mis-specify what the mock shows, fix that spec first (per SpecOps) — but the bulk is visual.
+
+## Approach (rough — refine at pickup)
+
+- Pull the `lib/v2` mock from the `v1` branch as the visual reference; lift its theme + widget
+  decomposition rather than re-inventing.
+- Land the theme/constants + shared widgets first, then restyle screens incrementally (each screen
+  is independently shippable — don't block on a big-bang).
+- Verify against each screen spec's Display Rules so styling doesn't drift behavior.
+
+## Validation
+
+- [ ] theme constants + shared widgets in place; screens restyled to the mock; `flutter analyze`
+      + widget tests stay green.
+- [ ] each restyled screen still satisfies its spec's Display Rules (no behavior regressions).
+
+## Risks / unknowns
+
+- Large surface; **must stay incremental** (per-screen PRs) — a single mega-restyle PR is
+  unreviewable and risky.
+- Easy to accidentally change behavior while restyling — keep the spec's Display Rules as the
+  acceptance check for each screen.
+- The `lib/v2` mock lives on the `v1` branch; porting means reading across branches.
+- Best sequenced **after** the remaining feature/UI work (message attachments) so screens aren't
+  restyled then immediately re-touched.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)


### PR DESCRIPTION
Gives the remaining v2 work living homes in the plans DAG rather than leaving it as 'Out of scope' / 'Follow-up' notes buried in **frozen (done)** plans — where `specops next` can't see it and the next session would re-litigate it.

Three `planned` stubs (intent + rough scope; specs-first deferred to pickup, like `v2-wants`):
- **v2-message-attachments-ui** — the deferred client half of `v2-storage-media` (composer attach + thumbnail render; backend + PhotoPicker already done).
- **v2-realtime-sse** — the SSE + LISTEN/NOTIFY realtime stage (long-named in the architecture; first living home).
- **v2-styling-pass** — re-port the polished mock UI (the deferred functionality-first debt).

`specops next` now surfaces **4 ready**: these three + `v2-wants`.

Note: the owed MCP visual walkthroughs / real-phone SMS check are intentionally **not** tracked — not worth doing retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)