### PR TITLE
fix(ci): web build points at prod API + CI can publish APKs

### DIFF
--- a/.github/workflows/v2-preview.yml
+++ b/.github/workflows/v2-preview.yml
@@ -44,7 +44,9 @@ jobs:
         working-directory: app
         run: |
           flutter pub get
-          flutter build web --pwa-strategy=none --base-href=/${{ steps.seg.outputs.segment }}/
+          flutter build web --pwa-strategy=none --base-href=/${{ steps.seg.outputs.segment }}/ \
+            --dart-define=API_BASE_URL=https://api.squadquest.app \
+            --dart-define=CLIENT_HEADER=web/1.0.0+${{ github.run_number }}
 
       - uses: 'google-github-actions/auth@v2'
         with:

--- a/.github/workflows/v2-publish.yml
+++ b/.github/workflows/v2-publish.yml
@@ -33,7 +33,9 @@ jobs:
         working-directory: app
         run: |
           flutter pub get
-          flutter build web --pwa-strategy=none
+          flutter build web --pwa-strategy=none \
+            --dart-define=API_BASE_URL=https://api.squadquest.app \
+            --dart-define=CLIENT_HEADER=web/1.0.0+${{ github.run_number }}
 
       - uses: 'google-github-actions/auth@v2'
         with:

--- a/specs/behaviors/ci-cd.md
+++ b/specs/behaviors/ci-cd.md
@@ -44,6 +44,12 @@ preview of develop as incidental, not a separate product surface.
 - Web builds use `--pwa-strategy=none` (no service worker — it otherwise serves a stale build
   until a second reload) and are uploaded with `Cache-Control: no-cache` so deploys show up
   immediately (CDN is off; traffic is tiny).
+- **Web builds MUST pass `--dart-define=API_BASE_URL=https://api.squadquest.app`** (and a
+  `web/<version>+<run_number>` `CLIENT_HEADER`). The client's compile-time default is
+  `http://localhost:4000` (see `app/lib/config.dart`), so a web build *without* this define ships
+  pointing at localhost and every API call from the deployed site fails — this bit prod once.
+  Both the root publish and the branch-preview build carry these defines. (The API origin is the
+  same for prod web and every path-based preview, so the CORS allow-list is unaffected.)
 
 ### Web preview origin & CORS
 

--- a/tf/storage.tf
+++ b/tf/storage.tf
@@ -35,6 +35,15 @@ resource "google_storage_bucket_iam_member" "media_runtime_admin" {
   member = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
 }
 
+# The CI deploy SA publishes built APKs to apk/ (v2-publish.yml v2-apk job).
+# It already has objectAdmin on the frontend buckets; the media bucket needs its
+# own grant. See specs/behaviors/ci-cd.md.
+resource "google_storage_bucket_iam_member" "media_ci_apk_writer" {
+  bucket = google_storage_bucket.media.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.v2_github.email}"
+}
+
 # Keyless V4 signing: the runtime SA must be able to sign blobs AS ITSELF
 # (@google-cloud/storage falls back to the IAM signBlob API when no private key
 # is present, which is the case on Cloud Run with ADC).


### PR DESCRIPTION
Two fixes for problems the first `v2-ci-cd-pipelines` deploy surfaced live.

## 1. Web app was hitting `http://localhost:4000` (the actual login bug)
The `Build web` step never passed `--dart-define=API_BASE_URL`, so the deployed site baked in the client's compile-time default (`localhost:4000`). Every API call from `v2.squadquest.app` — including login — hit localhost and failed. **This, not CORS, is what broke web login** (CORS was a real latent bug too, now also fixed).
- `v2-publish.yml` + `v2-preview.yml`: build web with `--dart-define=API_BASE_URL=https://api.squadquest.app` + a `web/<version>+<run_number>` client header.
- `ci-cd.md`: spec'd that web builds MUST carry `API_BASE_URL`, with the localhost-default footgun called out.

## 2. APK upload failed (`GcsApiError`)
The `v2-apk` job **built fine** but failed uploading: `v2-github-action` had `objectAdmin` on the frontend buckets but not on `squadquest-v2-media`. (My earlier manual `gcloud cp` worked only because it ran as owner — masking the gap.)
- `tf/storage.tf`: grant the CI SA `objectAdmin` on the media bucket. **Already applied** (`1 added`).

## Validation
- Both workflow YAMLs valid; `tofu` IAM grant applied.
- Post-merge: web login works (build points at prod); `squadquest-dev-b<N>.apk` publishes to the bucket.

Follow-up to #448 (`v2-ci-cd-pipelines`, still in-progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)