### PR TITLE
fix(server): wire community_event threads + correct API spec drift

### DIFF
--- a/plans/v2-api-drift-cleanup.md
+++ b/plans/v2-api-drift-cleanup.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: done
 depends: []
 specs:
   - specs/api/messages.md
@@ -7,7 +7,7 @@ specs:
   - specs/api/conventions.md
   - specs/screens/communities.md
 issues: []
-pr:
+pr: 443
 ---
 
 # Plan: v2 API drift cleanup
@@ -61,11 +61,11 @@ spec-to-match-code.
 
 ## Validation
 
-- [ ] community_event threads: `GET`/`POST /v1/threads/community_event/:id/messages` work, gated
+- [x] community_event threads: `GET`/`POST /v1/threads/community_event/:id/messages` work, gated
       to who can see the event; `thread_count` on event cards becomes reachable. Tests.
-- [ ] specs updated for pagination wording, client-header wording, timeline alias — no remaining
+- [x] specs updated for pagination wording, client-header wording, timeline alias — no remaining
       drift on these (re-run `/audit-spec-drift`).
-- [ ] `bun test` + type-check; CI.
+- [x] `bun test` (51 pass) + `type-check` (clean); CI.
 
 ## Risks / unknowns
 
@@ -75,8 +75,27 @@ spec-to-match-code.
 
 ## Notes
 
-(closeout)
+All four audit findings resolved in one PR (#443), two commits:
+
+- **Item 1 (code-to-match-spec):** `community_event` is now a live thread target. The visibility
+  gate reuses the open-community read model — any authenticated viewer who can see the event
+  (i.e. it exists) can read/reply; no follower gate, mirroring `events`/`discover` which never
+  gate on membership. Implemented by querying `communityEvent` directly in
+  `MessageService.assertCanSeeTarget` rather than coupling to `CommunityService`. New test in
+  `messages.test.ts` covers reply→read→`thread_count` reachable→bad-target 404.
+- **Items 2–4 (spec-to-match-code):** chose the cheaper honest fix (spec update) for all three,
+  as the plan anticipated. Pagination → "flat `{items}`, no cursor yet"; `/timeline` alias struck
+  from both `communities.md` and `screens/communities.md`; client-header reworded from "required"
+  to "sent by every client, absence tolerated (Stage-1), tightening deferred."
 
 ## Follow-ups
 
-(closeout)
+- **Deferred (tracked in spec prose, no plan needed):** real community-list pagination — revisit
+  when community count warrants it (noted in `communities.md`).
+- **Deferred (tracked in `conventions.md` + `client-version.ts` comment):** hard-require the
+  client-build header (reject absent/unparseable with `400`) once every shipped build is known to
+  send it. Latent companion footgun from the prior session still stands: `MIN_SUPPORTED_BUILD` is
+  set process-wide by `auth.test.ts` and leaks across the shared bun-test process — proper fix is
+  per-suite env reset; not addressed here.
+- **None** for the `errors.forbidden` signature nit and OTP `expires_in` docs — explicitly out of
+  scope, not worth tracking.

--- a/server/src/domain/message/service.ts
+++ b/server/src/domain/message/service.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray, sql } from 'drizzle-orm'
 
 import type { Database } from '../../db/index.ts'
-import { message, activity } from '../../db/schema/index.ts'
+import { message, activity, communityEvent } from '../../db/schema/index.ts'
 import type { MessageAttachment } from '../../db/schema/message.ts'
 import { ApiError, errors } from '../../contracts/errors.ts'
 import { ActivityService } from '../activity/service.ts'
@@ -16,8 +16,8 @@ function assertHasContent(body: string, attachments: MessageAttachment[]): void 
   }
 }
 
