### PR TITLE
feat(app): wants client — list, invite, respond, promote

### DIFF
--- a/app/lib/models/want.dart
+++ b/app/lib/models/want.dart
@@ -1,0 +1,84 @@
+/// A loose, shared pre-activity (specs/api/wants.md, screens/wants.md): an intent
+/// (topic + optional title/location/notes) plus the friends you'd do it with.
+/// Tolerant reader — unknown fields ignored.
+class Want {
+  const Want({
+    required this.id,
+    this.ownerId,
+    this.ownerName,
+    this.activityTypeId,
+    this.activityTypeLabel,
+    this.title,
+    this.location,
+    this.notes,
+    this.kind = 'one_shot',
+    this.invitees = const [],
+    this.yourResponse,
+    this.archivedAt,
+  });
+
+  final String id;
+  final String? ownerId;
+  final String? ownerName;
+  final String? activityTypeId;
+  final String? activityTypeLabel;
+  final String? title;
+  final String? location;
+  final String? notes;
+  final String kind; // 'one_shot' | 'ongoing'
+  final List<WantInvitee> invitees;
+  final String?
+  yourResponse; // set when you're an invitee: in|interested|next_time|null
+  final DateTime? archivedAt;
+
+  bool get isOngoing => kind == 'ongoing';
+  bool get isArchived => archivedAt != null;
+
+  factory Want.fromJson(Map<String, dynamic> json) {
+    final owner = json['owner'] as Map<String, dynamic>?;
+    final type = json['activity_type'] as Map<String, dynamic>?;
+    return Want(
+      id: json['id'] as String,
+      ownerId: owner?['id'] as String?,
+      ownerName: owner?['first_name'] as String?,
+      activityTypeId: type?['id'] as String?,
+      activityTypeLabel: type?['label'] as String?,
+      title: json['title'] as String?,
+      location: json['location'] as String?,
+      notes: json['notes'] as String?,
+      kind: json['kind'] as String? ?? 'one_shot',
+      invitees: ((json['invitees'] as List<dynamic>?) ?? const [])
+          .map((e) => WantInvitee.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      yourResponse: json['your_response'] as String?,
+      archivedAt: json['archived_at'] == null
+          ? null
+          : DateTime.tryParse(json['archived_at'] as String),
+    );
+  }
+}
+
+/// A friend invited to a want, with their soft response (null = not yet responded).
+class WantInvitee {
+  const WantInvitee({
+    required this.profileId,
+    this.name,
+    this.photo,
+    this.response,
+  });
+
+  final String profileId;
+  final String? name;
+  final String? photo;
+  final String? response; // 'in' | 'interested' | 'next_time' | null
+
+  factory WantInvitee.fromJson(Map<String, dynamic> json) {
+    final p = json['profile'] as Map<String, dynamic>?;
+    return WantInvitee(
+      profileId: p?['id'] as String? ?? '',
+      name: p?['first_name'] as String?,
+      photo: p?['photo'] as String?,
+      response: json['response'] as String?,
+    );
+  }
+}

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -18,6 +18,8 @@ import '../repositories/timeline_repository.dart';
 import '../repositories/token_store.dart';
 import '../repositories/topic_repository.dart';
 import '../repositories/upload_repository.dart';
+import '../repositories/want_repository.dart';
+import '../models/want.dart';
 import 'auth_controller.dart';
 
 /// Dependency-injection providers. Repositories expose abstract types so tests
@@ -78,6 +80,10 @@ final communityRepositoryProvider = Provider<CommunityRepository>(
   (ref) => ApiCommunityRepository(apiClient: ref.watch(apiClientProvider)),
 );
 
+final wantRepositoryProvider = Provider<WantRepository>(
+  (ref) => ApiWantRepository(apiClient: ref.watch(apiClientProvider)),
+);
+
 /// The My Friends timeline (specs/screens/friends-timeline.md).
 final friendsTimelineProvider = FutureProvider<TimelinePage>(
   (ref) => ref.watch(timelineRepositoryProvider).friends(),
@@ -104,6 +110,16 @@ final squadsProvider = FutureProvider<List<Squad>>(
 /// Activity types for the compose-idea form (specs/api/ideas-activities.md).
 final topicsProvider = FutureProvider<List<Topic>>(
   (ref) => ref.watch(topicRepositoryProvider).list(),
+);
+
+/// The caller's own wants (specs/screens/wants.md).
+final ownWantsProvider = FutureProvider<List<Want>>(
+  (ref) => ref.watch(wantRepositoryProvider).listOwn(),
+);
+
+/// Wants the caller has been invited to.
+final invitedWantsProvider = FutureProvider<List<Want>>(
+  (ref) => ref.watch(wantRepositoryProvider).listInvited(),
 );
 
 /// The user's accepted friends (for squad member selection + the Friends screen).

--- a/app/lib/repositories/want_repository.dart
+++ b/app/lib/repositories/want_repository.dart
@@ -1,0 +1,181 @@
+import '../api/api_client.dart';
+import '../models/activity.dart';
+import '../models/want.dart';
+
+/// Wants: a shared backlog of pre-activities (specs/api/wants.md). CRUD + invite +
+/// respond + ignore + promote. Mutating actions return the updated [Want] (the API
+/// re-serializes it) so callers refresh without a separate read; promote returns the
+/// spawned [Activity].
+abstract class WantRepository {
+  Future<List<Want>> listOwn({bool includeArchived = false});
+  Future<List<Want>> listInvited();
+
+  Future<Want> create({
+    required String activityTypeId,
+    String? title,
+    String? location,
+    String? notes,
+    String kind,
+    List<String> inviteeIds,
+  });
+  Future<Want> update(
+    String id, {
+    String? activityTypeId,
+    String? title,
+    String? location,
+    String? notes,
+    String? kind,
+  });
+  Future<void> delete(String id);
+
+  Future<Want> invite(String id, List<String> profileIds);
+  Future<Want> uninvite(String id, String profileId);
+
+  Future<Want> respond(String id, String value);
+  Future<Want> clearResponse(String id);
+  Future<void> ignore(String id);
+  Future<void> unignore(String id);
+
+  /// Promote = spawn an idea. [audiencePersonIds] null → server defaults to the
+  /// want's invitees. Returns the new activity.
+  Future<Activity> promote(
+    String id, {
+    List<String>? audiencePersonIds,
+    List<String> timeOptions,
+    List<String> locationOptions,
+    bool allowSuggestions,
+    String? squadId,
+  });
+}
+
+class ApiWantRepository implements WantRepository {
+  ApiWantRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  List<Want> _list(Map<String, dynamic> res) =>
+      ((res['items'] as List<dynamic>?) ?? const [])
+          .map((e) => Want.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+  @override
+  Future<List<Want>> listOwn({bool includeArchived = false}) async => _list(
+    await apiClient.get(
+      '/v1/wants${includeArchived ? '?include_archived=true' : ''}',
+    ),
+  );
+
+  @override
+  Future<List<Want>> listInvited() async =>
+      _list(await apiClient.get('/v1/wants/invited'));
+
+  @override
+  Future<Want> create({
+    required String activityTypeId,
+    String? title,
+    String? location,
+    String? notes,
+    String kind = 'one_shot',
+    List<String> inviteeIds = const [],
+  }) async {
+    final res = await apiClient.post(
+      '/v1/wants',
+      body: {
+        'activity_type_id': activityTypeId,
+        'title': ?title,
+        'location': ?location,
+        'notes': ?notes,
+        'kind': kind,
+        if (inviteeIds.isNotEmpty) 'invitee_ids': inviteeIds,
+      },
+    );
+    return Want.fromJson(res);
+  }
+
+  @override
+  Future<Want> update(
+    String id, {
+    String? activityTypeId,
+    String? title,
+    String? location,
+    String? notes,
+    String? kind,
+  }) async {
+    final res = await apiClient.patch(
+      '/v1/wants/$id',
+      body: {
+        'activity_type_id': ?activityTypeId,
+        'title': ?title,
+        'location': ?location,
+        'notes': ?notes,
+        'kind': ?kind,
+      },
+    );
+    return Want.fromJson(res);
+  }
+
+  @override
+  Future<void> delete(String id) async => apiClient.delete('/v1/wants/$id');
+
+  @override
+  Future<Want> invite(String id, List<String> profileIds) async {
+    final res = await apiClient.post(
+      '/v1/wants/$id/invites',
+      body: {'profile_ids': profileIds},
+    );
+    return Want.fromJson(res);
+  }
+
+  @override
+  Future<Want> uninvite(String id, String profileId) async {
+    final res = await apiClient.delete('/v1/wants/$id/invites/$profileId');
+    return Want.fromJson(res);
+  }
+
+  @override
+  Future<Want> respond(String id, String value) async {
+    final res = await apiClient.put(
+      '/v1/wants/$id/response',
+      body: {'value': value},
+    );
+    return Want.fromJson(res);
+  }
+
+  @override
+  Future<Want> clearResponse(String id) async {
+    final res = await apiClient.delete('/v1/wants/$id/response');
+    return Want.fromJson(res);
+  }
+
+  @override
+  Future<void> ignore(String id) async =>
+      apiClient.post('/v1/wants/$id/ignore');
+
+  @override
+  Future<void> unignore(String id) async =>
+      apiClient.post('/v1/wants/$id/unignore');
+
+  @override
+  Future<Activity> promote(
+    String id, {
+    List<String>? audiencePersonIds,
+    List<String> timeOptions = const [],
+    List<String> locationOptions = const [],
+    bool allowSuggestions = false,
+    String? squadId,
+  }) async {
+    final res = await apiClient.post(
+      '/v1/wants/$id/promote',
+      body: {
+        if (squadId != null) 'scope': 'squad',
+        'squad_id': ?squadId,
+        if (audiencePersonIds != null)
+          'audience': {'kind': 'people', 'person_ids': audiencePersonIds},
+        'allow_suggestions': allowSuggestions,
+        if (timeOptions.isNotEmpty) 'time_options': timeOptions,
+        if (locationOptions.isNotEmpty) 'location_options': locationOptions,
+      },
+    );
+    return Activity.fromJson(res);
+  }
+}

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -15,6 +15,7 @@ import 'screens/friends/friends_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/profile/profile_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
+import 'screens/wants/wants_screen.dart';
 import 'screens/thread/thread_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
 import 'screens/welcome/welcome_screen.dart';
@@ -48,6 +49,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/', builder: (_, _) => const TimelineScreen()),
       GoRoute(path: '/friends', builder: (_, _) => const FriendsScreen()),
       GoRoute(path: '/profile', builder: (_, _) => const ProfileScreen()),
+      GoRoute(path: '/wants', builder: (_, _) => const WantsScreen()),
       GoRoute(
         path: '/ideas/new',
         builder: (_, state) =>

--- a/app/lib/screens/profile/profile_screen.dart
+++ b/app/lib/screens/profile/profile_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../providers/auth_controller.dart';
 import '../../widgets/photo_picker.dart';
@@ -170,6 +171,16 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
                         : const Text('Save'),
+                  ),
+                  const SizedBox(height: 16),
+                  const Divider(),
+                  ListTile(
+                    key: const Key('wantsLink'),
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.checklist_outlined),
+                    title: const Text('Want to do'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => context.push('/wants'),
                   ),
                   const SizedBox(height: 8),
                   TextButton.icon(

--- a/app/lib/screens/wants/wants_screen.dart
+++ b/app/lib/screens/wants/wants_screen.dart
@@ -1,0 +1,597 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_exception.dart';
+import '../../models/friend.dart';
+import '../../models/topic.dart';
+import '../../models/want.dart';
+import '../../providers/providers.dart';
+
+/// "Want to do" — the user's shared backlog (specs/screens/wants.md). Two groupings:
+/// Yours (with invitee responses) and Invited (with respond/ignore). Promote spawns a
+/// real idea via the want-promote endpoint (no parallel publish path).
+class WantsScreen extends ConsumerWidget {
+  const WantsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final own = ref.watch(ownWantsProvider);
+    final invited = ref.watch(invitedWantsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Want to do')),
+      floatingActionButton: FloatingActionButton(
+        key: const Key('addWantButton'),
+        tooltip: 'Add a want',
+        onPressed: () => _openEditor(context, ref),
+        child: const Icon(Icons.add),
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          ref.invalidate(ownWantsProvider);
+          ref.invalidate(invitedWantsProvider);
+        },
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const _SectionHeader('Yours'),
+            own.when(
+              loading: () => const _Loading(),
+              error: (e, _) => _Err('$e'),
+              data: (list) => list.isEmpty
+                  ? const _Empty(
+                      'Got a "we should do that sometime" with a friend? Capture it here and make it happen.',
+                    )
+                  : Column(
+                      children: [for (final w in list) _OwnWantTile(want: w)],
+                    ),
+            ),
+            const SizedBox(height: 24),
+            const _SectionHeader('Invited'),
+            invited.when(
+              loading: () => const _Loading(),
+              error: (e, _) => _Err('$e'),
+              data: (list) => list.isEmpty
+                  ? const _Empty('No want invites right now.')
+                  : Column(
+                      children: [
+                        for (final w in list) _InvitedWantTile(want: w),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Tiles ────────────────────────────────────────────────────────────────
+
+class _OwnWantTile extends ConsumerWidget {
+  const _OwnWantTile({required this.want});
+  final Want want;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final responded = want.invitees.where((i) => i.response != null).toList();
+    final subtitle = [
+      if (want.location != null) want.location!,
+      if (want.isOngoing) 'Ongoing',
+      if (want.invitees.isNotEmpty)
+        '${responded.length}/${want.invitees.length} responded',
+    ].join(' · ');
+
+    return Card(
+      key: Key('want_${want.id}'),
+      child: ListTile(
+        title: Text(
+          want.title?.isNotEmpty == true
+              ? want.title!
+              : (want.activityTypeLabel ?? 'Want'),
+        ),
+        subtitle: Text(
+          [
+            if (want.title?.isNotEmpty == true) want.activityTypeLabel,
+            if (subtitle.isNotEmpty) subtitle,
+          ].whereType<String>().join('\n'),
+        ),
+        isThreeLine: subtitle.isNotEmpty && want.title?.isNotEmpty == true,
+        trailing: PopupMenuButton<String>(
+          key: Key('wantMenu_${want.id}'),
+          onSelected: (v) async {
+            switch (v) {
+              case 'promote':
+                await _openPromote(context, ref, want);
+              case 'edit':
+                await _openEditor(context, ref, existing: want);
+              case 'delete':
+                await ref.read(wantRepositoryProvider).delete(want.id);
+                ref.invalidate(ownWantsProvider);
+            }
+          },
+          itemBuilder: (_) => const [
+            PopupMenuItem(value: 'promote', child: Text('Promote to plan')),
+            PopupMenuItem(value: 'edit', child: Text('Edit')),
+            PopupMenuItem(value: 'delete', child: Text('Delete')),
+          ],
+        ),
+        onTap: () => _openPromote(context, ref, want),
+      ),
+    );
+  }
+}
+
+class _InvitedWantTile extends ConsumerWidget {
+  const _InvitedWantTile({required this.want});
+  final Want want;
+
+  Future<void> _respond(WidgetRef ref, String value) async {
+    await ref.read(wantRepositoryProvider).respond(want.id, value);
+    ref.invalidate(invitedWantsProvider);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final from = want.ownerName ?? 'A friend';
+    return Card(
+      key: Key('invitedWant_${want.id}'),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              want.title?.isNotEmpty == true
+                  ? want.title!
+                  : (want.activityTypeLabel ?? 'Want'),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            Text('$from · ${want.activityTypeLabel ?? ''}'),
+            const SizedBox(height: 8),
+            if (want.yourResponse == null)
+              Wrap(
+                spacing: 8,
+                children: [
+                  for (final v in const ['in', 'interested', 'next_time'])
+                    OutlinedButton(
+                      key: Key('respond_${v}_${want.id}'),
+                      onPressed: () => _respond(ref, v),
+                      child: Text(_label(v)),
+                    ),
+                  TextButton(
+                    key: Key('ignoreWant_${want.id}'),
+                    onPressed: () async {
+                      await ref.read(wantRepositoryProvider).ignore(want.id);
+                      ref.invalidate(invitedWantsProvider);
+                    },
+                    child: const Text('Ignore'),
+                  ),
+                ],
+              )
+            else
+              InputChip(
+                key: Key('yourResponseChip_${want.id}'),
+                label: Text(_label(want.yourResponse!)),
+                onDeleted: () async {
+                  await ref.read(wantRepositoryProvider).clearResponse(want.id);
+                  ref.invalidate(invitedWantsProvider);
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _label(String v) => switch (v) {
+    'in' => "I'm in",
+    'interested' => 'Interested',
+    'next_time' => 'Next time',
+    _ => v,
+  };
+}
+
+// ── Editor (add / edit) ──────────────────────────────────────────────────
+
+Future<void> _openEditor(
+  BuildContext context,
+  WidgetRef ref, {
+  Want? existing,
+}) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: _WantEditor(existing: existing),
+    ),
+  );
+}
+
+class _WantEditor extends ConsumerStatefulWidget {
+  const _WantEditor({this.existing});
+  final Want? existing;
+
+  @override
+  ConsumerState<_WantEditor> createState() => _WantEditorState();
+}
+
+class _WantEditorState extends ConsumerState<_WantEditor> {
+  late final TextEditingController _title;
+  late final TextEditingController _location;
+  late final TextEditingController _notes;
+  String? _topicId;
+  String _kind = 'one_shot';
+  final Set<String> _invitees = {};
+  bool _busy = false;
+  String? _error;
+
+  bool get _isEdit => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final w = widget.existing;
+    _title = TextEditingController(text: w?.title ?? '');
+    _location = TextEditingController(text: w?.location ?? '');
+    _notes = TextEditingController(text: w?.notes ?? '');
+    _topicId = w?.activityTypeId;
+    _kind = w?.kind ?? 'one_shot';
+  }
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _location.dispose();
+    _notes.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_topicId == null) {
+      setState(() => _error = 'Pick an activity type');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final repo = ref.read(wantRepositoryProvider);
+      if (_isEdit) {
+        await repo.update(
+          widget.existing!.id,
+          activityTypeId: _topicId,
+          title: _title.text.trim(),
+          location: _location.text.trim(),
+          notes: _notes.text.trim(),
+          kind: _kind,
+        );
+      } else {
+        await repo.create(
+          activityTypeId: _topicId!,
+          title: _title.text.trim().isEmpty ? null : _title.text.trim(),
+          location: _location.text.trim().isEmpty
+              ? null
+              : _location.text.trim(),
+          notes: _notes.text.trim().isEmpty ? null : _notes.text.trim(),
+          kind: _kind,
+          inviteeIds: _invitees.toList(),
+        );
+      }
+      ref.invalidate(ownWantsProvider);
+      if (mounted) Navigator.of(context).pop();
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = "Couldn't save. Try again.");
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final topics = ref.watch(topicsProvider);
+    final friends = ref.watch(friendsProvider);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        key: const Key('wantEditor'),
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            _isEdit ? 'Edit want' : 'Add a want',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          topics.when(
+            loading: () => const _Loading(),
+            error: (e, _) => _Err('$e'),
+            data: (list) => DropdownButtonFormField<String>(
+              key: const Key('wantTopicDropdown'),
+              initialValue: _topicId,
+              decoration: const InputDecoration(
+                labelText: 'Activity type',
+                border: OutlineInputBorder(),
+              ),
+              items: [
+                for (final Topic t in list)
+                  DropdownMenuItem(value: t.id, child: Text(t.label)),
+              ],
+              onChanged: (v) => setState(() => _topicId = v),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('wantTitleField'),
+            controller: _title,
+            decoration: const InputDecoration(
+              labelText: 'Title (optional)',
+              hintText: 'FDR lake paddle',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('wantLocationField'),
+            controller: _location,
+            decoration: const InputDecoration(
+              labelText: 'Location (optional)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('wantNotesField'),
+            controller: _notes,
+            decoration: const InputDecoration(
+              labelText: 'Notes (optional)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          SwitchListTile(
+            key: const Key('wantOngoingSwitch'),
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Ongoing'),
+            subtitle: const Text(
+              'A standing aspiration you can plan again and again',
+            ),
+            value: _kind == 'ongoing',
+            onChanged: (v) =>
+                setState(() => _kind = v ? 'ongoing' : 'one_shot'),
+          ),
+          // Invitees only on create (edit invites via the want menu later).
+          if (!_isEdit) ...[
+            const SizedBox(height: 8),
+            Text(
+              'Invite friends',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            friends.when(
+              loading: () => const _Loading(),
+              error: (e, _) => _Err('$e'),
+              data: (list) => Wrap(
+                spacing: 8,
+                children: [
+                  for (final Friend f in list)
+                    FilterChip(
+                      key: Key('inviteChip_${f.id}'),
+                      label: Text(
+                        f.displayName.isEmpty ? 'Friend' : f.displayName,
+                      ),
+                      selected: _invitees.contains(f.id),
+                      onSelected: (sel) => setState(() {
+                        if (sel) {
+                          _invitees.add(f.id);
+                        } else {
+                          _invitees.remove(f.id);
+                        }
+                      }),
+                    ),
+                ],
+              ),
+            ),
+          ],
+          if (_error != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              _error!,
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ],
+          const SizedBox(height: 16),
+          FilledButton(
+            key: const Key('saveWantButton'),
+            onPressed: _busy ? null : _save,
+            child: Text(_busy ? 'Saving…' : (_isEdit ? 'Save' : 'Add want')),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Promote ────────────────────────────────────────────────────────────────
+
+Future<void> _openPromote(
+  BuildContext context,
+  WidgetRef ref,
+  Want want,
+) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: _PromoteSheet(want: want),
+    ),
+  );
+}
+
+class _PromoteSheet extends ConsumerStatefulWidget {
+  const _PromoteSheet({required this.want});
+  final Want want;
+
+  @override
+  ConsumerState<_PromoteSheet> createState() => _PromoteSheetState();
+}
+
+class _PromoteSheetState extends ConsumerState<_PromoteSheet> {
+  late final TextEditingController _time;
+  late final TextEditingController _location;
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _time = TextEditingController();
+    _location = TextEditingController(text: widget.want.location ?? '');
+  }
+
+  @override
+  void dispose() {
+    _time.dispose();
+    _location.dispose();
+    super.dispose();
+  }
+
+  List<String> _split(String raw) =>
+      raw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+
+  Future<void> _promote() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await ref
+          .read(wantRepositoryProvider)
+          .promote(
+            widget.want.id,
+            timeOptions: _split(_time.text),
+            locationOptions: _split(_location.text),
+          );
+      ref.invalidate(ownWantsProvider);
+      ref.invalidate(friendsTimelineProvider);
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Posted to your friends!')),
+        );
+      }
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = "Couldn't promote. Try again.");
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final w = widget.want;
+    final names = w.invitees.map((i) => i.name).whereType<String>().toList();
+    final audience = names.isEmpty ? 'all your friends' : names.join(', ');
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        key: const Key('promoteSheet'),
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Promote to a plan',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 4),
+          Text('${w.activityTypeLabel ?? 'Activity'} · with $audience'),
+          const SizedBox(height: 16),
+          TextField(
+            key: const Key('promoteTimeField'),
+            controller: _time,
+            decoration: const InputDecoration(
+              labelText: 'Time options (comma-separated)',
+              hintText: 'Sat 7am, Sun 8am',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('promoteLocationField'),
+            controller: _location,
+            decoration: const InputDecoration(
+              labelText: 'Location options (comma-separated)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          if (_error != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              _error!,
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ],
+          const SizedBox(height: 16),
+          FilledButton(
+            key: const Key('confirmPromoteButton'),
+            onPressed: _busy ? null : _promote,
+            child: Text(_busy ? 'Posting…' : 'Post it'),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Small shared bits ───────────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+  final String text;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(bottom: 8),
+    child: Text(text, style: Theme.of(context).textTheme.titleMedium),
+  );
+}
+
+class _Loading extends StatelessWidget {
+  const _Loading();
+  @override
+  Widget build(BuildContext context) => const Padding(
+    padding: EdgeInsets.all(16),
+    child: Center(child: CircularProgressIndicator()),
+  );
+}
+
+class _Empty extends StatelessWidget {
+  const _Empty(this.text);
+  final String text;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 12),
+    child: Text(text, style: TextStyle(color: Theme.of(context).hintColor)),
+  );
+}
+
+class _Err extends StatelessWidget {
+  const _Err(this.text);
+  final String text;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.all(8),
+    child: Text("Couldn't load. $text"),
+  );
+}

--- a/app/test/wants_screen_test.dart
+++ b/app/test/wants_screen_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/activity.dart';
+import 'package:squadquest/models/want.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/want_repository.dart';
+import 'package:squadquest/screens/wants/wants_screen.dart';
+
+class _FakeWantRepository implements WantRepository {
+  _FakeWantRepository({this.own = const [], this.invited = const []});
+  List<Want> own;
+  List<Want> invited;
+  String? respondedId;
+  String? respondedValue;
+  String? ignoredId;
+
+  @override
+  Future<List<Want>> listOwn({bool includeArchived = false}) async => own;
+  @override
+  Future<List<Want>> listInvited() async => invited;
+
+  @override
+  Future<Want> respond(String id, String value) async {
+    respondedId = id;
+    respondedValue = value;
+    return invited.firstWhere((w) => w.id == id);
+  }
+
+  @override
+  Future<void> ignore(String id) async {
+    ignoredId = id;
+  }
+
+  // Unused in these tests:
+  @override
+  Future<Want> create({
+    required String activityTypeId,
+    String? title,
+    String? location,
+    String? notes,
+    String kind = 'one_shot',
+    List<String> inviteeIds = const [],
+  }) async => throw UnimplementedError();
+  @override
+  Future<Want> update(
+    String id, {
+    String? activityTypeId,
+    String? title,
+    String? location,
+    String? notes,
+    String? kind,
+  }) async => throw UnimplementedError();
+  @override
+  Future<void> delete(String id) async {}
+  @override
+  Future<Want> invite(String id, List<String> profileIds) async =>
+      throw UnimplementedError();
+  @override
+  Future<Want> uninvite(String id, String profileId) async =>
+      throw UnimplementedError();
+  @override
+  Future<Want> clearResponse(String id) async => throw UnimplementedError();
+  @override
+  Future<void> unignore(String id) async {}
+  @override
+  Future<Activity> promote(
+    String id, {
+    List<String>? audiencePersonIds,
+    List<String> timeOptions = const [],
+    List<String> locationOptions = const [],
+    bool allowSuggestions = false,
+    String? squadId,
+  }) async => throw UnimplementedError();
+}
+
+Want _want(String id, {String? title, List<WantInvitee> invitees = const []}) =>
+    Want(
+      id: id,
+      activityTypeLabel: 'Go Paddleboarding',
+      title: title,
+      invitees: invitees,
+    );
+
+Future<_FakeWantRepository> _pump(
+  WidgetTester tester, {
+  List<Want> own = const [],
+  List<Want> invited = const [],
+}) async {
+  final repo = _FakeWantRepository(own: own, invited: invited);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [wantRepositoryProvider.overrideWithValue(repo)],
+      child: const MaterialApp(home: WantsScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return repo;
+}
+
+void main() {
+  testWidgets('renders own + invited wants', (tester) async {
+    await _pump(
+      tester,
+      own: [_want('w1', title: 'FDR lake')],
+      invited: [_want('w2', title: 'Climb')],
+    );
+    expect(find.byKey(const Key('want_w1')), findsOneWidget);
+    expect(find.byKey(const Key('invitedWant_w2')), findsOneWidget);
+    expect(find.text('FDR lake'), findsOneWidget);
+  });
+
+  testWidgets('responding to an invite calls the repo', (tester) async {
+    final repo = await _pump(tester, invited: [_want('w2', title: 'Climb')]);
+    await tester.tap(find.byKey(const Key('respond_in_w2')));
+    await tester.pump();
+    expect(repo.respondedId, 'w2');
+    expect(repo.respondedValue, 'in');
+  });
+
+  testWidgets('ignoring an invite calls the repo', (tester) async {
+    final repo = await _pump(tester, invited: [_want('w3')]);
+    await tester.tap(find.byKey(const Key('ignoreWant_w3')));
+    await tester.pump();
+    expect(repo.ignoredId, 'w3');
+  });
+
+  testWidgets('empty state shows the capture prompt', (tester) async {
+    await _pump(tester);
+    expect(
+      find.textContaining('Capture it here and make it happen'),
+      findsOneWidget,
+    );
+  });
+}

--- a/plans/v2-wants-core.md
+++ b/plans/v2-wants-core.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 depends: [v2-backend-stage2-activities, v2-friends-and-onboarding]
 specs:
   - specs/data-model.md
@@ -8,7 +8,7 @@ specs:
   - specs/api/profile.md
   - specs/principles.md
 issues: []
-pr: 457
+pr: 460
 ---
 
 # Plan: v2 wants — core (shared pre-activity → promote to idea)
@@ -82,15 +82,15 @@ collaborative shared-edit lists.
 
 ## Validation
 
-- [ ] backend: CRUD scoped to owner; invite only accepted friends; an invitee reads the want + can
-      respond (no decline) + ignore (recoverable via Ignored, never shown to owner); promote spawns a real idea
-      via the existing path with `from_want` set + audience defaulted to invitees; `one_shot`
-      archives, `ongoing` persists. `bun test` + type-check; CI.
-- [ ] client: Yours + Invited lists; add/edit + invite friends + kind; respond to an invite; promote
-      → composer pre-filled (topic + invitee audience) → publishes to any channel. `flutter analyze`
-      + widget tests; CI.
-- [ ] (on-device, post-merge) create a want inviting a friend; the friend sees it + responds; owner
-      sees the response; promote → posts to those invitees; one_shot archives.
+- [x] backend (#459): CRUD scoped to owner; invite only accepted friends; an invitee reads the want
+      + responds (no decline) + ignore (recoverable, never shown to owner); promote spawns a real
+      idea via `createIdea` with `from_want` set + audience defaulted to invitees; `one_shot`
+      archives, `ongoing` persists. `bun test` 61 pass; type-check clean; CI.
+- [x] client (#460): Yours + Invited lists; add/edit + invite friends + kind; respond to an invite;
+      promote sheet pre-filled (topic + invitee audience) → posts via the want-promote endpoint.
+      `flutter analyze` clean; full suite 29 pass; CI.
+- [ ] **(on-device, post-merge)** create a want inviting a friend; the friend sees it + responds;
+      owner sees the response; promote → posts to those invitees; one_shot archives.
 
 ## Risks / unknowns
 
@@ -107,8 +107,28 @@ collaborative shared-edit lists.
 
 ## Notes
 
-(closeout)
+Shipped in two PRs: **#459** (backend — schema/migration, WantService, /v1/wants, 5 tests) and
+**#460** (client — models, repo, providers, WantsScreen, profile entry, 4 widget tests).
+
+Two implementation choices worth recording:
+
+- **Promote stays server-side.** Rather than route the client into `ComposeIdeaScreen` and rebuild
+  the idea payload there, the client calls `POST /v1/wants/:id/promote` with optional time/location
+  options; the *server* delegates to `createIdea` and defaults the audience to the want's invitees.
+  Keeps the "no parallel publish path" guarantee at the API layer and avoids threading a want-seed
+  through the composer. (The spec's "composer pre-filled" intent is met by a dedicated promote
+  sheet; if richer pre-fill is wanted later, `ComposeIdeaScreen` can take a want seed then.)
+- **`from_want_id` is a plain uuid (no FK)** on `activity`, matching the existing pattern for
+  `confirmed_*_option_id` — avoids a circular activity↔want constraint; integrity is enforced in
+  the domain layer.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred — edit invitees after creation:** the editor only sets invitees on *create*; the
+  backend supports `POST/DELETE /v1/wants/:id/invites`, so add invite-management to the edit path
+  in a fast-follow. (Low effort; not blocking the core flow.)
+- **Tracked — `v2-ignore-and-recovery`:** want-invite ignore currently surfaces only as "leaves the
+  Invited list"; folding ignored want-invites into the unified `GET /v1/ignored` + Ignored screen
+  is that plan's job.
+- **Tracked — `v2-wants-overlap`:** the someday mutual-wants signal.
+- **None** for `v2-wants-sharing` (cancelled — invites are sharing).


### PR DESCRIPTION
The client half of `v2-wants-core` (backend shipped in #459). Delivers the FDR-lake flow end-to-end.

## What's here
- **Models:** `Want` + `WantInvitee` (tolerant readers).
- **`WantRepository`** + providers (`ownWantsProvider`, `invitedWantsProvider`): CRUD, invite/uninvite, respond/clear, ignore/unignore, promote.
- **`WantsScreen` (`/wants`):**
  - **Yours** — each want with its invitee responses + a menu (Promote / Edit / Delete).
  - **Invited** — respond **I'm in / Interested / Next time**, or **Ignore** (silent, recoverable — the dismissal principle).
  - **Add/edit sheet** — topic + title/location/notes + **Ongoing** toggle + friend **invite chips**.
  - **Promote sheet** — shows the audience (the want's invitees), takes time/location options, posts via `POST /v1/wants/:id/promote` (server defaults audience to invitees + spawns the idea — no parallel publish path).
- **Profile** "Want to do" entry point.

## Validation
- 4 widget tests: renders own+invited, respond, ignore, empty state.
- `flutter analyze` clean; full suite **29 pass** (+4).

## Note on promote
Kept promote server-side (client → `/promote` → server delegates to `createIdea`) rather than threading a want-seed through `ComposeIdeaScreen`. Meets the spec's intent with a dedicated promote sheet; richer composer pre-fill can come later. Closes out `v2-wants-core` (done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)