### PR TITLE
docs(specs): "dismissal is silent and reversible" principle + ignore/recovery

### DIFF
--- a/plans/v2-ignore-and-recovery.md
+++ b/plans/v2-ignore-and-recovery.md
@@ -1,0 +1,77 @@
+---
+status: planned
+depends: [v2-friends-and-onboarding]
+specs:
+  - specs/principles.md
+  - specs/screens/ignored.md
+  - specs/api/friends.md
+  - specs/behaviors/friend-connections.md
+issues: []
+pr:
+---
+
+# Plan: v2 ignore + recovery (silent dismissal, app-wide)
+
+> Implements the [dismissal is silent and reversible](../specs/principles.md#dismissal-is-silent-and-reversible)
+> principle for **friend requests** + the shared **Ignored** recovery screen. (Want-invite ignore
+> ships with `v2-wants-core`, referencing the same principle; idea/activity responses already
+> embody it and need no change.) Specs landed in the principle PR; this is the code.
+
+## Scope
+
+**In:**
+
+- **Backend — friends:** replace the `declined` status with **silent ignore**. `friendship` gains
+  `ignored_at` (keep `status ∈ {requested, accepted}`; **drop `declined`**). `respond(accept:false)`
+  is removed; add `ignore` (sets `ignored_at`, edge stays `requested`) + `unignore` (clears it).
+  `GET /v1/friends/requests` `incoming` excludes ignored; **outgoing is unchanged regardless** (the
+  sender never sees a state change). Routes: `POST /v1/friends/requests/:id/ignore` + `/unignore`;
+  `PUT …` accepts only `{accept:true}`.
+- **Backend — recovery:** `GET /v1/ignored` aggregating ignored incoming items (friend requests
+  now; want invites once `v2-wants-core` lands — the aggregator should be extensible).
+- **Client:** ignore action on incoming friend requests (replaces decline); a new **Ignored** screen
+  (`/ignored`) from the profile entry; un-ignore restores to incoming. Tests both layers.
+- **Migration:** existing `declined` rows → set `ignored_at` (treat a past decline as an ignore) and
+  move to `requested`, OR drop them (decline wasn't a block; re-requestable). Decide at pickup;
+  lean toward converting so nothing is lost.
+
+**Out:** blocking (still a separate future plan); ignoring item types beyond friend requests +
+want invites; push/notification suppression nuance.
+
+## Implements
+
+`specs/principles.md` (dismissal is silent and reversible), `specs/screens/ignored.md` (new),
+`specs/api/friends.md` (ignore/unignore + `/v1/ignored`), `specs/behaviors/friend-connections.md`
+(no `declined`), `specs/data-model.md` (`friendship.ignored_at`, no `declined`).
+
+## Approach
+
+- This is **code-catching-up-to-spec**: the friends backend currently ships `declined` (PR #426);
+  the spec now forbids it. Migrate the column, swap the service method, update the route + client.
+- `GET /v1/ignored` is a small aggregator; design its response so want invites (and later types)
+  slot in by `type` without a new endpoint per type.
+- The Ignored screen is a thin list + un-ignore action; reuse the friend-request row widget.
+
+## Validation
+
+- [ ] backend: ignoring a request leaves the sender's outgoing view unchanged (still pending);
+      ignored requests leave the requestee's incoming + appear in `/v1/ignored`; un-ignore restores;
+      no `declined` status remains. Migration converts existing declined rows. `bun test` + type-check.
+- [ ] client: ignore from incoming; Ignored screen lists + un-ignores; accept-from-ignored works.
+      `flutter analyze` + widget tests.
+- [ ] re-run `/audit-spec-drift` — no `declined` drift between friends code + spec.
+
+## Risks / unknowns
+
+- **Migration of existing `declined` rows** — converting vs dropping; pick at pickup (lean convert).
+- The `respond` API change (`accept:false` removal) is a contract change to a shipped endpoint —
+  but no released client depends on a decline result yet (v2 isn't launched), so it's safe to change
+  in place rather than supersede. Confirm no client calls `accept:false`.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/specs/api/friends.md
+++ b/specs/api/friends.md
@@ -24,6 +24,10 @@ Pending connection requests involving the caller.
 - **Response:** `200 { "incoming": [<request>…], "outgoing": [<request>…] }`
   where a request is `{ "id", "profile": <friend>, "created_at" }` — `profile` is the *other*
   party (the sender for incoming, the target for outgoing).
+- `incoming` **excludes** requests the caller has ignored (they appear in the Ignored surface
+  instead — see below). `outgoing` is unaffected by whether the recipient ignored: a sender always
+  sees their request as pending (see
+  [dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible)).
 
 ## POST /v1/friends/requests
 
@@ -38,15 +42,42 @@ Send a connection request by phone.
 
 ## PUT /v1/friends/requests/:id
 
-Respond to an **incoming** request (requestee only).
+Accept an **incoming** request (requestee only).
 
-- **Request:** `{ "accept": true }` → `accepted`; `{ "accept": false }` → `declined`.
-- **Response:** `200 { "status": "accepted" | "declined" }`. Non-requestee → `404`.
+- **Request:** `{ "accept": true }` → `accepted`.
+- **Response:** `200 { "status": "accepted" }`. Non-requestee → `404`.
+- There is **no decline.** To make a request go away without connecting, the requestee **ignores**
+  it (below) — silent and reversible, never a visible "declined".
+
+## POST /v1/friends/requests/:id/ignore
+
+Ignore an incoming request (requestee only). The edge stays `requested` (the sender keeps seeing a
+pending request — unchanged), `ignored_at` is set, and the request leaves `GET
+/v1/friends/requests` `incoming` for the caller's **Ignored** surface.
+
+- **Response:** `200 { "status": "requested", "ignored": true }`. Non-requestee → `404`.
+
+## GET /v1/ignored
+
+The caller's ignored incoming items, aggregated across types (see
+[`screens/ignored.md`](../screens/ignored.md)). For friend requests, returns the ignored incoming
+requests as `<request>` objects tagged by type.
+
+- **Response:** `200 { "items": [ { "type": "friend_request", "id", "profile": <friend>,
+  "created_at", "ignored_at" }, … ] }` (want invites and future ignorable types join `items`).
+
+## POST /v1/friends/requests/:id/unignore
+
+Un-ignore — clears `ignored_at`; the request returns to `incoming` exactly as before. Requestee
+only.
+
+- **Response:** `200 { "status": "requested", "ignored": false }`.
 
 ## Notes
 
 - Only `accepted` edges grant timeline/detail visibility (see friend-connections).
 - QR / contact-based connection are future channels; phone is the first.
+- Ignoring never notifies or changes anything the sender sees; un-ignoring is always available.
 
 ## Principles
 
@@ -54,3 +85,5 @@ Respond to an **incoming** request (requestee only).
 
 - [Private-first](../principles.md#private-first-public-never-touches-the-friends-surface) —
   a one-sided request grants no access; only acceptance opens the private surface.
+- [Dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible) —
+  there is no decline; the requestee ignores (silent to the sender, recoverable from Ignored).

--- a/specs/behaviors/friend-connections.md
+++ b/specs/behaviors/friend-connections.md
@@ -4,8 +4,11 @@
 
 The friend graph is **double opt-in**: a connection exists only when both people have
 agreed (`friendship.status = accepted`). You build it by **sending a request** (by phone
-now; QR and other channels are future), and the other person **accepting**. Either side may
-decline; absence of acceptance is not a connection.
+now; QR and other channels are future), and the other person **accepting**. The requestee may
+**ignore** a request instead — it leaves their screen with no visible "declined" state, so to
+the sender it is indistinguishable from not-yet-seen (see
+[dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible)).
+Absence of acceptance is not a connection.
 
 ## Applies To
 
@@ -22,9 +25,12 @@ surfaces pending requests).
 - **One edge per pair:** a `friendship` row is unique per unordered pair. If an edge already
   exists (requested or accepted, either direction), sending is idempotent — never a duplicate.
   If *they* already requested *you*, your "send" is treated as an accept.
-- **States:** `requested → accepted` (both connected) or `requested → declined` (no
-  connection; may be re-requested later). A decline is not a block.
-- **Respond:** only the **requestee** may accept/decline a `requested` edge.
+- **States:** `requested → accepted` (both connected). The requestee may also **ignore** a
+  `requested` edge: it stays `requested` (the sender still sees a pending request — never a
+  "declined"), but it's flagged ignored so it leaves the requestee's incoming list and moves to
+  their **Ignored** list, from which they can un-ignore it (which restores it to incoming) or
+  accept it later. Ignoring is not a block.
+- **Respond:** only the **requestee** may accept or ignore a `requested` edge.
 - **Self:** you cannot friend yourself.
 - **Visibility of details:** only `accepted` friends see each other's activity/timeline
   (the friends-timeline audience). A merely-`requested` edge grants nothing.
@@ -44,8 +50,18 @@ identity (name/photo when available), never timeline content.
 - [Preserve the social graph; archive the content](../principles.md#preserve-the-social-graph-archive-the-content)
   — shells + claim-on-login mean a request survives until the invitee joins.
 
+## Principles (continued)
+
+- [Dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible) —
+  ignoring a request never shows the sender a "declined"; the edge stays `requested` and the
+  ignored request is recoverable from the requestee's Ignored list.
+
 ## Local
 
-- **Double opt-in, decline ≠ block.** v2 keeps v1's mutual-confirmation model (no one-way
-  follows among friends; that's what communities are for). Declining simply leaves no edge;
-  it isn't a permanent block (a future plan may add blocking). Promote if blocking arrives.
+- **Double opt-in, ignore ≠ block.** v2 keeps v1's mutual-confirmation model (no one-way
+  follows among friends; that's what communities are for). Ignoring a request just removes it
+  from the requestee's view (recoverable); it isn't a permanent block (a future plan may add
+  blocking). Promote if blocking arrives.
+- **No `declined` state.** Earlier drafts had `requested → declined`; that's removed — a visible
+  decline contradicts [dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible).
+  Ignore is the replacement (silent, edge stays `requested`, recoverable).

--- a/specs/behaviors/response-system.md
+++ b/specs/behaviors/response-system.md
@@ -31,3 +31,8 @@ Every idea/activity card and thread header (`screens/friends-timeline.md`,
 
 - [Lower the stakes](../principles.md#lower-the-stakes-of-participation) — three soft
   options and a no-friction passive dismiss; never force a visible "no".
+- [Dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible) —
+  "not responding is the dismiss" is the original instance of this app-wide rule: ignoring an
+  idea/activity is indistinguishable to the captain from never having seen it. (Idea/activity
+  responses aren't recoverable from the Ignored list — there's nothing to undo; the item is still
+  on the timeline.)

--- a/specs/data-model.md
+++ b/specs/data-model.md
@@ -27,9 +27,14 @@ yet logged in). One per phone.
 ### friendship
 
 The double-opt-in graph. `requester` → `profile`, `requestee` → `profile`, `status ∈
-{requested, accepted, declined}`. A pair is "friends" when `accepted`. The friends-network
-(direct friends, and friends-of-friends for discovery) is derived from this. Unique on
-(requester, requestee).
+{requested, accepted}`, plus `ignored_at` (null = visible to the requestee; set = the requestee
+ignored it — it stays `requested` but leaves their incoming list for their Ignored list, and the
+sender still sees only a pending request). A pair is "friends" when `accepted`. There is **no
+`declined`** status — a visible decline would violate
+[dismissal is silent and reversible](principles.md#dismissal-is-silent-and-reversible); ignoring is
+the silent, recoverable replacement (see [`behaviors/friend-connections.md`](behaviors/friend-connections.md)).
+The friends-network (direct friends, and friends-of-friends for discovery) is derived from this.
+Unique on (requester, requestee).
 
 ### topic + topic_subscription
 

--- a/specs/principles.md
+++ b/specs/principles.md
@@ -30,6 +30,30 @@ responding is the dismiss** — there is no explicit decline button.
 > social risk at the moment of participation is what kills them. Default to the
 > lower-pressure framing every time.
 
+## Dismissal is silent and reversible
+
+Anything one user sends another — a **friend request**, an event invite, a **want invite**, any
+future incoming item — the recipient can **ignore**: it leaves their screens, and the result is
+**indistinguishable to the sender from the recipient simply never having seen it**. There is no
+"declined" / "rejected" state shown to the sender, ever. The sender's view of what they sent does
+not change when the recipient ignores it (a pending request stays pending; an invite shows no
+"declined" marker).
+
+Ignoring is **reversible, never a black hole**: ignored items collect in an **Ignored** list
+(see [`screens/ignored.md`](screens/ignored.md)) the user can browse to un-ignore something. So
+"ignore" is safe to tap — it's *hide from me*, not *destroy*.
+
+Use **one consistent vocabulary** across the whole app: the verb is **Ignore**, the recovered-items
+surface is **Ignored**. Don't introduce synonyms ("dismiss", "decline", "reject", "hide") in UI
+copy or API field names for this action.
+
+> **Why.** This is [lower the stakes](#lower-the-stakes-of-participation) generalized from
+> responses to *every* incoming thing. A visible "no" — even a soft one — creates social friction
+> for both sides: the recipient feels rude declining, the sender feels rejected. Making dismissal
+> silent removes that friction entirely; making it reversible removes the fear of an irreversible
+> mistake. The existing "not responding is the dismiss" rule for idea/activity responses is one
+> instance of this principle; friend requests and want invites are others.
+
 ## Group text, not social feed
 
 Favor chat-like affordances — input at the bottom, scroll up for history, threads — over

--- a/specs/screens/ignored.md
+++ b/specs/screens/ignored.md
@@ -1,0 +1,50 @@
+# Screen: Ignored
+
+A recovery surface for everything the user has **ignored** — the safety valve that makes ignoring
+safe to tap (see [dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible)).
+Ignoring removes an incoming item from its normal surface; this is where it goes so it's never an
+irreversible black hole. Authenticated.
+
+## Route
+
+`/ignored`. Reached from the **Profile** screen (a low-prominence link — it's a rarely-needed
+recovery tool, not a primary surface).
+
+## Data Requirements
+
+- The caller's ignored incoming items, aggregated across types. As of the wants work this is:
+  - **Friend requests** the caller ignored (`friendship` rows where the caller is requestee and
+    `ignored_at` is set) — see [`api/friends.md`](../api/friends.md).
+  - **Want invites** the caller hid (`want_invite` rows the caller ignored) — see
+    [`api/wants.md`](../api/wants.md).
+- Other ignorable item types join this list as they're built (one consistent surface).
+
+## Display Rules
+
+- A list of ignored items, grouped or labeled by type ("Friend request from …", "Want invite from
+  …"), each showing who it's from + enough context to recognize it, and when it was ignored.
+- Empty state: "Nothing ignored" — the common case; this screen is usually empty.
+- The sender is **never** shown anything about this screen; it's purely the recipient's private view.
+
+## Actions
+
+- **Un-ignore** an item → it returns to its normal incoming surface (a friend request reappears in
+  the requestee's incoming requests; a want invite reappears in the **Invited** list) exactly as if
+  never ignored. The sender's view is unaffected throughout (it never changed when ignored, and
+  doesn't change when un-ignored).
+- Acting on an item directly from here where it makes sense (e.g. **Accept** an ignored friend
+  request) is allowed — un-ignore is the minimum.
+
+## Navigation
+
+- **In:** Profile → "Ignored".
+- **Out:** back → Profile; un-ignoring routes the item back to its home surface.
+
+## Principles
+
+**Inherited:**
+
+- [Dismissal is silent and reversible](../principles.md#dismissal-is-silent-and-reversible) —
+  this screen *is* the reversibility half of that principle. Ignoring is "hide from me," not
+  "destroy"; this is where hidden things are recoverable, and nothing here is ever visible to the
+  sender.

--- a/specs/screens/profile.md
+++ b/specs/screens/profile.md
@@ -36,12 +36,14 @@ returns to wherever the user came from (normally the timeline).
   A photo-only change (name untouched) is valid. On success the updated profile replaces auth
   state; surfaces showing the avatar/name reflect it. On failure, show a retryable error and
   keep edits.
+- **Ignored** — a low-prominence link into the recovery surface for ignored incoming items
+  ([`screens/ignored.md`](ignored.md)).
 - **Sign out** — clears the session and returns to the login screen.
 
 ## Navigation
 
 - **In:** My Friends timeline app bar → tap avatar.
-- **Out:** back → timeline; **Sign out** → login.
+- **Out:** back → timeline; **Ignored** → `/ignored`; **Sign out** → login.
 
 ## Principles
 


### PR DESCRIPTION
Captures the app-wide principle you articulated: **anything one user sends another** — friend request, event invite, want invite — the recipient can **ignore**, and the result is **indistinguishable to the sender from never having seen it**. No visible "declined"/"rejected", ever. Ignoring is **reversible** via an **Ignored** recovery list, so it's "hide from me," not "destroy."

## What's here (specs only)
- **`principles.md`** — new principle *Dismissal is silent and reversible*. Generalizes the existing "not responding is the dismiss" response rule to every incoming item. One vocabulary: verb **Ignore**, surface **Ignored**.
- **Reconciliation (the principle conflicts with shipped behavior):** friend requests currently have an explicit `declined` state. Removed it across `friend-connections.md`, `data-model.md`, `api/friends.md` → replaced with silent ignore (`friendship.ignored_at`; edge stays `requested`; sender's outgoing view never changes; `POST …/ignore` + `/unignore`; `GET /v1/ignored`).
- **`screens/ignored.md`** (new) + profile entry point — the recovery surface.
- **`response-system.md`** — references the principle as its original instance.

## Implementation follow-up
The friends **backend already ships `declined`** (PR #426), so this spec now intentionally leads code. Tracked in **`plans/v2-ignore-and-recovery.md`** (ignore/unignore + Ignored screen + a migration of existing declined rows). Want-invite ignore ships with `v2-wants-core`, referencing the same principle.

## Ordering note
`v2-wants` specs (PR #457) reference this principle for want-invite dismissal. Recommend merging **this PR first**, then I rebase #457 onto it.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)