### PR TITLE
feat(app): profile screen — edit name/photo, sign out

### DIFF
--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -13,6 +13,7 @@ import 'screens/communities/create_event_screen.dart';
 import 'screens/communities/discover_screen.dart';
 import 'screens/friends/friends_screen.dart';
 import 'screens/login/login_screen.dart';
+import 'screens/profile/profile_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
 import 'screens/thread/thread_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
@@ -46,6 +47,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/welcome', builder: (_, _) => const WelcomeScreen()),
       GoRoute(path: '/', builder: (_, _) => const TimelineScreen()),
       GoRoute(path: '/friends', builder: (_, _) => const FriendsScreen()),
+      GoRoute(path: '/profile', builder: (_, _) => const ProfileScreen()),
       GoRoute(
         path: '/ideas/new',
         builder: (_, state) =>

--- a/app/lib/screens/profile/profile_screen.dart
+++ b/app/lib/screens/profile/profile_screen.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/auth_controller.dart';
+import '../../widgets/photo_picker.dart';
+
+/// The signed-in user's own profile: view/edit name + photo, see phone (read-only),
+/// and sign out. The post-onboarding home for the identity the welcome step first
+/// set. See specs/screens/profile.md. Reachable from the timeline app-bar avatar.
+class ProfileScreen extends ConsumerStatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends ConsumerState<ProfileScreen> {
+  late final TextEditingController _firstName;
+  late final TextEditingController _lastName;
+  String? _photoUrl; // current/pending photo URL
+  bool _busy = false;
+  String? _error;
+  bool _dirty = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final p = ref.read(authControllerProvider.notifier).currentProfile;
+    _firstName = TextEditingController(text: p?.firstName ?? '')
+      ..addListener(_markDirty);
+    _lastName = TextEditingController(text: p?.lastName ?? '')
+      ..addListener(_markDirty);
+    _photoUrl = p?.photo;
+  }
+
+  @override
+  void dispose() {
+    _firstName.dispose();
+    _lastName.dispose();
+    super.dispose();
+  }
+
+  void _markDirty() {
+    if (!_dirty) setState(() => _dirty = true);
+  }
+
+  bool get _canSave => _dirty && _firstName.text.trim().isNotEmpty && !_busy;
+
+  Future<void> _save() async {
+    if (!_canSave) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final last = _lastName.text.trim();
+      await ref
+          .read(authControllerProvider.notifier)
+          .updateProfile(
+            firstName: _firstName.text.trim(),
+            lastName: last.isEmpty ? null : last,
+            photo: _photoUrl,
+          );
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _dirty = false;
+        });
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Profile saved')));
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _error = 'Couldn\'t save. Try again.';
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final profile = ref.watch(authControllerProvider.notifier).currentProfile;
+    final phone = profile?.phone;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Column(
+                key: const Key('profileForm'),
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Center(
+                    child: PhotoPicker(
+                      kind: 'profile',
+                      currentUrl: _photoUrl,
+                      fallbackIcon: Icons.person,
+                      onUploaded: (url) => setState(() {
+                        _photoUrl = url;
+                        _dirty = true;
+                      }),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Tap to change your photo',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: 12),
+                  ),
+                  const SizedBox(height: 24),
+                  TextField(
+                    key: const Key('firstNameField'),
+                    controller: _firstName,
+                    textCapitalization: TextCapitalization.words,
+                    textInputAction: TextInputAction.next,
+                    decoration: const InputDecoration(
+                      labelText: 'First name',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    key: const Key('lastNameField'),
+                    controller: _lastName,
+                    textCapitalization: TextCapitalization.words,
+                    textInputAction: TextInputAction.done,
+                    onSubmitted: (_) => _save(),
+                    decoration: const InputDecoration(
+                      labelText: 'Last name (optional)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  // Phone is the identity key — shown, not editable here.
+                  if (phone != null)
+                    TextField(
+                      key: const Key('phoneField'),
+                      enabled: false,
+                      controller: TextEditingController(text: phone),
+                      decoration: const InputDecoration(
+                        labelText: 'Phone',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    key: const Key('saveProfileButton'),
+                    onPressed: _canSave ? _save : null,
+                    child: _busy
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Save'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    key: const Key('signOutButton'),
+                    icon: const Icon(Icons.logout),
+                    label: const Text('Sign out'),
+                    onPressed: _busy
+                        ? null
+                        : () => ref
+                              .read(authControllerProvider.notifier)
+                              .logout(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -60,12 +60,14 @@ class TimelineScreen extends ConsumerWidget {
             tooltip: 'People',
             onPressed: () => context.push('/friends'),
           ),
-          IconButton(
-            key: const Key('logoutButton'),
-            icon: const Icon(Icons.logout),
-            tooltip: 'Sign out',
-            onPressed: () => ref.read(authControllerProvider.notifier).logout(),
+          // Tap your avatar → profile (view/edit name+photo, sign out).
+          _ProfileAvatarButton(
+            photo: ref
+                .watch(authControllerProvider.notifier)
+                .currentProfile
+                ?.photo,
           ),
+          const SizedBox(width: 8),
         ],
       ),
       // Communities are leaders-broadcast: followers don't compose here.
@@ -176,6 +178,29 @@ class TimelineScreen extends ConsumerWidget {
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+/// App-bar avatar that opens the profile screen. Shows the user's photo, or a
+/// person glyph when none is set (so the entry point is always visible).
+class _ProfileAvatarButton extends StatelessWidget {
+  const _ProfileAvatarButton({this.photo});
+
+  final String? photo;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasPhoto = photo != null && photo!.isNotEmpty;
+    return IconButton(
+      key: const Key('profileButton'),
+      tooltip: 'Profile',
+      onPressed: () => context.push('/profile'),
+      icon: CircleAvatar(
+        radius: 14,
+        foregroundImage: hasPhoto ? NetworkImage(photo!) : null,
+        child: hasPhoto ? null : const Icon(Icons.person, size: 18),
       ),
     );
   }

--- a/app/test/profile_screen_test.dart
+++ b/app/test/profile_screen_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/profile.dart';
+import 'package:squadquest/providers/auth_controller.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/profile_repository.dart';
+import 'package:squadquest/repositories/token_store.dart';
+import 'package:squadquest/screens/profile/profile_screen.dart';
+
+/// A token store that always reports a session (load is a no-op), so the auth
+/// controller resolves to SignedIn without touching the platform keychain.
+class _FakeTokenStore extends TokenStore {
+  _FakeTokenStore() {
+    accessToken = 'test-access';
+    refreshToken = 'test-refresh';
+  }
+  @override
+  Future<void> load() async {}
+}
+
+/// Returns [profile] from me(); records the last updateProfile args.
+class _FakeProfileRepository implements ProfileRepository {
+  _FakeProfileRepository(this.profile);
+  final Profile profile;
+  String? lastFirstName;
+  String? lastLastName;
+  String? lastPhoto;
+  bool updateCalled = false;
+
+  @override
+  Future<Profile> me() async => profile;
+
+  @override
+  Future<Profile> updateProfile({
+    String? firstName,
+    String? lastName,
+    String? photo,
+  }) async {
+    updateCalled = true;
+    lastFirstName = firstName;
+    lastLastName = lastName;
+    lastPhoto = photo;
+    return Profile(
+      id: profile.id,
+      firstName: firstName ?? profile.firstName,
+      lastName: lastName ?? profile.lastName,
+      photo: photo ?? profile.photo,
+      phone: profile.phone,
+    );
+  }
+}
+
+/// Mounts ProfileScreen only once auth resolves to SignedIn — mirrors how the
+/// real router gates /profile, so currentProfile is populated in initState.
+class _Gate extends ConsumerWidget {
+  const _Gate();
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authControllerProvider);
+    return auth is SignedIn ? const ProfileScreen() : const SizedBox.shrink();
+  }
+}
+
+Future<_FakeProfileRepository> _pumpProfile(
+  WidgetTester tester,
+  Profile p,
+) async {
+  final repo = _FakeProfileRepository(p);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tokenStoreProvider.overrideWithValue(_FakeTokenStore()),
+        profileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: const MaterialApp(home: _Gate()),
+    ),
+  );
+  await tester.pumpAndSettle(); // let _restore() resolve to SignedIn
+  return repo;
+}
+
+void main() {
+  const me = Profile(
+    id: 'me',
+    firstName: 'Chris',
+    lastName: 'Alfano',
+    phone: '+12155551234',
+  );
+
+  testWidgets('shows current name + read-only phone', (tester) async {
+    await _pumpProfile(tester, me);
+
+    expect(find.byKey(const Key('profileForm')), findsOneWidget);
+    expect(find.widgetWithText(TextField, 'Chris'), findsOneWidget);
+    expect(find.text('+12155551234'), findsOneWidget);
+    // Save is disabled until something changes.
+    final save = tester.widget<FilledButton>(
+      find.byKey(const Key('saveProfileButton')),
+    );
+    expect(save.onPressed, isNull);
+  });
+
+  testWidgets('editing the name enables Save and patches the profile', (
+    tester,
+  ) async {
+    final repo = await _pumpProfile(tester, me);
+
+    await tester.enterText(
+      find.byKey(const Key('firstNameField')),
+      'Christopher',
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('saveProfileButton')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(repo.updateCalled, isTrue);
+    expect(repo.lastFirstName, 'Christopher');
+  });
+
+  testWidgets('clearing the first name disables Save (guard)', (tester) async {
+    final repo = await _pumpProfile(tester, me);
+
+    await tester.enterText(find.byKey(const Key('firstNameField')), '');
+    await tester.pump();
+
+    final save = tester.widget<FilledButton>(
+      find.byKey(const Key('saveProfileButton')),
+    );
+    expect(save.onPressed, isNull);
+    expect(repo.updateCalled, isFalse);
+  });
+}

--- a/plans/v2-profile-screen.md
+++ b/plans/v2-profile-screen.md
@@ -1,12 +1,12 @@
 ---
-status: planned
+status: done
 depends: [v2-storage-media]
 specs:
   - specs/screens/profile.md
   - specs/api/profile.md
   - specs/api/uploads.md
 issues: []
-pr:
+pr: 456
 ---
 
 # Plan: v2 profile screen (view/edit name + photo, sign out)
@@ -56,14 +56,16 @@ app bar).
 
 ## Validation
 
-- [ ] `/profile` renders current name + photo + read-only phone; reachable from the timeline
-      avatar.
-- [ ] Changing the photo and saving persists (`PATCH /v1/me`), avatar updates app-wide; a
-      photo-only save (name untouched) works; Save guard keeps first name non-empty.
-- [ ] Sign out works from the profile screen; the timeline no longer carries a standalone logout
-      button.
-- [ ] `flutter analyze` + widget tests clean; CI `app` job.
-- [ ] (on-device) build `squadquest-dev-b{N}.apk`, set a photo from the phone, confirm it sticks.
+- [x] `/profile` renders current name + photo + read-only phone; reachable from the timeline
+      avatar (tappable photo/person-glyph button replacing the logout IconButton).
+- [x] Save guard verified: disabled until a change + non-empty first name; edit→`PATCH /v1/me`;
+      photo-only save supported (`updateProfile` sends only changed fields). Widget tests cover
+      render + guard + edit-patches.
+- [x] Sign out moved into the profile screen; the timeline no longer carries a standalone logout
+      button (no test referenced `logoutButton`).
+- [x] `flutter analyze` clean; full `flutter test` 25 pass (+3 new). CI `app` job.
+- [ ] **(post-merge, on-device)** open the auto-built dev APK/IPA, set a photo from the phone,
+      confirm it persists — exercises the real upload + PATCH end-to-end.
 
 ## Risks / unknowns
 
@@ -74,8 +76,21 @@ app bar).
 
 ## Notes
 
-(closeout)
+PR #456. Built as planned — pure client wiring, no API change. The screen reads the current
+profile from `authControllerProvider.currentProfile` (the router already gates `/profile` behind
+`SignedIn`, so it's always populated in `initState`), reuses `PhotoPicker(currentUrl:)`, and Saves
+via the existing `updateProfile` (sends only changed fields → photo-only save works). Sign-out
+relocated from the timeline app bar into the profile screen; the app bar now shows a tappable
+avatar (photo or person glyph) → `/profile`.
+
+Test note: the profile screen needs a `SignedIn` auth state, which starts as `AuthLoading` until
+`_restore()` runs. The widget test seeds a fake `TokenStore` (preset token, no-op `load`) + fake
+repo and mounts the screen behind a small gate that waits for `SignedIn` — mirroring the real
+router so `initState` sees a profile.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred (noted in `specs/screens/profile.md`):** clearing a photo (empty-string `photo`) — the
+  API supports it but there's no UI affordance yet. Low priority.
+- **None** otherwise — notification-preference editing and other-user profiles remain out of scope
+  for this screen.


### PR DESCRIPTION
Closes the gap you hit: a user who skipped the photo at onboarding had **no way to add it later** — name/photo edit lived only in the welcome step, and the onboarding gate (keyed on `first_name`) never routes back to `/welcome` once a name is set.

## What's new
- **`/profile` screen** — view/edit own name + photo, read-only phone, Sign out.
  - Reuses `PhotoPicker(kind: 'profile', currentUrl: …)`; Save sends only changed fields (photo-only save works); Save disabled until a change + non-empty first name.
  - Sign-out **relocated here** from the timeline app bar (its natural home).
- **Entry point:** the timeline app bar's standalone logout button → a tappable **avatar** (your photo, or a person glyph) that opens `/profile`.

Implements `specs/screens/profile.md`. **No API change** — `PATCH /v1/me` with `photo` already shipped.

## Validation
- `flutter analyze` clean; full `flutter test` **25 pass** (+3 new: render + read-only phone, edit→patch, Save guard).
- Post-merge on-device: the auto-built dev APK/IPA lets you set a photo from your phone and confirm it persists.

Plan `v2-profile-screen` closed out (done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)