-// Thread targets supported this stage (community_event arrives with communities).
-export type ThreadTargetType = 'activity' | 'message'
+// Polymorphic thread root kinds (specs/api/messages.md, data-model.md).
+export type ThreadTargetType = 'activity' | 'community_event' | 'message'
 
 export class MessageService {
   constructor(private readonly db: Database) {}
@@ -59,6 +59,16 @@ export class MessageService {
       if (!act || !(await this.activities.canView(viewerId, act))) {
         throw new ApiError(404, 'not_found', 'Thread not found')
       }
+      return
+    }
+    if (targetType === 'community_event') {
+      // Communities are open: any authenticated user who can see the event (i.e. it
+      // exists) can see its thread. No follow gate — mirrors the open events/discover read.
+      const [ev] = await this.db
+        .select()
+        .from(communityEvent)
+        .where(eq(communityEvent.id, targetId))
+      if (!ev) throw new ApiError(404, 'not_found', 'Thread not found')
       return
     }
     // message target: a thread hung off a squad message → squad members can see it.

--- a/server/src/routes/v1/messages.ts
+++ b/server/src/routes/v1/messages.ts
@@ -28,9 +28,9 @@ function decodeCursor(raw: string): { createdAt: Date; id: string } | undefined 
   }
 }
 
-// targetType ∈ {activity, message} this stage (community_event arrives with communities).
+// targetType ∈ {activity, community_event, message} (specs/api/messages.md).
 function parseTargetType(raw: string): ThreadTargetType {
-  if (raw === 'activity' || raw === 'message') return raw
+  if (raw === 'activity' || raw === 'community_event' || raw === 'message') return raw
   throw errors.badRequest('invalid_target', 'Unsupported thread target')
 }
 

--- a/server/test/messages.test.ts
+++ b/server/test/messages.test.ts
@@ -29,12 +29,21 @@ afterAll(async () => {
   await server.close()
 })
 beforeEach(async () => {
-  await server.sql`truncate message, squad, squad_membership, activity, friendship, profile, topic cascade`
+  await server.sql`truncate message, squad, squad_membership, activity, friendship, community, community_event, profile, topic cascade`
   const [t] = await server.sql<{ id: string }[]>`
     insert into topic (noun, verb, label) values ('Bike Ride','Go on a','Go on a Bike Ride')
     returning id`
   topicId = t.id
 })
+
+async function seedCommunityEvent(): Promise<string> {
+  const [c] = await server.sql<{ id: string }[]>`
+    insert into community (name, tagline) values ('Wednesday Rides','ride bikes') returning id`
+  const [e] = await server.sql<{ id: string }[]>`
+    insert into community_event (community_id, title, time) values (${c.id}, 'Cherry Blossoms Ride', 'Wed 6:30pm')
+    returning id`
+  return e.id
+}
 
 function createSquad(auth: object, name: string, memberIds: string[] = []) {
   return server.inject({ method: 'POST', url: '/v1/squads', headers: auth, payload: { name, member_ids: memberIds } })
@@ -174,4 +183,47 @@ test('squad-message thread: members reply/read, non-members 404; free text never
       expect(item.scope ?? 'friends').toBe('friends')
     }
   }
+})
+
+test('community_event thread: any user can reply/read (open community); thread_count surfaces; bad target 404s', async () => {
+  const leader = await makeUser('+12150002030')
+  const anyone = await makeUser('+12150002031')
+  const eventId = await seedCommunityEvent()
+
+  // anyone authenticated (communities are open) can reply
+  const reply = await server.inject({
+    method: 'POST',
+    url: `/v1/threads/community_event/${eventId}/messages`,
+    headers: anyone.auth,
+    payload: { body: 'see you there!' },
+  })
+  expect(reply.statusCode).toBe(201)
+
+  // and read it back
+  const thread = await server.inject({
+    method: 'GET',
+    url: `/v1/threads/community_event/${eventId}/messages`,
+    headers: leader.auth,
+  })
+  expect(thread.json().items).toHaveLength(1)
+  expect(thread.json().items[0].body).toBe('see you there!')
+
+  // thread_count is now reachable on the event card
+  const [{ communityId }] = await server.sql<{ communityId: string }[]>`
+    select community_id as "communityId" from community_event where id = ${eventId}`
+  const events = await server.inject({
+    method: 'GET',
+    url: `/v1/communities/${communityId}/events`,
+    headers: leader.auth,
+  })
+  const ev = events.json().items.find((e: { id: string }) => e.id === eventId)
+  expect(ev.thread_count).toBe(1)
+
+  // a thread on a nonexistent event 404s
+  const missing = await server.inject({
+    method: 'GET',
+    url: '/v1/threads/community_event/00000000-0000-0000-0000-000000000000/messages',
+    headers: leader.auth,
+  })
+  expect(missing.statusCode).toBe(404)
 })

