### PR TITLE
fix(app): android release networking + per-build client header

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The app talks to the /v1 API over HTTPS in every build mode (not just
+         debug/profile), so INTERNET belongs in the main manifest. flutter create
+         only adds it to the debug/profile manifests. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="squadquest"
         android:name="${applicationName}"

--- a/app/lib/config.dart
+++ b/app/lib/config.dart
@@ -12,5 +12,12 @@ const apiBaseUrl = String.fromEnvironment(
 );
 
 /// Sent as X-SquadQuest-Client on every request (telemetry + upgrade floor).
-/// TODO: derive from package_info_plus once release versioning is wired up.
-const clientHeader = 'macos/0.1.0+1';
+/// Passed via --dart-define per build target so it reports the right platform,
+/// e.g. --dart-define=CLIENT_HEADER=android/1.0.0+1. Defaults to the macOS dev
+/// value so `flutter run -d macos` needs no flag.
+/// TODO: derive build automatically from package_info_plus once release
+/// versioning is wired up.
+const clientHeader = String.fromEnvironment(
+  'CLIENT_HEADER',
+  defaultValue: 'macos/0.1.0+1',
+);


### PR DESCRIPTION
Two client correctness fixes surfaced while producing release APKs that connect to the live `api.squadquest.app`.

- **INTERNET permission in the main manifest.** `flutter create` only adds `android.permission.INTERNET` to the debug/profile manifests. A release build merges from `main` without it and silently can't reach the `/v1` API. The app uses the network in every build mode, so it belongs in `main`.
- **Per-build client header.** `clientHeader` was hardcoded `macos/0.1.0+1`; an Android build would mis-report its platform in `X-SquadQuest-Client` telemetry. Now a `--dart-define=CLIENT_HEADER=...` like `apiBaseUrl`, defaulting to the macOS dev value so `flutter run -d macos` is unchanged.

Enables debug-signed release APKs (pointed at prod) for on-device milestone testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)