### PR TITLE
fix(server): stop MIN_SUPPORTED_BUILD leaking across test suites

### DIFF
--- a/server/test/auth.test.ts
+++ b/server/test/auth.test.ts
@@ -2,16 +2,20 @@ import { afterAll, beforeAll, expect, test } from 'bun:test'
 import Fastify, { type FastifyInstance } from 'fastify'
 
 // Base test env (DATABASE_URL, JWT_SECRET) comes from test/setup.ts (bun preload).
-// This suite raises the client-version floor to exercise the 426 path; set before
-// importing the app so @fastify/env picks it up.
-process.env.MIN_SUPPORTED_BUILD = '500'
-
 const { app } = await import('../src/app.ts')
 
 const logs: Array<Record<string, unknown>> = []
 let server: FastifyInstance
 
+// This suite raises the client-version floor to exercise the 426 path. @fastify/env
+// reads process.env at registration (in beforeAll), so set it just before register
+// and RESTORE it in afterAll — bun runs all test files in one process, so a
+// top-level mutation would leak the floor into every other suite (it has, twice).
+let priorFloor: string | undefined
+
 beforeAll(async () => {
+  priorFloor = process.env.MIN_SUPPORTED_BUILD
+  process.env.MIN_SUPPORTED_BUILD = '500'
   server = Fastify({
     logger: {
       level: 'info',
@@ -33,6 +37,9 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await server.close()
+  // Restore the floor so it can't bleed into other suites in the shared process.
+  if (priorFloor === undefined) delete process.env.MIN_SUPPORTED_BUILD
+  else process.env.MIN_SUPPORTED_BUILD = priorFloor
 })
 
 function lastOtp(): string {

--- a/server/test/otp-provider.test.ts
+++ b/server/test/otp-provider.test.ts
@@ -19,8 +19,10 @@ beforeEach(async () => {
   await server.sql`truncate otp_code, refresh_token, profile cascade`
 })
 
-// Build kept high: a sibling suite (auth.test.ts) sets MIN_SUPPORTED_BUILD=500
-// process-wide, and these files share one bun-test process.
+// Explicit high build so this suite never depends on another's env: auth.test.ts
+// raises MIN_SUPPORTED_BUILD during its lifecycle (now restored in its afterAll),
+// but files share one bun-test process with no guaranteed ordering, so a suite
+// that cares about the floor sets its own client build rather than assume the default.
 const auth = { 'x-squadquest-client': 'web/9.9.9+999' }
 
 test('console OTP: request then verify with the logged code logs in', async () => {


### PR DESCRIPTION
The `MIN_SUPPORTED_BUILD` env-leak (distinct from test-DB isolation, which the `bin/` + `squadquest_test` setup already solved — that's the part you remembered correctly).

`auth.test.ts` set `MIN_SUPPORTED_BUILD=500` at module top-level. bun runs all test files in one process, so the floor leaked into other auth-touching suites (bit the otp-provider tests twice).

- Move the mutation into `beforeAll`; restore the prior value in `afterAll`.
- Keep otp-provider's explicit high client build — suites that care about the floor shouldn't depend on another suite's lifecycle timing (file order isn't guaranteed). Defense in depth.

`bun test` 56 pass. (Tried to commit straight to develop per request, but branch protection requires a PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)