--- a/specs/api/communities.md
+++ b/specs/api/communities.md
@@ -8,7 +8,9 @@ Authenticated.
 
 ## GET /v1/communities
 
-List/discover communities. `?search=`, cursor-paginated.
+List/discover communities. `?search=` (case-insensitive name match). Returns all matches as a
+flat `{ "items": [...] }` — no cursor yet; real pagination is deferred until community count
+warrants it.
 
 - **Item:** `{ "id", "name", "tagline", "icon", "color", "photo", "follower_count", "you_follow": bool, "your_role": "leader" | null }`.
   `icon` is an emoji glyph; `photo` is a public media URL (cover image, nullable) — see
@@ -24,7 +26,7 @@ Toggle following (open/frictionless — no approval).
 
 ## GET /v1/communities/:id/events
 
-The community's events (also surfaced via `GET /v1/communities/:id/timeline`).
+The community's events.
 
 - **Serialized community_event:**
 

--- a/specs/api/conventions.md
+++ b/specs/api/conventions.md
@@ -40,7 +40,7 @@ Within a major version:
   route edge map current schema → stable wire shapes. Business logic speaks one current
   domain model; version logic lives only in edge adapters (`server/src/contracts/`).
 
-### Client build header (required on every request)
+### Client build header (sent on every request)
 
 ```
 X-SquadQuest-Client: <platform>/<version>+<build>      e.g. ios/1.4.2+312
@@ -50,6 +50,12 @@ Used for: (1) telemetry on the live build distribution; (2) the upgrade floor; (
 per-build **response** shaping when a read shape must change (fork the serializer, not the
 handler). The client never asks for "version N of X" — it calls the URLs baked into its
 build; the header is how the *server* learns who's calling.
+
+Every SquadQuest client sends it. The server currently **tolerates its absence** (a request
+with no header is parsed as "unknown build" and allowed through) — a Stage-1 simplification.
+A missing header therefore can't trip the upgrade floor; only a *present* build below the
+floor does. Hard-requiring the header (reject unparseable/absent with `400`) is a later-stage
+tightening, deferred until every shipped build is known to send it.
 
 ### Upgrade floor
 

--- a/specs/screens/communities.md
+++ b/specs/screens/communities.md
@@ -10,7 +10,7 @@ Title bar shows the community icon + name, tappable to switch context.
 
 ## Data Requirements
 
-- `GET /v1/communities/:id/timeline` (or `/events`) — serialized `community_event` objects
+- `GET /v1/communities/:id/events` — serialized `community_event` objects
   (see [`api/communities.md`](../api/communities.md)), each with `going_count`,
   `public_going` (face-pile), `your_rsvp`, `recurrence`, `thread_count`.
 


### PR DESCRIPTION
Resolves the `v2-api-drift-cleanup` plan — the four findings from last session's spec-drift audit.

## Item 1 — community_event threads (the one real bug)

`GET`/`POST /v1/threads/community_event/:id/messages` was a dead route: the `thread_target_type` enum had `community_event`, `CommunityService` already computed its `thread_count`, and `specs/api/messages.md` listed it as valid — but `parseTargetType` rejected it with `invalid_target` 400.

- Add `community_event` to `ThreadTargetType` + accept it in `parseTargetType`.
- Gate visibility in `assertCanSeeTarget`: communities are open, so any authenticated viewer who can see the event (it exists) can read/reply — no follower gate, mirroring the ungated `events`/`discover` reads. Queries `communityEvent` directly to avoid coupling `MessageService` → `CommunityService`.
- New test: reply → read → `thread_count` reachable on the event card → bad-target 404.

## Items 2–4 — spec-to-match-code corrections

- **Pagination:** `GET /v1/communities` returns a flat `{items}` (no cursor) — dropped the "cursor-paginated" claim; real pagination deferred.
- **`/timeline` alias:** only `/events` exists — struck from `communities.md` + `screens/communities.md`.
- **Client header:** reworded "required" → sent by every client but absence tolerated (Stage-1); hard-require deferred.

## Validation

- `bun test` — 51 pass (was 50; +1 new test)
- `type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)