### PR TITLE
fix(ci): publish APKs to v2 bucket /downloads/ (off the media bucket)

### DIFF
--- a/.github/workflows/v2-preview.yml
+++ b/.github/workflows/v2-preview.yml
@@ -29,6 +29,14 @@ jobs:
         id: seg
         run: |
           seg=$(printf '%s' "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')
+          # Reserve segments owned by other publish paths so a branch can't clobber
+          # them: downloads/ holds the APKs (v2-publish.yml), and the bucket root is
+          # the prod web build. See specs/behaviors/ci-cd.md.
+          case "$seg" in
+            downloads|develop|"")
+              echo "::error::Refusing to publish a preview to reserved path '/$seg/'."
+              exit 1 ;;
+          esac
           echo "segment=$seg" >> "$GITHUB_OUTPUT"
           echo "Preview path: /$seg/"
 

--- a/.github/workflows/v2-publish.yml
+++ b/.github/workflows/v2-publish.yml
@@ -131,15 +131,18 @@ jobs:
 
       - uses: 'google-github-actions/setup-gcloud@v3'
 
-      # Publish a build-numbered artifact + overwrite the stable "latest" link.
-      # public-read bucket + APK mime type so the link installs in one tap.
-      - name: Publish APK to media bucket
+      # Publish a build-numbered artifact + overwrite the stable "latest" link to
+      # the v2 frontend bucket under downloads/ (served via the LB at
+      # https://v2.squadquest.app/downloads/...). Same bucket as the web build;
+      # the CI SA already has write there. APK mime type so it installs in one tap;
+      # no-cache on -latest so a new build is picked up immediately.
+      - name: Publish APK
         run: |
           SRC=app/build/app/outputs/flutter-apk/app-dev-release.apk
           MIME=application/vnd.android.package-archive
           gcloud storage cp "$SRC" \
-            "gs://squadquest-v2-media/apk/squadquest-dev-b${{ github.run_number }}.apk" \
+            "gs://v2.squadquest.app/downloads/squadquest-dev-b${{ github.run_number }}.apk" \
             --content-type="$MIME"
           gcloud storage cp "$SRC" \
-            "gs://squadquest-v2-media/apk/squadquest-dev-latest.apk" \
+            "gs://v2.squadquest.app/downloads/squadquest-dev-latest.apk" \
             --content-type="$MIME" --cache-control="no-cache"

--- a/specs/behaviors/ci-cd.md
+++ b/specs/behaviors/ci-cd.md
@@ -12,7 +12,7 @@ Federation (no long-lived keys):
 |---|---|---|
 | push to `develop` | **prod web** build | `gs://v2.squadquest.app/` (root) → `https://v2.squadquest.app` |
 | push to `develop` | **backend image** | Artifact Registry → Cloud Run `squadquest-backend` (migrate-on-startup) |
-| push to `develop` | **dev APK** | `gs://squadquest-v2-media/apk/squadquest-dev-b<N>.apk` |
+| push to `develop` | **dev APK** | `gs://v2.squadquest.app/downloads/squadquest-dev-b<N>.apk` (+ `-latest`) → `https://v2.squadquest.app/downloads/…` |
 | push to **any branch except `v1`** | **branch web preview** | `gs://v2.squadquest.app/<branch>/` → `https://v2.squadquest.app/<branch>/` |
 
 `develop` is itself "any branch except v1", so a develop push publishes both the root prod web
