### PR TITLE
feat: v2 CI/CD pipelines — CORS, dev-APK on develop, branch web previews

### DIFF
--- a/.github/workflows/v2-preview.yml
+++ b/.github/workflows/v2-preview.yml
@@ -1,0 +1,67 @@
+name: 'V2: Branch preview'
+
+# Publish a web build of any feature branch to v2.squadquest.app/<branch>/ so it's
+# previewable without merging. develop publishes the root (v2-publish.yml) and v1 is
+# the protected production branch — both excluded here. See specs/behaviors/ci-cd.md.
+on:
+  push:
+    branches-ignore:
+      - develop
+      - v1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Sanitize the branch name into a path segment: lowercase, anything outside
+      # [a-z0-9._-] (notably the "/" in feat/x) → "-". e.g. feat/Profile → feat-profile.
+      - name: Derive preview path segment
+        id: seg
+        run: |
+          seg=$(printf '%s' "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')
+          echo "segment=$seg" >> "$GITHUB_OUTPUT"
+          echo "Preview path: /$seg/"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.1
+          channel: stable
+          cache: true
+
+      # --base-href=/<segment>/ so asset URLs resolve under the subpath.
+      # --pwa-strategy=none for the same reason as the root build (no stale SW).
+      - name: Build web
+        working-directory: app
+        run: |
+          flutter pub get
+          flutter build web --pwa-strategy=none --base-href=/${{ steps.seg.outputs.segment }}/
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          service_account: 'v2-github-action@squadquest-d8665.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/902139539375/locations/global/workloadIdentityPools/github/providers/v2-github-actions'
+
+      - uses: 'google-github-actions/setup-gcloud@v3'
+
+      - uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: 'app/build/web'
+          destination: 'v2.squadquest.app/${{ steps.seg.outputs.segment }}'
+          parent: false
+
+      # Always-revalidate so a re-push shows immediately (CDN off, traffic tiny).
+      - name: 'Set no-cache on preview objects'
+        run: gcloud storage objects update "gs://v2.squadquest.app/${{ steps.seg.outputs.segment }}/**" --cache-control="no-cache"
+
+      - name: 'Preview URL'
+        run: echo "Published → https://v2.squadquest.app/${{ steps.seg.outputs.segment }}/"

--- a/.github/workflows/v2-publish.yml
+++ b/.github/workflows/v2-publish.yml
@@ -89,3 +89,55 @@ jobs:
 
       - name: 'Deploy to Cloud Run'
         run: gcloud run deploy "$SERVICE" --image="$IMAGE" --region="$REGION" --quiet
+
+  # Build the `dev`-flavor Android APK pointed at prod and publish it to the media
+  # bucket as squadquest-dev-b<run_number>.apk (+ a stable -latest copy). The dev
+  # flavor (app.squadquest.dev) installs alongside v1 on a device. See
+  # specs/behaviors/ci-cd.md + architecture.md (build channels). Runs in parallel
+  # with the web + backend jobs; same WIF auth (gated to develop).
+  v2-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # AGP 9 / Gradle 9.1 need JDK 17+. GitHub runners ship a JDK, but pin it
+      # explicitly so the build doesn't drift with the runner image.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.1
+          channel: stable
+          cache: true
+
+      # build number = the run number (monotonic, traceable back to this run).
+      - name: Build dev APK (→ prod API)
+        working-directory: app
+        run: |
+          flutter pub get
+          flutter build apk --release --flavor dev \
+            --dart-define=API_BASE_URL=https://api.squadquest.app \
+            --dart-define=CLIENT_HEADER=android/1.0.0+${{ github.run_number }}
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          service_account: 'v2-github-action@squadquest-d8665.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/902139539375/locations/global/workloadIdentityPools/github/providers/v2-github-actions'
+
+      - uses: 'google-github-actions/setup-gcloud@v3'
+
+      # Publish a build-numbered artifact + overwrite the stable "latest" link.
+      # public-read bucket + APK mime type so the link installs in one tap.
+      - name: Publish APK to media bucket
+        run: |
+          SRC=app/build/app/outputs/flutter-apk/app-dev-release.apk
+          MIME=application/vnd.android.package-archive
+          gcloud storage cp "$SRC" \
+            "gs://squadquest-v2-media/apk/squadquest-dev-b${{ github.run_number }}.apk" \
+            --content-type="$MIME"
+          gcloud storage cp "$SRC" \
+            "gs://squadquest-v2-media/apk/squadquest-dev-latest.apk" \
+            --content-type="$MIME" --cache-control="no-cache"

--- a/plans/v2-ci-cd-pipelines.md
+++ b/plans/v2-ci-cd-pipelines.md
@@ -1,11 +1,11 @@
 ---
-status: planned
+status: in-progress
 depends: [v2-backend-infra, v2-storage-media, v2-app-android-dev-flavor]
 specs:
   - specs/behaviors/ci-cd.md
   - specs/api/conventions.md
 issues: []
-pr:
+pr: 448
 ---
 
 # Plan: v2 CI/CD pipelines (CORS + dev APK on develop + branch web previews)
@@ -71,17 +71,18 @@ Touches `.github/workflows/` (publish + new preview workflow), `server/src/{app,
 
 ## Validation
 
-- [ ] CORS: after deploy, a browser request from `https://v2.squadquest.app` to the API succeeds
-      (preflight + actual); an off-list origin is blocked; a no-Origin (curl/native) request is
-      unaffected. Server tests cover the resolver.
-- [ ] Web actually works end-to-end at `https://v2.squadquest.app` (login → timeline) — the
-      observable proof the CORS fix landed.
-- [ ] develop push publishes a fresh `squadquest-dev-b<N>.apk` to the media bucket; the link
-      installs and points at prod.
-- [ ] A push to a feature branch publishes `v2.squadquest.app/<branch>/` and it loads (assets
-      resolve under the subpath via base-href); the API is reachable from it (same origin).
-- [ ] A push to `v1` triggers **no** v2 deploy (workflow filter + WIF condition both exclude it).
-- [ ] `tofu plan` clean; `bun test`; CI green.
+- [x] CORS: server resolver covered by `cors.test.ts` (allow-list, no-Origin, localhost gating,
+      empty-default). `ALLOWED_ORIGINS` applied to Cloud Run via tofu. **Post-merge:** preflight
+      from `https://v2.squadquest.app` echoes `Access-Control-Allow-Origin`; off-list blocked.
+- [ ] **(post-merge)** Web works end-to-end at `https://v2.squadquest.app` (login → timeline) —
+      observable proof the CORS fix deployed.
+- [ ] **(post-merge)** develop push publishes a fresh `squadquest-dev-b<N>.apk` (+ `-latest`) to
+      the media bucket; the link installs and points at prod.
+- [ ] **(post-merge)** A feature-branch push publishes `v2.squadquest.app/<branch>/` and it loads
+      (assets resolve under the subpath via base-href); API reachable from it (same origin).
+- [ ] **(post-merge)** A push to `v1` triggers no v2 deploy (workflow filter + WIF both exclude).
+- [x] `tofu plan` clean (CORS env: 1 change; WIF condition: 1 change — both reviewed full/untargeted);
+      `bun test` 56 pass; `type-check` clean; both workflow YAMLs valid.
 
 ## Risks / unknowns
 
@@ -96,7 +97,24 @@ Touches `.github/workflows/` (publish + new preview workflow), `server/src/{app,
 
 ## Notes
 
-(closeout)
+Built on branch `feat/ci-cd-cors` → PR #448, in two commits:
+
+- **CORS** (`bc72791`): `ALLOWED_ORIGINS` env + pure `isOriginAllowed`/`parseAllowedOrigins`
+  resolver (unit-tested without booting the app / mutating `NODE_ENV` — sidesteps the known
+  process-wide env-leak footgun). tf env **already applied** to Cloud Run (old image ignores it
+  harmlessly; the merge deploys the code that reads it).
+- **APK + previews + WIF** (`8347aaa`): `v2-apk` job (idiomatic `flutter build apk --flavor dev`
+  — the gradlew workaround was only the local no-TTY harness, not CI); `v2-preview.yml`
+  (branches-ignore develop/v1, sanitized segment + base-href); WIF v2 provider relaxed to
+  `ref != refs/heads/v1`.
+
+Status is **in-progress, not done** — the four post-merge validation items can only be confirmed
+after merge + deploy. Flip to done at closeout once verified in prod.
+
+**Sequencing for merge:** the WIF tofu change is **not yet applied** (security-sensitive; left for
+explicit review). It must be `tofu apply`'d for branch previews to authenticate — but it's
+independent of the CORS deploy. Order doesn't matter for CORS; previews simply won't auth until
+the WIF apply lands.
 
 ## Follow-ups
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,6 +9,30 @@ import authPlugin from './plugins/auth.ts'
 import { ApiError, sendError } from './contracts/errors.ts'
 import v1Routes from './routes/v1/index.ts'
 
+// Pure CORS origin decision (extracted so it's unit-testable without booting the
+// app or mutating process-wide NODE_ENV). Returns whether a given request Origin
+// is allowed. A missing origin ⇒ non-browser request ⇒ allowed.
+// See specs/api/conventions.md (CORS) + behaviors/ci-cd.md.
+export function isOriginAllowed(
+  origin: string | undefined,
+  allowedOrigins: Set<string>,
+  allowLocalhost: boolean,
+): boolean {
+  if (!origin) return true
+  if (allowedOrigins.has(origin)) return true
+  if (allowLocalhost && /^https?:\/\/localhost(:\d+)?$/.test(origin)) return true
+  return false
+}
+
+export function parseAllowedOrigins(raw: string): Set<string> {
+  return new Set(
+    raw
+      .split(',')
+      .map((o) => o.trim())
+      .filter(Boolean),
+  )
+}
+
 export const app: FastifyPluginAsync = async (fastify) => {
   // Environment config must load first (validates + decorates fastify.config).
   await fastify.register(envPlugin)
@@ -22,9 +46,18 @@ export const app: FastifyPluginAsync = async (fastify) => {
   await fastify.register(clientVersionPlugin)
   await fastify.register(authPlugin)
 
+  // CORS allow-list (browser clients only — native apps send no Origin and are
+  // never gated). Allowed origins come from ALLOWED_ORIGINS (comma-separated
+  // scheme://host[:port]); in non-production we also allow any localhost origin
+  // for dev convenience. An off-list browser origin gets no CORS headers.
+  // See specs/api/conventions.md (CORS) + behaviors/ci-cd.md.
+  const allowedOrigins = parseAllowedOrigins(fastify.config.ALLOWED_ORIGINS)
+  const allowLocalhost = fastify.config.NODE_ENV !== 'production'
   await fastify.register(cors, {
-    origin: fastify.config.NODE_ENV === 'production' ? false : true,
     credentials: true,
+    // Off-list browser origins get no CORS headers echoed (browser blocks). Not an error.
+    origin: (origin, cb) =>
+      cb(null, isOriginAllowed(origin ?? undefined, allowedOrigins, allowLocalhost)),
   })
 
   // Map thrown ApiErrors to the standard error envelope; everything else is a

--- a/server/src/plugins/env.ts
+++ b/server/src/plugins/env.ts
@@ -31,6 +31,11 @@ const schema = {
     // GCS bucket for user media (signed-URL uploads, public-key reads). Empty
     // disables the uploads endpoint (local dev without GCS creds).
     MEDIA_BUCKET: { type: 'string', default: '' },
+    // Comma-separated browser origins allowed via CORS (scheme://host[:port]),
+    // e.g. "https://v2.squadquest.app". Empty blocks all browser origins (the
+    // safe default). Native clients send no Origin and are never CORS-gated.
+    // See specs/api/conventions.md (CORS) + behaviors/ci-cd.md.
+    ALLOWED_ORIGINS: { type: 'string', default: '' },
   },
 }
 
@@ -48,6 +53,7 @@ declare module 'fastify' {
       TWILIO_AUTH_TOKEN: string
       TWILIO_VERIFY_SERVICE_SID: string
       MEDIA_BUCKET: string
+      ALLOWED_ORIGINS: string
     }
   }
 }

--- a/server/test/cors.test.ts
+++ b/server/test/cors.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test'
+
+import { isOriginAllowed, parseAllowedOrigins } from '../src/app.ts'
+
+// CORS allow-list resolver (specs/api/conventions.md, behaviors/ci-cd.md).
+// Pure-function tested so we don't mutate process-wide NODE_ENV/ALLOWED_ORIGINS.
+
+const prod = parseAllowedOrigins('https://v2.squadquest.app')
+
+test('parseAllowedOrigins: trims, drops empties, handles multi + blank', () => {
+  expect([...parseAllowedOrigins(' https://a.app , https://b.app ')]).toEqual([
+    'https://a.app',
+    'https://b.app',
+  ])
+  expect([...parseAllowedOrigins('')]).toEqual([])
+  expect([...parseAllowedOrigins('  ,  ')]).toEqual([])
+})
+
+test('allowed origin is permitted; off-list browser origin is blocked', () => {
+  // production posture: no localhost allowance
+  expect(isOriginAllowed('https://v2.squadquest.app', prod, false)).toBe(true)
+  expect(isOriginAllowed('https://evil.example', prod, false)).toBe(false)
+  // a path is not part of an origin — the browser only ever sends the origin,
+  // so a preview under v2.squadquest.app/<branch>/ presents this same origin.
+})
+
+test('no Origin (native client / curl) is always allowed', () => {
+  expect(isOriginAllowed(undefined, prod, false)).toBe(true)
+  expect(isOriginAllowed(undefined, parseAllowedOrigins(''), false)).toBe(true)
+})
+
+test('localhost allowed only when allowLocalhost (non-production)', () => {
+  expect(isOriginAllowed('http://localhost:4000', prod, true)).toBe(true)
+  expect(isOriginAllowed('http://localhost', prod, true)).toBe(true)
+  expect(isOriginAllowed('https://localhost:8080', prod, true)).toBe(true)
+  // in production, localhost is not special
+  expect(isOriginAllowed('http://localhost:4000', prod, false)).toBe(false)
+})
+
+test('empty allow-list blocks every browser origin (safe default)', () => {
+  const none = parseAllowedOrigins('')
+  expect(isOriginAllowed('https://v2.squadquest.app', none, false)).toBe(false)
+  // but still never blocks a no-Origin request
+  expect(isOriginAllowed(undefined, none, false)).toBe(true)
+})

--- a/specs/behaviors/ci-cd.md
+++ b/specs/behaviors/ci-cd.md
@@ -97,7 +97,11 @@ every path to the v2 bucket.
 ## Notes
 
 - Existing state this builds on: `v2-publish.yml` already does prod web + backend on `develop` via
-  WIF; the dev APK build recipe is `gradlew :app:assembleDevRelease` with base64 dart-defines (the
-  `flutter build apk` wrapper hangs headless). APKs already live under `squadquest-v2-media/apk/`.
+  WIF. APKs already live under `squadquest-v2-media/apk/`.
+- **Build command:** on CI, use the idiomatic `flutter build apk --release --flavor dev` with
+  `--dart-define`s — it handles flavor + defines cleanly on a hosted runner. (The
+  `./gradlew :app:assembleDevRelease` workaround with base64 dart-defines is only needed in the
+  local agent harness, where the `flutter build apk` wrapper hangs on a detached/no-TTY process —
+  not a CI concern.)
 - CORS is currently `origin: false` in production (web is blocked today) — the allow-list change
   is a live bug fix, not just preview enablement.

--- a/tf/cloudrun.tf
+++ b/tf/cloudrun.tf
@@ -110,6 +110,14 @@ resource "google_cloud_run_v2_service" "backend" {
         value = google_storage_bucket.media.name
       }
 
+      # CORS allow-list for browser clients. The v2 web app (prod + all path-based
+      # branch previews) shares this one origin; native clients aren't CORS-gated.
+      # See specs/api/conventions.md + behaviors/ci-cd.md.
+      env {
+        name  = "ALLOWED_ORIGINS"
+        value = "https://v2.squadquest.app"
+      }
+
       startup_probe {
         http_get {
           path = "/v1/health"

--- a/tf/frontend.tf
+++ b/tf/frontend.tf
@@ -220,7 +220,13 @@ resource "google_iam_workload_identity_pool_provider" "v2" {
     "attribute.actor"            = "assertion.actor"
   }
 
-  attribute_condition = "assertion.repository == 'SquadQuest/SquadQuest' && assertion.ref=='refs/heads/develop'"
+  # Any branch in this repo EXCEPT v1 may mint a deploy token: develop runs the
+  # full publish; other branches publish a web preview (specs/behaviors/ci-cd.md).
+  # v1 is the protected production branch and must never deploy through the v2
+  # pipeline — excluded here AND at the preview workflow's branch filter (defense
+  # in depth). The SA's permissions are unchanged; this only widens which refs may
+  # assume it.
+  attribute_condition = "assertion.repository == 'SquadQuest/SquadQuest' && assertion.ref != 'refs/heads/v1'"
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"


### PR DESCRIPTION
Implements **`v2-ci-cd-pipelines`** — the full delta from the existing develop publish toward build automation. Three parts, two commits.

## 1. CORS allow-list (live prod fix) — `bc72791`
Web login is broken at `v2.squadquest.app` today: the API ran `origin:false` under `NODE_ENV=production`, blocking all browser CORS.
- `env.ts` `ALLOWED_ORIGINS`; `app.ts` allow-list resolver (pure `isOriginAllowed`/`parseAllowedOrigins`, unit-tested without booting the app); `cloudrun.tf` `ALLOWED_ORIGINS=https://v2.squadquest.app`; `cors.test.ts` (5 tests).
- **Already applied to Cloud Run via tofu** — old image ignores the env; this merge deploys the code that reads it.

## 2. Dev APK on develop — `8347aaa`
`v2-apk` job: `flutter build apk --release --flavor dev` (pointed at prod, build no. = run number) → publishes `squadquest-dev-b<N>.apk` + `squadquest-dev-latest.apk` to the media bucket.

## 3. Branch web previews + WIF — `8347aaa`
- `v2-preview.yml`: any branch except `develop`/`v1` → `v2.squadquest.app/<branch>/` (sanitized segment + matching `--base-href`). Path-based, so it shares prod web's origin → covered by the one CORS entry.
- `tf/frontend.tf`: v2 WIF provider relaxed `ref==develop` → `ref != v1`.

## ⚠️ Reviewer note — WIF change needs `tofu apply`
The WIF relaxation is **committed but NOT yet applied** (security-sensitive — left for explicit review). It widens *which refs* can mint a deploy token for the v2 SA (SA permissions unchanged); `v1` excluded at both the WIF condition and the workflow filter. **Branch previews won't authenticate until this is applied.** Independent of the CORS deploy.

## Validation
- `bun test` 56 pass (+5); `type-check` clean; both workflow YAMLs valid.
- `tofu plan` (full, untargeted): CORS env = 1 change; WIF = 1 change.
- Post-merge to confirm: web login works; APK publishes + installs; a branch push previews; a `v1` push deploys nothing.

Plan left **in-progress** (not done) pending those post-merge checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)