### PR TITLE
docs(specs,plans): CI/CD pipelines — CORS, dev-APK, web previews

### DIFF
--- a/plans/v2-app-android-dev-flavor.md
+++ b/plans/v2-app-android-dev-flavor.md
@@ -1,0 +1,59 @@
+---
+status: done
+depends: []
+specs:
+  - specs/architecture.md
+issues: []
+pr: 445
+---
+
+# Plan: v2 android dev/prod build flavors
+
+> Authored retroactively at `done` to give the dev-flavor work (shipped in PR #445) a real home
+> in the DAG — `v2-ci-cd-pipelines` depends on it (the APK job builds the `dev` flavor).
+
+## Scope
+
+Give Android milestone builds a distinct identity from the store build so a sideloaded debug APK
+installs alongside SquadQuest v1 instead of colliding with it.
+
+**In (shipped):** a `channel` flavor dimension — `prod` (`app.squadquest`, "SquadQuest", the
+preserved v1 store id) and `dev` (`app.squadquest.dev`, "SquadQuest Dev", sideload-alongside).
+Main-manifest label parameterized to `${appLabel}` per flavor. Android only.
+
+**Out:** iOS flavor schemes (deferred); release-keystore signing (dev stays debug-signed).
+
+## Implements
+
+`specs/architecture.md` "Build channels (flavors)" section. Android `build.gradle.kts` flavor
+config + manifest label placeholder.
+
+## Validation
+
+- [x] `assembleDevRelease` → APK reports `app.squadquest.dev`, label "SquadQuest Dev",
+      debug-signed, prod API + android client header baked in.
+- [x] `prod` flavor unchanged (`app.squadquest`).
+- [x] CI unaffected (analyze/test/build-web — no flavorless android build).
+
+## Risks / unknowns
+
+(resolved — see Notes)
+
+## Notes
+
+Shipped in PR #445. Build recipe (the canonical one for milestone APKs — `flutter build apk`
+hangs headless in this environment, so drive gradle directly):
+
+```
+cd app/android && ./gradlew :app:assembleDevRelease --no-daemon --console=plain \
+  -Pdart-defines=<base64 API_BASE_URL=…>,<base64 CLIENT_HEADER=…>
+```
+
+First dev APK published manually to `gs://squadquest-v2-media/apk/squadquest-dev-b1.apk`;
+automation of that publish is `v2-ci-cd-pipelines`.
+
+## Follow-ups
+
+- **Tracked as `v2-ci-cd-pipelines`:** automate the dev-APK build+upload on every develop push
+  (this plan did it once, by hand).
+- **Deferred:** iOS flavor schemes (xcconfig + Runner schemes) for `flutter build ipa --flavor`.