@@ -35,12 +35,16 @@ preview of develop as incidental, not a separate product surface.
   monotonic and traceable back to a run. The APK is the **`dev` flavor** (`app.squadquest.dev`,
   "SquadQuest Dev") pointed at prod (`--dart-define=API_BASE_URL=https://api.squadquest.app`,
   `CLIENT_HEADER=android/<version>+<run_number>`) so it installs alongside v1 (see
-  [`architecture.md`](../architecture.md) build channels). A stable
-  `squadquest-dev-latest.apk` copy may also be published for a permanent "newest dev build" link.
+  [`architecture.md`](../architecture.md) build channels). APKs are published to the **v2 frontend
+  bucket** under `downloads/` (same bucket as the web build — the CI SA already has write there,
+  and it's public + LB-fronted, so the link is `https://v2.squadquest.app/downloads/…`). A stable
+  `squadquest-dev-latest.apk` (uploaded `no-cache`) gives a permanent "newest dev build" link.
 - **Branch name → path segment** is sanitized: lowercased, any character outside `[a-z0-9._-]`
   (notably `/` in `feat/x`) replaced with `-`, yielding e.g. `feat/profile-screen` →
   `feat-profile-screen/`. The same sanitized segment is the web `--base-href=/<segment>/` so
-  asset URLs resolve under the subpath.
+  asset URLs resolve under the subpath. **Reserved segments** (`downloads`, `develop`, and the
+  empty string) are refused by the preview workflow so a branch can't overwrite the APK downloads
+  or collide with the root prod build.
 - Web builds use `--pwa-strategy=none` (no service worker — it otherwise serves a stale build
   until a second reload) and are uploaded with `Cache-Control: no-cache` so deploys show up
   immediately (CDN is off; traffic is tiny).
@@ -71,8 +75,9 @@ every path to the v2 bucket.
   'SquadQuest/SquadQuest'` **except** `refs/heads/v1` (v1 is the protected production branch and
   must never deploy through the v2 pipeline).
 - This is the one security-sensitive change: it widens which refs can mint a deploy token for the
-  v2 deploy service account. The SA's permissions are unchanged (write to the v2 + media buckets,
-  deploy Cloud Run); only *which branches* can assume it widens. The `v1` exclusion is the guard.
+  v2 deploy service account. The SA's permissions are unchanged (write to the v2 frontend bucket —
+  which holds web builds *and* APK downloads — and deploy Cloud Run); only *which branches* can
+  assume it widens. The `v1` exclusion is the guard.
 - The branch-preview workflow itself must also exclude `v1` (`branches-ignore: [v1]`) and skip the
   backend/Cloud Run + root web deploy (those stay `develop`-only) — defense in depth alongside the
   WIF condition.
@@ -103,7 +108,8 @@ every path to the v2 bucket.
 ## Notes
 
 - Existing state this builds on: `v2-publish.yml` already does prod web + backend on `develop` via
-  WIF. APKs already live under `squadquest-v2-media/apk/`.
+  WIF. APKs are published under `v2.squadquest.app/downloads/` (moved off the media bucket so user
+  media and build artifacts don't share a bucket).
 - **Build command:** on CI, use the idiomatic `flutter build apk --release --flavor dev` with
   `--dart-define`s — it handles flavor + defines cleanly on a hosted runner. (The
   `./gradlew :app:assembleDevRelease` workaround with base64 dart-defines is only needed in the

--- a/tf/storage.tf
+++ b/tf/storage.tf
@@ -35,15 +35,6 @@ resource "google_storage_bucket_iam_member" "media_runtime_admin" {
   member = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
 }
 
-# The CI deploy SA publishes built APKs to apk/ (v2-publish.yml v2-apk job).
-# It already has objectAdmin on the frontend buckets; the media bucket needs its
-# own grant. See specs/behaviors/ci-cd.md.
-resource "google_storage_bucket_iam_member" "media_ci_apk_writer" {
-  bucket = google_storage_bucket.media.name
-  role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.v2_github.email}"
-}
-
 # Keyless V4 signing: the runtime SA must be able to sign blobs AS ITSELF
 # (@google-cloud/storage falls back to the IAM signBlob API when no private key
 # is present, which is the case on Cloud Run with ADC).


### PR DESCRIPTION
Build artifacts shouldn't share the user-media bucket. Moves dev APKs to the **v2 frontend bucket** under `downloads/`.

## Why the v2 bucket (vs a new one)
- The CI SA **already has write** there (web deploys) — so this *removes* the media-bucket IAM grant rather than adding one.
- Already public + load-balancer-fronted → clean link `https://v2.squadquest.app/downloads/squadquest-dev-latest.apk` (not the raw `storage.googleapis.com` URL).
- Net infra change is negative: −1 IAM binding, 0 new resources.

## Changes
- `v2-publish.yml`: APKs → `gs://v2.squadquest.app/downloads/`.
- `v2-preview.yml`: refuse reserved segments (`downloads`/`develop`/empty) so a branch preview can't clobber the APKs or the root build.
- `tf/storage.tf`: drop the now-unneeded media-bucket grant. **Already applied** (`1 destroyed`).
- `ci-cd.md`: new path + reserved-segment rule.

## Done already (out of band)
- The 4 old APKs in `squadquest-v2-media/apk/` are **deleted**; that bucket is now empty.
- ⚠️ The old `storage.googleapis.com/squadquest-v2-media/apk/...` link is dead. The new link populates on the next develop publish (this merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)