### PR TITLE
feat(app): android dev/prod build flavors

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -15,14 +15,31 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        // Base application id. The `prod` flavor keeps it as-is (v2 ships as the
+        // v1 store update — bundle id is deliberately preserved; see
+        // specs/behaviors/v1-migration.md). The `dev` flavor suffixes it so a
+        // milestone build installs alongside v1/prod on the same device.
         applicationId = "app.squadquest"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+    }
+
+    // Build channels. `prod` is the real store identity; `dev` is the sideload-
+    // alongside identity for on-device milestone testing. Android-only for now
+    // (iOS flavor schemes are a later follow-up).
+    flavorDimensions += "channel"
+    productFlavors {
+        create("prod") {
+            dimension = "channel"
+            manifestPlaceholders["appLabel"] = "SquadQuest"
+        }
+        create("dev") {
+            dimension = "channel"
+            applicationIdSuffix = ".dev"
+            manifestPlaceholders["appLabel"] = "SquadQuest Dev"
+        }
     }
 
     buildTypes {

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
          only adds it to the debug/profile manifests. -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <application
-        android:label="squadquest"
+        android:label="${appLabel}"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -16,6 +16,22 @@ is preserved from v1 so v2 ships as an app-store update. The v1 app and the orig
 `lib/v2` mock are archived on the protected `v1` branch; v2 screens are re-ported from there
 as they're built against the real backend + specs.
 
+**Build channels (flavors).** The Android build carries a `channel` flavor dimension so a
+sideloaded test build is a distinct app from the store build:
+
+- **`prod`** (default) — `applicationId app.squadquest`, label "SquadQuest". The real store
+  identity; preserves the v1 bundle id per the update path above.
+- **`dev`** — `app.squadquest.dev`, label "SquadQuest Dev". Installs *alongside* v1/prod on the
+  same device (a same-id/different-signing-key APK is a hard Android install block, which a
+  debug-signed `app.squadquest` build would hit). Used for the milestone APKs published to the
+  media bucket for on-device testing.
+
+Both currently sign with the debug key; a release keystore is a later step. Flavors are
+**Android-only** for now — iOS schemes/xcconfig flavors are a deferred follow-up, so
+`flutter build ipa --flavor …` isn't wired yet. The API base URL and client header are
+per-build `--dart-define`s (`API_BASE_URL`, `CLIENT_HEADER`), independent of flavor — a dev
+APK points at prod `https://api.squadquest.app` unless told otherwise.
+
 ## Backend: custom Fastify/Bun + Postgres (not Supabase)
 
 v2 runs on a **purpose-built backend we own**, not Supabase:


### PR DESCRIPTION
Gives milestone test builds a distinct app identity so they install **alongside** SquadQuest v1 instead of colliding with it.

## Why

The APK I built earlier was `app.squadquest` — the **same bundle id as v1** (v2 deliberately reuses it to ship as a store update). Android refuses to install a same-id APK signed with a different key over an existing install, so a debug-signed `app.squadquest` build can't go on a phone that has v1.

## What

A `channel` flavor dimension (Android):

| Flavor | applicationId | Label |
|---|---|---|
| `prod` (default) | `app.squadquest` | SquadQuest |
| `dev` | `app.squadquest.dev` | SquadQuest Dev |

- `prod` is unchanged — preserves the v1 bundle id per `specs/behaviors/v1-migration.md`.
- Main manifest label is now `${appLabel}`, supplied per-flavor.
- Android-only for now; iOS flavor schemes are a deferred follow-up.
- API base URL + client header remain flavor-independent `--dart-define`s.

## Verified

Built `assembleDevRelease` → APK reports `package: app.squadquest.dev`, `application-label: 'SquadQuest Dev'`, debug-signed, prod API + `android/1.0.0+1` baked in (no localhost/macos defaults). Published to the media bucket as `squadquest-dev-b1.apk`.

CI unaffected — it runs analyze/test/build-web, never a flavorless android build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)