--- a/plans/v2-ci-cd-pipelines.md
+++ b/plans/v2-ci-cd-pipelines.md
@@ -1,0 +1,103 @@
+---
+status: planned
+depends: [v2-backend-infra, v2-storage-media, v2-app-android-dev-flavor]
+specs:
+  - specs/behaviors/ci-cd.md
+  - specs/api/conventions.md
+issues: []
+pr:
+---
+
+# Plan: v2 CI/CD pipelines (CORS + dev APK on develop + branch web previews)
+
+> Extends the existing `develop` publish (prod web + backend) with: a live CORS fix so the web
+> app can actually call the API, an automated dev-APK build per develop push, and per-branch web
+> previews under `v2.squadquest.app/<branch>/`. See [`specs/behaviors/ci-cd.md`](../specs/behaviors/ci-cd.md).
+
+## Scope
+
+Implement the three publish surfaces and the CORS allow-list the spec describes. One plan, three
+coherent parts; the CORS part is the most urgent (web login is broken in prod today).
+
+**In:**
+
+1. **CORS allow-list (live bug fix).**
+   - `server/src/plugins/env.ts`: add `ALLOWED_ORIGINS` (string, default `''`).
+   - `server/src/app.ts`: replace `origin: NODE_ENV==='production' ? false : true` with an
+     allow-list resolver — parse `ALLOWED_ORIGINS` (comma-sep); in non-production also allow
+     `localhost`/dev as today. Echo matched origin, `credentials: true`.
+   - `tf/cloudrun.tf`: set `ALLOWED_ORIGINS=https://v2.squadquest.app` on the service.
+   - Tests: allowed origin echoed; off-list origin blocked; no-Origin (native) unaffected.
+
+2. **Dev APK on develop.** Add a job to `v2-publish.yml`:
+   - Set up Flutter + Java/Android SDK; build `./gradlew :app:assembleDevRelease --no-daemon
+     --console=plain` with base64 `-Pdart-defines` (API_BASE_URL=prod, CLIENT_HEADER=
+     `android/<version>+<run_number>`). (Use gradle directly — `flutter build apk` hangs headless.)
+   - Upload to `gs://squadquest-v2-media/apk/squadquest-dev-b<run_number>.apk` (+ optional
+     `squadquest-dev-latest.apk`) via the existing WIF auth + `upload-cloud-storage`.
+
+3. **Branch web previews.** New workflow (e.g. `v2-preview.yml`), `on: push` with
+   `branches-ignore: [v1]`:
+   - Sanitize branch → segment (`feat/x`→`feat-x`); `flutter build web --pwa-strategy=none
+     --base-href=/<segment>/`.
+   - Upload `app/build/web` to `gs://v2.squadquest.app/<segment>/`; `no-cache` on objects.
+   - Backend/Cloud Run + root web deploy stay develop-only (don't run here).
+
+4. **WIF relaxation (`tf/frontend.tf`).** Change the `v2` provider `attribute_condition` from
+   `ref=='refs/heads/develop'` to `repository=='SquadQuest/SquadQuest' && ref != 'refs/heads/v1'`.
+   (Storybook provider left as-is unless we want previews there too — out of scope.)
+
+**Out:** dedicated preview subdomain/origin (path-based chosen — no new DNS/SSL/LB); auto-pruning
+stale previews on branch delete (documented follow-up); iOS build publishing; release-keystore
+signing (dev builds stay debug-signed); storybook preview branches.
+
+## Implements
+
+`specs/behaviors/ci-cd.md` (new) and the CORS section added to `specs/api/conventions.md`.
+Touches `.github/workflows/` (publish + new preview workflow), `server/src/{app,plugins/env}.ts`,
+`tf/cloudrun.tf` (ALLOWED_ORIGINS), `tf/frontend.tf` (WIF condition).
+
+## Approach (refine at pickup)
+
+- Land **CORS first** as its own commit/PR slice — it's the live fix and is independently
+  verifiable (curl with an `Origin` header against prod after deploy). The APK + preview jobs can
+  follow in the same plan but later commits.
+- WIF condition change is `tofu apply` (security-sensitive — call it out in the PR). Verify a
+  non-develop branch push can mint a token *after* apply, not before.
+- Reuse the exact dev-APK recipe proven this session; parameterize build number from
+  `${{ github.run_number }}`.
+- Keep the preview workflow's permissions minimal (`id-token: write`, `contents: read`) and its
+  steps to build-web + auth + upload only.
+
+## Validation
+
+- [ ] CORS: after deploy, a browser request from `https://v2.squadquest.app` to the API succeeds
+      (preflight + actual); an off-list origin is blocked; a no-Origin (curl/native) request is
+      unaffected. Server tests cover the resolver.
+- [ ] Web actually works end-to-end at `https://v2.squadquest.app` (login → timeline) — the
+      observable proof the CORS fix landed.
+- [ ] develop push publishes a fresh `squadquest-dev-b<N>.apk` to the media bucket; the link
+      installs and points at prod.
+- [ ] A push to a feature branch publishes `v2.squadquest.app/<branch>/` and it loads (assets
+      resolve under the subpath via base-href); the API is reachable from it (same origin).
+- [ ] A push to `v1` triggers **no** v2 deploy (workflow filter + WIF condition both exclude it).
+- [ ] `tofu plan` clean; `bun test`; CI green.
+
+## Risks / unknowns
+
+- **WIF relaxation is the sharp edge.** Widening allowed refs must keep `v1` excluded at both the
+  WIF condition and the workflow filter (defense in depth). Double-check the CEL expression syntax
+  for `!=` on `assertion.ref`.
+- Android build time on CI: first run pulls the Gradle distro + deps (slow); rely on
+  `subosito/flutter-action` cache + gradle caching to keep develop pushes reasonable.
+- base-href correctness: a wrong `--base-href` yields a white screen (assets 404 under the
+  subpath). Verify with a real branch push, not just locally.
+- Preview bucket growth: no auto-prune at launch — documented, not solved.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/specs/api/conventions.md
+++ b/specs/api/conventions.md
@@ -10,6 +10,23 @@ inherits these conventions. The client binds **only** to this contract, never th
 - JSON over HTTPS. UTF-8. Request/response bodies are JSON unless noted (uploads use signed
   URLs — see Storage).
 
+### CORS (browser clients)
+
+Native clients (Android/iOS/macOS) are not browsers and are unaffected by CORS; this section
+governs only the **web** build.
+
+- The API serves an **explicit allow-list** of browser origins, configured via the
+  `ALLOWED_ORIGINS` env (comma-separated `scheme://host[:port]`). A request whose `Origin` is on
+  the list gets that origin echoed back with `credentials` allowed; an off-list browser origin
+  gets no CORS headers (blocked).
+- The launch allow-list is the production web host **`https://v2.squadquest.app`** plus local dev
+  (`http://localhost:*`). Because an origin is `scheme://host:port` — **path is not part of the
+  origin** — every branch preview served under a path of that host
+  (`v2.squadquest.app/<branch>/`, see [`behaviors/ci-cd.md`](../behaviors/ci-cd.md)) shares the
+  one allow-listed origin and needs no additional CORS entry.
+- An empty/unset `ALLOWED_ORIGINS` blocks all browser origins (safe default). Non-browser
+  requests (no `Origin`) are never CORS-gated.
+
 ## Versioning
 
 Three tiers, each with a distinct job:

--- a/specs/behaviors/ci-cd.md
+++ b/specs/behaviors/ci-cd.md
@@ -1,0 +1,103 @@
+# Behavior: CI/CD — build & publish pipelines
+
+## Rule
+
+Pushes to the v2 trunk and to feature branches produce published artifacts automatically, so
+every merge is live and every branch is previewable without manual build steps.
+
+Three publish surfaces, all from GitHub Actions authenticating to GCP via Workload Identity
+Federation (no long-lived keys):
+
+| Trigger | Artifact | Destination |
+|---|---|---|
+| push to `develop` | **prod web** build | `gs://v2.squadquest.app/` (root) → `https://v2.squadquest.app` |
+| push to `develop` | **backend image** | Artifact Registry → Cloud Run `squadquest-backend` (migrate-on-startup) |
+| push to `develop` | **dev APK** | `gs://squadquest-v2-media/apk/squadquest-dev-b<N>.apk` |
+| push to **any branch except `v1`** | **branch web preview** | `gs://v2.squadquest.app/<branch>/` → `https://v2.squadquest.app/<branch>/` |
+
+`develop` is itself "any branch except v1", so a develop push publishes both the root prod web
+build *and* (harmlessly) a `/develop/` preview; the root deploy is the canonical one. Treat the
+preview of develop as incidental, not a separate product surface.
+
+## Applies To
+
+- `.github/workflows/v2-publish.yml` (develop: web + backend + APK).
+- The branch-preview workflow (push to non-`v1` branches: web preview).
+- `tf/` Workload Identity Federation providers + the deploy service account's bucket bindings.
+- [`api/conventions.md`](../api/conventions.md) CORS allow-list (the web previews + prod web are
+  the browser origins the API must allow).
+
+## Details
+
+### Artifact identity & paths
+
+- **APK build number** is the GitHub Actions **run number** (`squadquest-dev-b<run_number>.apk`),
+  monotonic and traceable back to a run. The APK is the **`dev` flavor** (`app.squadquest.dev`,
+  "SquadQuest Dev") pointed at prod (`--dart-define=API_BASE_URL=https://api.squadquest.app`,
+  `CLIENT_HEADER=android/<version>+<run_number>`) so it installs alongside v1 (see
+  [`architecture.md`](../architecture.md) build channels). A stable
+  `squadquest-dev-latest.apk` copy may also be published for a permanent "newest dev build" link.
+- **Branch name → path segment** is sanitized: lowercased, any character outside `[a-z0-9._-]`
+  (notably `/` in `feat/x`) replaced with `-`, yielding e.g. `feat/profile-screen` →
+  `feat-profile-screen/`. The same sanitized segment is the web `--base-href=/<segment>/` so
+  asset URLs resolve under the subpath.
+- Web builds use `--pwa-strategy=none` (no service worker — it otherwise serves a stale build
+  until a second reload) and are uploaded with `Cache-Control: no-cache` so deploys show up
+  immediately (CDN is off; traffic is tiny).
+
+### Web preview origin & CORS
+
+A branch preview is served under a **path** of `v2.squadquest.app`, so its browser **origin** is
+`https://v2.squadquest.app` — identical to prod web. One CORS allow-list entry therefore covers
+prod web and all previews (see [`api/conventions.md`](../api/conventions.md) CORS). No per-branch
+DNS, SSL SAN, or LB rule is needed — the existing `v2.squadquest.app` host-rule already routes
+every path to the v2 bucket.
+
+> Consequence (acceptable for a dev tool): previews share an origin with prod web, hence share
+> browser-local token storage. A preview and prod web can't be signed in as different users in
+> the same browser at the same time. If that ever matters, promote previews to a dedicated
+> origin (subdomain) — which then needs wildcard CORS + DNS + SSL.
+
+### Trigger gating (Workload Identity Federation)
+
+- The WIF provider attribute condition currently pins to `assertion.ref=='refs/heads/develop'`.
+  Branch previews require **relaxing** it to allow any ref in `repository ==
+  'SquadQuest/SquadQuest'` **except** `refs/heads/v1` (v1 is the protected production branch and
+  must never deploy through the v2 pipeline).
+- This is the one security-sensitive change: it widens which refs can mint a deploy token for the
+  v2 deploy service account. The SA's permissions are unchanged (write to the v2 + media buckets,
+  deploy Cloud Run); only *which branches* can assume it widens. The `v1` exclusion is the guard.
+- The branch-preview workflow itself must also exclude `v1` (`branches-ignore: [v1]`) and skip the
+  backend/Cloud Run + root web deploy (those stay `develop`-only) — defense in depth alongside the
+  WIF condition.
+
+### Idempotency / cleanup
+
+- Re-pushing a branch overwrites its `<branch>/` preview in place (no accumulation per push).
+- Stale previews for merged/deleted branches are **not** auto-pruned at launch (a later
+  follow-up could add a cleanup on branch-delete). Document the limitation rather than silently
+  letting the bucket grow unbounded.
+
+## Principles
+
+**Inherited:**
+
+- [The client binds to the versioned API, never the schema](../principles.md#the-client-binds-to-the-versioned-api-never-the-schema)
+  — previews and prod web are just different builds of the same client hitting the same `/v1`
+  contract; nothing about a preview changes the API surface.
+
+**Local:**
+
+- **`v1` is sacrosanct in the v2 pipeline.** Every v2 CI trigger explicitly excludes `refs/heads/v1`,
+  at both the workflow filter and the WIF condition. v1 ships through its own separate path; a v2
+  workflow must never build, deploy, or mint a deploy token for v1. This is why trigger gating is
+  "all branches *except* v1" rather than an allow-list — an allow-list would silently fail to
+  preview a new branch, but the exclusion makes the one forbidden branch explicit.
+
+## Notes
+
+- Existing state this builds on: `v2-publish.yml` already does prod web + backend on `develop` via
+  WIF; the dev APK build recipe is `gradlew :app:assembleDevRelease` with base64 dart-defines (the
+  `flutter build apk` wrapper hangs headless). APKs already live under `squadquest-v2-media/apk/`.
+- CORS is currently `origin: false` in production (web is blocked today) — the allow-list change
+  is a live bug fix, not just preview enablement.


### PR DESCRIPTION
Spec + plan for build automation, designed as the delta from the existing `develop` publish (prod web + backend) after mapping current state.

## Key findings
- **`v2.squadquest.app` is CORS-blocked from the API right now.** Cloud Run runs `NODE_ENV=production`, and the API does `origin: production ? false : true` → web login is broken in prod today. The plan fixes this first (`ALLOWED_ORIGINS` allow-list).
- **Path-based previews make CORS trivial.** A browser origin is `scheme://host:port` — path isn't part of it. So `v2.squadquest.app/<branch>/` shares prod web's origin; **one** allow-list entry covers prod web + all previews. No per-branch DNS/SSL/LB.

## What's specced
- **`specs/behaviors/ci-cd.md`** (new): develop → prod web + backend + dev APK; any **non-v1** branch → web preview at `v2.squadquest.app/<branch>/`. WIF relaxed to all-branches-except-`v1` (the one security-sensitive change — v1 stays sacrosanct, enforced at both the workflow filter and the WIF condition).
- **`specs/api/conventions.md`**: CORS section (explicit allow-list; safe-empty default; native clients not CORS-gated).

## Plans
- **`plans/v2-ci-cd-pipelines.md`** (planned): combined, CORS-first.
- **`plans/v2-app-android-dev-flavor.md`**: backfilled at `done` (PR #445) so the new plan's dependency on the dev flavor has a real home (caught by `specops` flagging a dangling edge).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)