### PR TITLE
docs(specs,plans): profile screen (edit name/photo, sign out)

### DIFF
--- a/plans/v2-profile-screen.md
+++ b/plans/v2-profile-screen.md
@@ -1,0 +1,81 @@
+---
+status: planned
+depends: [v2-storage-media]
+specs:
+  - specs/screens/profile.md
+  - specs/api/profile.md
+  - specs/api/uploads.md
+issues: []
+pr:
+---
+
+# Plan: v2 profile screen (view/edit name + photo, sign out)
+
+> Surfaced from real on-device use: a user who skipped the photo at onboarding has **no way to
+> add it later** — photo/name edit lives only in the welcome step, and the router's onboarding
+> gate (keyed on `first_name`) can never route back to `/welcome` once a name is set. Every
+> backend + client primitive already exists (`PATCH /v1/me` with `photo`,
+> `ProfileRepository.updateProfile`, `authController.updateProfile`, the `PhotoPicker` with
+> `currentUrl`); the entire gap is one screen + an entry point.
+
+## Scope
+
+Build the `/profile` screen per [`specs/screens/profile.md`](../specs/screens/profile.md): view +
+edit own name and photo, phone shown read-only, and sign out (relocated here from the timeline
+app bar).
+
+**In:**
+
+- `ProfileScreen` (`app/lib/screens/profile/profile_screen.dart`) — avatar (`PhotoPicker`,
+  kind `profile`, seeded with `currentUrl` = current photo), first/last name fields, read-only
+  phone, Save (enabled only on change + non-empty first name), Sign out.
+- Route `/profile` in `router.dart`.
+- **Entry point:** make the timeline app-bar avatar tappable → `context.push('/profile')`,
+  replacing the bare logout `IconButton` (sign-out moves into the profile screen).
+- Save calls `authController.updateProfile(...)` with only changed fields; photo-only save works.
+- Widget tests + `flutter analyze`.
+
+**Out:** other-user profile screens; notification-preference editing; clearing a photo
+(empty-string `photo` — API supports it, defer the UI); any styling pass.
+
+## Implements
+
+`specs/screens/profile.md` (new). Reuses the existing `api/profile.md` `PATCH /v1/me` (photo) and
+`api/uploads.md` contracts — no API change. Pure client wiring + one new screen.
+
+## Approach (refine at pickup)
+
+- Reuse `PhotoPicker(kind: 'profile', currentUrl: profile.photo, onUploaded: ...)` — it already
+  pre-populates the avatar and reports the stored public URL.
+- Hold pending photo URL + name edits in screen state; Save sends only what changed (mirror
+  `welcome_screen.dart`'s `_save`). `updateProfile` already accepts optional `firstName` so a
+  photo-only / last-name-only patch is fine.
+- Read current profile from `authControllerProvider`'s `SignedIn(profile)`.
+- Timeline app bar: swap the `logoutButton` IconButton for a tappable `CircleAvatar` (current
+  photo or initials) routing to `/profile`; move sign-out into the profile screen.
+
+## Validation
+
+- [ ] `/profile` renders current name + photo + read-only phone; reachable from the timeline
+      avatar.
+- [ ] Changing the photo and saving persists (`PATCH /v1/me`), avatar updates app-wide; a
+      photo-only save (name untouched) works; Save guard keeps first name non-empty.
+- [ ] Sign out works from the profile screen; the timeline no longer carries a standalone logout
+      button.
+- [ ] `flutter analyze` + widget tests clean; CI `app` job.
+- [ ] (on-device) build `squadquest-dev-b{N}.apk`, set a photo from the phone, confirm it sticks.
+
+## Risks / unknowns
+
+- Avatar-as-button in the app bar: keep a sensible fallback (initials/glyph) when `photo` is null
+  so the entry point is always visible.
+- `Profile` model is currently a read-only DTO (no `copyWith`); not needed — `updateProfile`
+  returns the fresh profile from the server and swaps auth state.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/specs/screens/profile.md
+++ b/specs/screens/profile.md
@@ -1,0 +1,61 @@
+# Screen: Profile
+
+The signed-in user's own profile — view and edit name + photo, and sign out. The post-onboarding
+home for the identity that the welcome step first sets. Authenticated; only ever shows the
+caller's own profile (there is no other-user profile screen at this stage).
+
+## Route
+
+`/profile`. Reached from the **My Friends timeline** app bar (tapping the user's avatar). Back
+returns to wherever the user came from (normally the timeline).
+
+## Data Requirements
+
+- The signed-in profile, already held in the auth controller (`first_name`, `last_name`,
+  `photo`, `phone`) — see [`api/profile.md`](../api/profile.md) `GET /v1/me`. No separate fetch
+  is required; the screen reads current auth state.
+
+## Display Rules
+
+- **Avatar** — the current `photo` if set, else a person-glyph fallback. Tappable to change
+  (the shared photo picker; see [`api/uploads.md`](uploads.md), kind `profile`).
+- **Name** — `first_name` (required) and `last_name` (optional), each editable.
+- **Phone** — shown read-only (the identity key; not editable here). Display the value as stored.
+- A **Save** affordance is enabled only when something changed and a non-empty first name is
+  present; disabled/again-idle otherwise. While saving, show a busy indicator and block
+  re-submit.
+- A **Sign out** action lives on this screen (relocated from the timeline app bar — this is its
+  natural home).
+
+## Actions
+
+- **Change photo** — pick + upload via the photo picker; on success the new public URL is held
+  pending Save (consistent with the welcome step). Picking a photo does not by itself persist.
+- **Edit name** — change first/last name fields.
+- **Save** — `PATCH /v1/me` with only the changed fields (`first_name`, `last_name`, `photo`).
+  A photo-only change (name untouched) is valid. On success the updated profile replaces auth
+  state; surfaces showing the avatar/name reflect it. On failure, show a retryable error and
+  keep edits.
+- **Sign out** — clears the session and returns to the login screen.
+
+## Navigation
+
+- **In:** My Friends timeline app bar → tap avatar.
+- **Out:** back → timeline; **Sign out** → login.
+
+## Principles
+
+**Inherited:**
+
+- [Audience clarity at the moment of action](../principles.md#audience-clarity-at-the-moment-of-action)
+  — a real name + photo is what makes a face-pile / captain line legible; this screen is how a
+  user keeps that identity current after onboarding, not only at first launch.
+
+## Notes
+
+- The onboarding gate keys on a null/empty `first_name`; this screen is only reachable once past
+  that gate, so a photo-only or last-name edit can never strand the user back in onboarding (first
+  name is always already set, and the Save guard keeps it non-empty).
+- Photo upload mechanics (signed PUT, kinds, content-types) are owned by
+  [`api/uploads.md`](uploads.md); this screen just reuses the picker. Removing/clearing a photo
+  (empty-string `photo`) is supported by the API but is a later affordance — not required here.


### PR DESCRIPTION
Spec + plan for a `/profile` screen — surfaced from on-device use: a user who skips the photo at onboarding has **no way to add it later** (name/photo edit lives only in the welcome step, and the onboarding gate keyed on `first_name` never routes back to `/welcome`).

- **`specs/screens/profile.md`** (new): view/edit own name + photo, read-only phone, sign out (relocated from the timeline app bar). Reuses `PATCH /v1/me` (photo) + uploads — **no API change**.
- **`plans/v2-profile-screen.md`** (planned): every primitive already exists (`PhotoPicker` w/ `currentUrl`, `updateProfile`, photo-only PATCH); the gap is one screen + an entry point.

Docs-only; implementation is a follow-up plan pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)