### PR TITLE
feat: friend-request ignore + Ignored recovery (dismissal-is-silent)

### DIFF
--- a/app/lib/models/friend.dart
+++ b/app/lib/models/friend.dart
@@ -65,3 +65,38 @@ class FriendRequests {
         .toList(),
   );
 }
+
+/// An item the caller has ignored, from `GET /v1/ignored` (specs/screens/ignored.md).
+/// `type` is `friend_request` or `want_invite`; the other party is in [profile]
+/// (the sender of a request, or a want's owner). [title] is set for want invites.
+class IgnoredItem {
+  const IgnoredItem({
+    required this.id,
+    required this.type,
+    required this.profile,
+    this.title,
+    this.subtitle,
+  });
+
+  final String id;
+  final String type; // 'friend_request' | 'want_invite'
+  final Friend? profile;
+  final String? title;
+  final String? subtitle;
+
+  bool get isFriendRequest => type == 'friend_request';
+
+  factory IgnoredItem.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String? ?? '';
+    // friend_request carries `profile`; want_invite carries `owner` + activity_type.
+    final p = (json['profile'] ?? json['owner']) as Map<String, dynamic>?;
+    final activityType = json['activity_type'] as Map<String, dynamic>?;
+    return IgnoredItem(
+      id: json['id'] as String,
+      type: type,
+      profile: p == null ? null : Friend.fromJson(p),
+      title: json['title'] as String? ?? activityType?['label'] as String?,
+      subtitle: activityType?['label'] as String?,
+    );
+  }
+}

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -122,6 +122,11 @@ final invitedWantsProvider = FutureProvider<List<Want>>(
   (ref) => ref.watch(wantRepositoryProvider).listInvited(),
 );
 
+/// The caller's ignored incoming items (specs/screens/ignored.md).
+final ignoredItemsProvider = FutureProvider<List<IgnoredItem>>(
+  (ref) => ref.watch(friendRepositoryProvider).ignored(),
+);
+
 /// The user's accepted friends (for squad member selection + the Friends screen).
 final friendsProvider = FutureProvider<List<Friend>>(
   (ref) => ref.watch(friendRepositoryProvider).list(),

--- a/app/lib/repositories/friend_repository.dart
+++ b/app/lib/repositories/friend_repository.dart
@@ -12,8 +12,16 @@ abstract class FriendRepository {
   /// `'requested'` or `'accepted'` (reciprocal/idempotent). See specs/api/friends.md.
   Future<String> sendRequest(String phone);
 
-  /// Accept/decline an incoming request (requestee only).
-  Future<void> respond(String requestId, {required bool accept});
+  /// Accept an incoming request (requestee only). There is no decline — see [ignore].
+  Future<void> accept(String requestId);
+
+  /// Ignore / un-ignore an incoming request. Silent (the sender still sees pending)
+  /// and recoverable from the Ignored surface. See the dismissal-is-silent principle.
+  Future<void> ignore(String requestId);
+  Future<void> unignore(String requestId);
+
+  /// The caller's ignored incoming items (friend requests + want invites), by type.
+  Future<List<IgnoredItem>> ignored();
 }
 
 class ApiFriendRepository implements FriendRepository {
@@ -43,10 +51,26 @@ class ApiFriendRepository implements FriendRepository {
   }
 
   @override
-  Future<void> respond(String requestId, {required bool accept}) async {
+  Future<void> accept(String requestId) async {
     await apiClient.put(
       '/v1/friends/requests/$requestId',
-      body: {'accept': accept},
+      body: {'accept': true},
     );
+  }
+
+  @override
+  Future<void> ignore(String requestId) async =>
+      apiClient.post('/v1/friends/requests/$requestId/ignore');
+
+  @override
+  Future<void> unignore(String requestId) async =>
+      apiClient.post('/v1/friends/requests/$requestId/unignore');
+
+  @override
+  Future<List<IgnoredItem>> ignored() async {
+    final res = await apiClient.get('/v1/ignored');
+    return ((res['items'] as List<dynamic>?) ?? const [])
+        .map((e) => IgnoredItem.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -12,6 +12,7 @@ import 'screens/communities/create_community_screen.dart';
 import 'screens/communities/create_event_screen.dart';
 import 'screens/communities/discover_screen.dart';
 import 'screens/friends/friends_screen.dart';
+import 'screens/ignored/ignored_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/profile/profile_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
@@ -50,6 +51,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/friends', builder: (_, _) => const FriendsScreen()),
       GoRoute(path: '/profile', builder: (_, _) => const ProfileScreen()),
       GoRoute(path: '/wants', builder: (_, _) => const WantsScreen()),
+      GoRoute(path: '/ignored', builder: (_, _) => const IgnoredScreen()),
       GoRoute(
         path: '/ideas/new',
         builder: (_, state) =>

--- a/app/lib/screens/friends/friends_screen.dart
+++ b/app/lib/screens/friends/friends_screen.dart
@@ -130,20 +130,34 @@ class _IncomingTile extends ConsumerStatefulWidget {
 class _IncomingTileState extends ConsumerState<_IncomingTile> {
   bool _busy = false;
 
-  Future<void> _respond(bool accept) async {
+  Future<void> _accept() async {
     if (_busy) return;
     setState(() => _busy = true);
     try {
-      await ref
-          .read(friendRepositoryProvider)
-          .respond(widget.request.id, accept: accept);
+      await ref.read(friendRepositoryProvider).accept(widget.request.id);
       ref.invalidate(friendRequestsProvider);
-      if (accept) ref.invalidate(friendsProvider);
+      ref.invalidate(friendsProvider);
     } catch (_) {
       if (mounted) {
         setState(() => _busy = false);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Couldn\'t respond. Try again.')),
+        );
+      }
+    }
+  }
+
+  Future<void> _ignore() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await ref.read(friendRepositoryProvider).ignore(widget.request.id);
+      ref.invalidate(friendRequestsProvider);
+    } catch (_) {
+      if (mounted) {
+        setState(() => _busy = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t ignore. Try again.')),
         );
       }
     }
@@ -171,16 +185,16 @@ class _IncomingTileState extends ConsumerState<_IncomingTile> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 IconButton(
-                  key: Key('decline_${widget.request.id}'),
+                  key: Key('ignore_${widget.request.id}'),
                   icon: const Icon(Icons.close),
-                  tooltip: 'Decline',
-                  onPressed: () => _respond(false),
+                  tooltip: 'Ignore',
+                  onPressed: _ignore,
                 ),
                 IconButton(
                   key: Key('accept_${widget.request.id}'),
                   icon: const Icon(Icons.check),
                   tooltip: 'Accept',
-                  onPressed: () => _respond(true),
+                  onPressed: _accept,
                 ),
               ],
             ),

--- a/app/lib/screens/ignored/ignored_screen.dart
+++ b/app/lib/screens/ignored/ignored_screen.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/friend.dart';
+import '../../providers/providers.dart';
+
+/// The Ignored recovery surface (specs/screens/ignored.md): everything the user
+/// has ignored — friend requests + want invites — with un-ignore to restore. The
+/// reversibility half of the dismissal-is-silent-and-reversible principle. Usually
+/// empty; nothing here is ever visible to the sender.
+class IgnoredScreen extends ConsumerWidget {
+  const IgnoredScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final items = ref.watch(ignoredItemsProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ignored')),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.invalidate(ignoredItemsProvider),
+        child: items.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => ListView(
+            children: [
+              const SizedBox(height: 80),
+              Center(child: Text("Couldn't load. $e")),
+            ],
+          ),
+          data: (list) => list.isEmpty
+              ? ListView(
+                  children: const [
+                    SizedBox(height: 80),
+                    Center(child: Text('Nothing ignored')),
+                  ],
+                )
+              : ListView(
+                  padding: const EdgeInsets.all(8),
+                  children: [for (final i in list) _IgnoredTile(item: i)],
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IgnoredTile extends ConsumerStatefulWidget {
+  const _IgnoredTile({required this.item});
+  final IgnoredItem item;
+  @override
+  ConsumerState<_IgnoredTile> createState() => _IgnoredTileState();
+}
+
+class _IgnoredTileState extends ConsumerState<_IgnoredTile> {
+  bool _busy = false;
+
+  Future<void> _run(Future<void> Function() action) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await action();
+      ref.invalidate(ignoredItemsProvider);
+      ref.invalidate(friendRequestsProvider);
+      ref.invalidate(invitedWantsProvider);
+    } catch (_) {
+      if (mounted) {
+        setState(() => _busy = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t update. Try again.')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final who = item.profile?.displayName;
+    final friends = ref.read(friendRepositoryProvider);
+    final wants = ref.read(wantRepositoryProvider);
+
+    final label = item.isFriendRequest
+        ? 'Friend request from ${who?.isNotEmpty == true ? who : 'someone'}'
+        : 'Want invite${who?.isNotEmpty == true ? ' from $who' : ''}'
+              '${item.title != null ? ' · ${item.title}' : ''}';
+
+    return Card(
+      key: Key('ignored_${item.type}_${item.id}'),
+      child: ListTile(
+        title: Text(label),
+        trailing: _busy
+            ? const SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : TextButton(
+                key: Key('unignore_${item.id}'),
+                onPressed: () => _run(
+                  () => item.isFriendRequest
+                      ? friends.unignore(item.id)
+                      : wants.unignore(item.id),
+                ),
+                child: const Text('Un-ignore'),
+              ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/profile/profile_screen.dart
+++ b/app/lib/screens/profile/profile_screen.dart
@@ -182,6 +182,14 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                     trailing: const Icon(Icons.chevron_right),
                     onTap: () => context.push('/wants'),
                   ),
+                  ListTile(
+                    key: const Key('ignoredLink'),
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.visibility_off_outlined),
+                    title: const Text('Ignored'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => context.push('/ignored'),
+                  ),
                   const SizedBox(height: 8),
                   TextButton.icon(
                     key: const Key('signOutButton'),

--- a/app/test/create_squad_test.dart
+++ b/app/test/create_squad_test.dart
@@ -16,7 +16,13 @@ class FakeFriendRepository implements FriendRepository {
   @override
   Future<String> sendRequest(String phone) async => 'requested';
   @override
-  Future<void> respond(String requestId, {required bool accept}) async {}
+  Future<void> accept(String requestId) async {}
+  @override
+  Future<void> ignore(String requestId) async {}
+  @override
+  Future<void> unignore(String requestId) async {}
+  @override
+  Future<List<IgnoredItem>> ignored() async => const [];
 }
 
 void main() {

--- a/app/test/friends_screen_test.dart
+++ b/app/test/friends_screen_test.dart
@@ -19,8 +19,8 @@ class FakeFriendRepository implements FriendRepository {
   List<FriendRequest> outgoing;
 
   String? sentPhone;
-  String? respondedId;
-  bool? respondedAccept;
+  String? acceptedId;
+  String? ignoredId;
 
   @override
   Future<List<Friend>> list() async => friends;
@@ -36,10 +36,20 @@ class FakeFriendRepository implements FriendRepository {
   }
 
   @override
-  Future<void> respond(String requestId, {required bool accept}) async {
-    respondedId = requestId;
-    respondedAccept = accept;
+  Future<void> accept(String requestId) async {
+    acceptedId = requestId;
   }
+
+  @override
+  Future<void> ignore(String requestId) async {
+    ignoredId = requestId;
+  }
+
+  @override
+  Future<void> unignore(String requestId) async {}
+
+  @override
+  Future<List<IgnoredItem>> ignored() async => const [];
 }
 
 Widget _app(FakeFriendRepository fake) => ProviderScope(
@@ -76,9 +86,7 @@ void main() {
     expect(find.text('Jordan'), findsOneWidget);
   });
 
-  testWidgets('accepting an incoming request calls respond(accept:true)', (
-    tester,
-  ) async {
+  testWidgets('accepting an incoming request calls accept()', (tester) async {
     final fake = FakeFriendRepository(
       incoming: const [
         FriendRequest(
@@ -91,12 +99,29 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key('accept_r1')));
-    // Don't pumpAndSettle: the tile shows a transient spinner while responding.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(fake.respondedId, 'r1');
-    expect(fake.respondedAccept, true);
+    expect(fake.acceptedId, 'r1');
+  });
+
+  testWidgets('ignoring an incoming request calls ignore()', (tester) async {
+    final fake = FakeFriendRepository(
+      incoming: const [
+        FriendRequest(
+          id: 'r1',
+          profile: Friend(id: 'p1', firstName: 'Sam'),
+        ),
+      ],
+    );
+    await tester.pumpWidget(_app(fake));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('ignore_r1')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(fake.ignoredId, 'r1');
   });
 
   testWidgets('add-by-phone sends a request with the entered number', (

--- a/app/test/ignored_screen_test.dart
+++ b/app/test/ignored_screen_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/friend.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/friend_repository.dart';
+import 'package:squadquest/screens/ignored/ignored_screen.dart';
+
+/// Minimal fake serving the ignored list + recording un-ignore.
+class _FakeFriendRepository implements FriendRepository {
+  _FakeFriendRepository(this.items);
+  final List<IgnoredItem> items;
+  String? unignoredId;
+
+  @override
+  Future<List<IgnoredItem>> ignored() async => items;
+  @override
+  Future<void> unignore(String requestId) async {
+    unignoredId = requestId;
+  }
+
+  @override
+  Future<List<Friend>> list() async => const [];
+  @override
+  Future<FriendRequests> requests() async => const FriendRequests();
+  @override
+  Future<String> sendRequest(String phone) async => 'requested';
+  @override
+  Future<void> accept(String requestId) async {}
+  @override
+  Future<void> ignore(String requestId) async {}
+}
+
+Widget _app(_FakeFriendRepository fake) => ProviderScope(
+  overrides: [friendRepositoryProvider.overrideWithValue(fake)],
+  child: const MaterialApp(home: IgnoredScreen()),
+);
+
+void main() {
+  testWidgets('empty shows "Nothing ignored"', (tester) async {
+    await tester.pumpWidget(_app(_FakeFriendRepository(const [])));
+    await tester.pumpAndSettle();
+    expect(find.text('Nothing ignored'), findsOneWidget);
+  });
+
+  testWidgets('lists an ignored friend request and un-ignores it', (
+    tester,
+  ) async {
+    final fake = _FakeFriendRepository(const [
+      IgnoredItem(
+        id: 'r1',
+        type: 'friend_request',
+        profile: Friend(id: 'p1', firstName: 'Sam'),
+      ),
+    ]);
+    await tester.pumpWidget(_app(fake));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Friend request from Sam'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('unignore_r1')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(fake.unignoredId, 'r1');
+  });
+}

--- a/plans/v2-ignore-and-recovery.md
+++ b/plans/v2-ignore-and-recovery.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: done
 depends: [v2-friends-and-onboarding]
 specs:
   - specs/principles.md
@@ -7,7 +7,7 @@ specs:
   - specs/api/friends.md
   - specs/behaviors/friend-connections.md
 issues: []
-pr:
+pr: 461
 ---
 
 # Plan: v2 ignore + recovery (silent dismissal, app-wide)
@@ -54,12 +54,14 @@ want invites; push/notification suppression nuance.
 
 ## Validation
 
-- [ ] backend: ignoring a request leaves the sender's outgoing view unchanged (still pending);
+- [x] backend: ignoring a request leaves the sender's outgoing view unchanged (still pending);
       ignored requests leave the requestee's incoming + appear in `/v1/ignored`; un-ignore restores;
-      no `declined` status remains. Migration converts existing declined rows. `bun test` + type-check.
-- [ ] client: ignore from incoming; Ignored screen lists + un-ignores; accept-from-ignored works.
-      `flutter analyze` + widget tests.
-- [ ] re-run `/audit-spec-drift` — no `declined` drift between friends code + spec.
+      no `declined` status remains (enum is `requested|accepted`). Migration converts existing
+      `declined` rows → `requested` + ignored_at. `bun test` 62 pass; type-check clean.
+- [x] client: ignore from incoming; Ignored screen lists + un-ignores; `{accept:false}` rejected.
+      `flutter analyze` clean; suite 32 pass (+3).
+- [x] no `declined` left in server/client code (only an explanatory comment). Test DB verified:
+      enum `{requested,accepted}`, `friendship.ignored_at` present, migration 0007 applied.
 
 ## Risks / unknowns
 
@@ -70,8 +72,20 @@ want invites; push/notification suppression nuance.
 
 ## Notes
 
-(closeout)
+Shipped in one PR (#461), three commits: schema+migration, backend service+routes, client.
+
+- **Migration (0007) hand-edited.** drizzle-kit's generated enum-swap cast `status::friendship_status`
+  *after* dropping `declined` — which would throw on any existing `declined` row. Moved the
+  `UPDATE … SET status='requested', ignored_at=now() WHERE status='declined'` to run while the
+  column is text, before the re-cast. No edge is lost; a past decline becomes a silent ignore.
+- **`GET /v1/ignored` is the shared aggregator** — returns `{items:[{type, …}]}` mixing
+  `friend_request` + `want_invite` (the want-invite ignore from `v2-wants-core` now has its recovery
+  home). Extensible by `type` without a new endpoint per kind.
+- **Contract change in place, not superseded:** `PUT /requests/:id` now enum-restricts `accept` to
+  `true` (decline is gone). Safe because v2 isn't launched — no released client sends `accept:false`.
 
 ## Follow-ups
 
-(closeout)
+- **`ignored_at` not serialized on friend-request ignored items** — the screen shows who+context,
+  which is enough; add the timestamp to the serializer if the UI ever needs "ignored 3d ago".
+- **None** otherwise — blocking remains a separate future plan (ignore ≠ block, as documented).

--- a/server/migrations/0007_faithful_tenebrous.sql
+++ b/server/migrations/0007_faithful_tenebrous.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "friendship" ALTER COLUMN "status" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "friendship" ALTER COLUMN "status" SET DEFAULT 'requested'::text;--> statement-breakpoint
+ALTER TABLE "friendship" ADD COLUMN "ignored_at" timestamp with time zone;--> statement-breakpoint
+-- Convert existing `declined` rows: a past decline becomes a silent ignore. The
+-- edge returns to `requested` with ignored_at set, so it leaves the requestee's
+-- incoming list for their Ignored surface (nothing is lost; re-requestable).
+-- Must run while `status` is text — before the enum no longer has 'declined'.
+UPDATE "friendship" SET "status" = 'requested', "ignored_at" = now() WHERE "status" = 'declined';--> statement-breakpoint
+DROP TYPE "public"."friendship_status";--> statement-breakpoint
+CREATE TYPE "public"."friendship_status" AS ENUM('requested', 'accepted');--> statement-breakpoint
+ALTER TABLE "friendship" ALTER COLUMN "status" SET DEFAULT 'requested'::"public"."friendship_status";--> statement-breakpoint
+ALTER TABLE "friendship" ALTER COLUMN "status" SET DATA TYPE "public"."friendship_status" USING "status"::"public"."friendship_status";

--- a/server/migrations/meta/0007_snapshot.json
+++ b/server/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1531 @@
+{
+  "id": "83cc337c-44ae-4592-8d77-c1ad17e4f4bc",
+  "prevId": "4373053c-a931-4301-a8ff-f7ff390ea7a8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester": {
+          "name": "requester",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestee": {
+          "name": "requestee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_requester_profile_id_fk": {
+          "name": "friendship_requester_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requester"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_requestee_profile_id_fk": {
+          "name": "friendship_requestee_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requestee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "friendship_pair": {
+          "name": "friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "requester",
+            "requestee"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_phone_unique": {
+          "name": "profile_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "noun": {
+          "name": "noun",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_subscription": {
+      "name": "topic_subscription",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_subscription_topic_id_topic_id_fk": {
+          "name": "topic_subscription_topic_id_topic_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_subscription_profile_id_profile_id_fk": {
+          "name": "topic_subscription_profile_id_profile_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_subscription_topic_id_profile_id_pk": {
+          "name": "topic_subscription_topic_id_profile_id_pk",
+          "columns": [
+            "topic_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_code": {
+      "name": "otp_code",
+      "schema": "",
+      "columns": {
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_token": {
+      "name": "refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_token_profile_id_profile_id_fk": {
+          "name": "refresh_token_profile_id_profile_id_fk",
+          "tableFrom": "refresh_token",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_token_token_hash_unique": {
+          "name": "refresh_token_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "activity_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "activity_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_kind": {
+          "name": "audience_kind",
+          "type": "audience_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_friends'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmed_time_option_id": {
+          "name": "confirmed_time_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_location_option_id": {
+          "name": "confirmed_location_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_event_id": {
+          "name": "community_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_want_id": {
+          "name": "from_want_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_captain_id_profile_id_fk": {
+          "name": "activity_captain_id_profile_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_activity_type_id_topic_id_fk": {
+          "name": "activity_activity_type_id_topic_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_audience": {
+      "name": "activity_audience",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_audience_activity_id_activity_id_fk": {
+          "name": "activity_audience_activity_id_activity_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_audience_profile_id_profile_id_fk": {
+          "name": "activity_audience_profile_id_profile_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_audience_activity_id_profile_id_pk": {
+          "name": "activity_audience_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_option": {
+      "name": "activity_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "option_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_option_activity_id_activity_id_fk": {
+          "name": "activity_option_activity_id_activity_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_option_created_by_profile_id_fk": {
+          "name": "activity_option_created_by_profile_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.option_vote": {
+      "name": "option_vote",
+      "schema": "",
+      "columns": {
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "option_vote_option_id_activity_option_id_fk": {
+          "name": "option_vote_option_id_activity_option_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "activity_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "option_vote_profile_id_profile_id_fk": {
+          "name": "option_vote_profile_id_profile_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "option_vote_option_id_profile_id_pk": {
+          "name": "option_vote_option_id_profile_id_pk",
+          "columns": [
+            "option_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response": {
+      "name": "response",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "response_activity_id_activity_id_fk": {
+          "name": "response_activity_id_activity_id_fk",
+          "tableFrom": "response",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "response_profile_id_profile_id_fk": {
+          "name": "response_profile_id_profile_id_fk",
+          "tableFrom": "response",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "response_activity_id_profile_id_pk": {
+          "name": "response_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad": {
+      "name": "squad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad_membership": {
+      "name": "squad_membership",
+      "schema": "",
+      "columns": {
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "squad_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "squad_membership_squad_id_squad_id_fk": {
+          "name": "squad_membership_squad_id_squad_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "squad_membership_profile_id_profile_id_fk": {
+          "name": "squad_membership_profile_id_profile_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "squad_membership_squad_id_profile_id_pk": {
+          "name": "squad_membership_squad_id_profile_id_pk",
+          "columns": [
+            "squad_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_target_type": {
+          "name": "thread_target_type",
+          "type": "thread_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_target_id": {
+          "name": "thread_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_sender_id_profile_id_fk": {
+          "name": "message_sender_id_profile_id_fk",
+          "tableFrom": "message",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_squad_id_squad_id_fk": {
+          "name": "message_squad_id_squad_id_fk",
+          "tableFrom": "message",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community": {
+      "name": "community",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_event": {
+      "name": "community_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_event_community_id_community_id_fk": {
+          "name": "community_event_community_id_community_id_fk",
+          "tableFrom": "community_event",
+          "tableTo": "community",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_event_activity_type_id_topic_id_fk": {
+          "name": "community_event_activity_type_id_topic_id_fk",
+          "tableFrom": "community_event",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_event_rsvp": {
+      "name": "community_event_rsvp",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "going": {
+          "name": "going",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_event_rsvp_event_id_community_event_id_fk": {
+          "name": "community_event_rsvp_event_id_community_event_id_fk",
+          "tableFrom": "community_event_rsvp",
+          "tableTo": "community_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_event_rsvp_profile_id_profile_id_fk": {
+          "name": "community_event_rsvp_profile_id_profile_id_fk",
+          "tableFrom": "community_event_rsvp",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_event_rsvp_event_id_profile_id_pk": {
+          "name": "community_event_rsvp_event_id_profile_id_pk",
+          "columns": [
+            "event_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_membership": {
+      "name": "community_membership",
+      "schema": "",
+      "columns": {
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'follower'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_membership_community_id_community_id_fk": {
+          "name": "community_membership_community_id_community_id_fk",
+          "tableFrom": "community_membership",
+          "tableTo": "community",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_membership_profile_id_profile_id_fk": {
+          "name": "community_membership_profile_id_profile_id_fk",
+          "tableFrom": "community_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_membership_community_id_profile_id_pk": {
+          "name": "community_membership_community_id_profile_id_pk",
+          "columns": [
+            "community_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.want": {
+      "name": "want",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "want_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "want_owner_id_profile_id_fk": {
+          "name": "want_owner_id_profile_id_fk",
+          "tableFrom": "want",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "want_activity_type_id_topic_id_fk": {
+          "name": "want_activity_type_id_topic_id_fk",
+          "tableFrom": "want",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.want_invite": {
+      "name": "want_invite",
+      "schema": "",
+      "columns": {
+        "want_id": {
+          "name": "want_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "want_invite_want_id_want_id_fk": {
+          "name": "want_invite_want_id_want_id_fk",
+          "tableFrom": "want_invite",
+          "tableTo": "want",
+          "columnsFrom": [
+            "want_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "want_invite_profile_id_profile_id_fk": {
+          "name": "want_invite_profile_id_profile_id_fk",
+          "tableFrom": "want_invite",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "want_invite_want_id_profile_id_pk": {
+          "name": "want_invite_want_id_profile_id_pk",
+          "columns": [
+            "want_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted"
+      ]
+    },
+    "public.activity_scope": {
+      "name": "activity_scope",
+      "schema": "public",
+      "values": [
+        "friends",
+        "squad"
+      ]
+    },
+    "public.activity_state": {
+      "name": "activity_state",
+      "schema": "public",
+      "values": [
+        "idea",
+        "confirmed"
+      ]
+    },
+    "public.audience_kind": {
+      "name": "audience_kind",
+      "schema": "public",
+      "values": [
+        "all_friends",
+        "people"
+      ]
+    },
+    "public.option_kind": {
+      "name": "option_kind",
+      "schema": "public",
+      "values": [
+        "time",
+        "location"
+      ]
+    },
+    "public.response_value": {
+      "name": "response_value",
+      "schema": "public",
+      "values": [
+        "in",
+        "interested",
+        "next_time"
+      ]
+    },
+    "public.squad_role": {
+      "name": "squad_role",
+      "schema": "public",
+      "values": [
+        "captain",
+        "member"
+      ]
+    },
+    "public.thread_target_type": {
+      "name": "thread_target_type",
+      "schema": "public",
+      "values": [
+        "activity",
+        "community_event",
+        "message"
+      ]
+    },
+    "public.community_role": {
+      "name": "community_role",
+      "schema": "public",
+      "values": [
+        "leader",
+        "follower"
+      ]
+    },
+    "public.want_kind": {
+      "name": "want_kind",
+      "schema": "public",
+      "values": [
+        "one_shot",
+        "ongoing"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781274252435,
       "tag": "0006_narrow_unus",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781283036609,
+      "tag": "0007_faithful_tenebrous",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema/identity.ts
+++ b/server/src/db/schema/identity.ts
@@ -23,11 +23,9 @@ export const profile = pgTable('profile', {
     .defaultNow(),
 })
 
-export const friendshipStatus = pgEnum('friendship_status', [
-  'requested',
-  'accepted',
-  'declined',
-])
+// No `declined`: a dismissed request is ignored (silent + recoverable), never
+// declined. See principles.md#dismissal-is-silent-and-reversible.
+export const friendshipStatus = pgEnum('friendship_status', ['requested', 'accepted'])
 
 // The double-opt-in graph. A pair is "friends" when status = accepted.
 export const friendship = pgTable(
@@ -41,6 +39,10 @@ export const friendship = pgTable(
       .notNull()
       .references(() => profile.id, { onDelete: 'cascade' }),
     status: friendshipStatus('status').notNull().default('requested'),
+    // Set when the requestee ignored an incoming request: the edge stays
+    // `requested` (the sender still sees pending) but it leaves the requestee's
+    // incoming list for their Ignored surface. Silent + recoverable.
+    ignoredAt: timestamp('ignored_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/server/src/domain/friend/service.ts
+++ b/server/src/domain/friend/service.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from 'drizzle-orm'
+import { and, eq, isNotNull, or } from 'drizzle-orm'
 
 import type { Database } from '../../db/index.ts'
 import { profile, friendship } from '../../db/schema/index.ts'
@@ -48,23 +48,17 @@ export class FriendService {
 
     if (edge) {
       if (edge.status === 'accepted') return 'accepted'
-      if (edge.status === 'requested') {
-        if (edge.requester === targetId) {
-          // They already requested me → my "send" is an accept.
-          await this.db
-            .update(friendship)
-            .set({ status: 'accepted' })
-            .where(eq(friendship.id, edge.id))
-          return 'accepted'
-        }
-        return 'requested' // I already requested them — idempotent.
+      // status === 'requested' (the only other value).
+      if (edge.requester === targetId) {
+        // They already requested me → my "send" is an accept. (If I'd ignored
+        // their request, accepting supersedes the ignore.)
+        await this.db
+          .update(friendship)
+          .set({ status: 'accepted', ignoredAt: null })
+          .where(eq(friendship.id, edge.id))
+        return 'accepted'
       }
-      // declined → re-open as a fresh request from me (decline is not a block).
-      await this.db
-        .update(friendship)
-        .set({ requester: me, requestee: targetId, status: 'requested' })
-        .where(eq(friendship.id, edge.id))
-      return 'requested'
+      return 'requested' // I already requested them — idempotent.
     }
 
     await this.db
@@ -103,19 +97,47 @@ export class FriendService {
       const other = byId.get(otherId)
       if (!other) continue
       const view = { id: e.id, profile: other, createdAt: e.createdAt }
-      if (e.requestee === me) incoming.push(view)
-      else outgoing.push(view)
+      if (e.requestee === me) {
+        // Ignored incoming requests leave this list for the Ignored surface; the
+        // sender's outgoing view is unaffected by whether the recipient ignored.
+        if (e.ignoredAt === null) incoming.push(view)
+      } else {
+        outgoing.push(view)
+      }
     }
     return { incoming, outgoing }
   }
 
-  // Accept/decline an incoming request. Requestee-only; a non-requestee (or a
-  // missing / already-resolved edge) is indistinguishable from not-found → 404.
-  async respond(
-    me: string,
-    requestId: string,
-    accept: boolean,
-  ): Promise<'accepted' | 'declined'> {
+  // Incoming requests the caller has ignored (for the Ignored recovery surface).
+  async listIgnoredRequests(me: string): Promise<FriendRequestView[]> {
+    const edges = await this.db
+      .select()
+      .from(friendship)
+      .where(
+        and(
+          eq(friendship.status, 'requested'),
+          eq(friendship.requestee, me),
+          isNotNull(friendship.ignoredAt),
+        ),
+      )
+    if (edges.length === 0) return []
+    const senderIds = edges.map((e) => e.requester)
+    const senders = await this.db
+      .select()
+      .from(profile)
+      .where(or(...senderIds.map((id) => eq(profile.id, id))))
+    const byId = new Map(senders.map((p) => [p.id, p]))
+    return edges
+      .map((e) => {
+        const other = byId.get(e.requester)
+        return other ? { id: e.id, profile: other, createdAt: e.createdAt } : null
+      })
+      .filter((v): v is FriendRequestView => v !== null)
+  }
+
+  // Resolve an incoming `requested` edge owned by the caller (requestee). A
+  // non-requestee / missing / accepted edge is indistinguishable from 404.
+  private async incomingEdgeOr404(me: string, requestId: string) {
     const [edge] = await this.db
       .select()
       .from(friendship)
@@ -123,8 +145,26 @@ export class FriendService {
     if (!edge || edge.requestee !== me || edge.status !== 'requested') {
       throw new ApiError(404, 'not_found', 'Request not found')
     }
-    const status = accept ? 'accepted' : 'declined'
-    await this.db.update(friendship).set({ status }).where(eq(friendship.id, edge.id))
-    return status
+    return edge
+  }
+
+  // Accept an incoming request. Requestee-only. (There is no decline — see ignore.)
+  async accept(me: string, requestId: string): Promise<'accepted'> {
+    const edge = await this.incomingEdgeOr404(me, requestId)
+    await this.db
+      .update(friendship)
+      .set({ status: 'accepted', ignoredAt: null })
+      .where(eq(friendship.id, edge.id))
+    return 'accepted'
+  }
+
+  // Ignore / un-ignore an incoming request. Silent (the edge stays `requested`, so
+  // the sender still sees pending) and recoverable. Requestee-only.
+  async setIgnored(me: string, requestId: string, ignored: boolean): Promise<void> {
+    const edge = await this.incomingEdgeOr404(me, requestId)
+    await this.db
+      .update(friendship)
+      .set({ ignoredAt: ignored ? new Date() : null })
+      .where(eq(friendship.id, edge.id))
   }
 }

--- a/server/src/routes/v1/friends.ts
+++ b/server/src/routes/v1/friends.ts
@@ -3,7 +3,9 @@ import { and, eq, or, inArray } from 'drizzle-orm'
 
 import { profile, friendship } from '../../db/schema/index.ts'
 import { FriendService } from '../../domain/friend/service.ts'
+import { WantService } from '../../domain/want/service.ts'
 import { serializeFriend, serializeFriendRequest } from '../../contracts/friend.ts'
+import { serializeWants } from '../../contracts/want.ts'
 
 // The accepted friend graph + double-opt-in connection requests.
 // See specs/api/friends.md + specs/behaviors/friend-connections.md.
@@ -69,7 +71,8 @@ const friendsRoutes: FastifyPluginAsync = async (fastify) => {
     },
   )
 
-  // PUT /v1/friends/requests/:id — accept/decline an incoming request (requestee only).
+  // PUT /v1/friends/requests/:id — accept an incoming request (requestee only).
+  // There is no decline; to make a request go away, ignore it (below).
   fastify.put<{ Params: { id: string }; Body: { accept: boolean } }>(
     '/friends/requests/:id',
     {
@@ -78,19 +81,51 @@ const friendsRoutes: FastifyPluginAsync = async (fastify) => {
         body: {
           type: 'object',
           required: ['accept'],
-          properties: { accept: { type: 'boolean' } },
+          properties: { accept: { type: 'boolean', enum: [true] } },
         },
       },
     },
     async (request) => {
-      const status = await friends.respond(
-        request.profileId!,
-        request.params.id,
-        request.body.accept,
-      )
+      const status = await friends.accept(request.profileId!, request.params.id)
       return { status }
     },
   )
+
+  // POST /v1/friends/requests/:id/ignore — silent + recoverable (dismissal principle).
+  fastify.post<{ Params: { id: string } }>(
+    '/friends/requests/:id/ignore',
+    { preHandler: fastify.authenticate },
+    async (request) => {
+      await friends.setIgnored(request.profileId!, request.params.id, true)
+      return { status: 'requested', ignored: true }
+    },
+  )
+
+  fastify.post<{ Params: { id: string } }>(
+    '/friends/requests/:id/unignore',
+    { preHandler: fastify.authenticate },
+    async (request) => {
+      await friends.setIgnored(request.profileId!, request.params.id, false)
+      return { status: 'requested', ignored: false }
+    },
+  )
+
+  // GET /v1/ignored — the caller's ignored incoming items, aggregated across types
+  // (friend requests + want invites). See specs/screens/ignored.md.
+  fastify.get('/ignored', { preHandler: fastify.authenticate }, async (request) => {
+    const me = request.profileId!
+    const [reqs, wantViews] = await Promise.all([
+      friends.listIgnoredRequests(me),
+      new WantService(fastify.db).listIgnored(me),
+    ])
+    const requestItems = reqs.map((r) => ({
+      type: 'friend_request' as const,
+      ...serializeFriendRequest(r),
+    }))
+    const wants = await serializeWants(fastify.db, me, wantViews)
+    const wantItems = wants.map((w) => ({ type: 'want_invite' as const, ...w }))
+    return { items: [...requestItems, ...wantItems] }
+  })
 }
 
 export default friendsRoutes

--- a/server/test/friends.test.ts
+++ b/server/test/friends.test.ts
@@ -148,7 +148,7 @@ test('re-sending an existing request is idempotent (still one requested edge)', 
   expect(count).toBe(1)
 })
 
-test('declining leaves no connection; the pair can re-request later', async () => {
+test('ignoring is silent + recoverable; sender still sees pending', async () => {
   const alice = await makeUser('+12150001040')
   const bob = await makeUser('+12150001041')
 
@@ -162,35 +162,67 @@ test('declining leaves no connection; the pair can re-request later', async () =
     await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth })
   ).json().incoming[0].id
 
-  const declined = await server.inject({
+  // Bob ignores → silent (edge stays requested), recoverable.
+  const ignored = await server.inject({
+    method: 'POST',
+    url: `/v1/friends/requests/${reqId}/ignore`,
+    headers: bob.auth,
+  })
+  expect(ignored.json()).toEqual({ status: 'requested', ignored: true })
+
+  // It left Bob's incoming list but is in his Ignored surface.
+  expect(
+    (await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth }))
+      .json().incoming,
+  ).toHaveLength(0)
+  const ign = await server.inject({ method: 'GET', url: '/v1/ignored', headers: bob.auth })
+  expect(ign.json().items).toHaveLength(1)
+  expect(ign.json().items[0].type).toBe('friend_request')
+
+  // Alice (the sender) is UNAFFECTED — still sees a pending outgoing request.
+  expect(
+    (await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: alice.auth }))
+      .json().outgoing,
+  ).toHaveLength(1)
+
+  // Bob un-ignores → it returns to his incoming list.
+  await server.inject({
+    method: 'POST',
+    url: `/v1/friends/requests/${reqId}/unignore`,
+    headers: bob.auth,
+  })
+  const back = await server.inject({
+    method: 'GET',
+    url: '/v1/friends/requests',
+    headers: bob.auth,
+  })
+  expect(back.json().incoming).toHaveLength(1)
+
+  // Still exactly one edge throughout.
+  const [{ count }] = await server.sql<{ count: number }[]>`
+    select count(*)::int as count from friendship`
+  expect(count).toBe(1)
+})
+
+test('there is no decline: PUT {accept:false} is rejected', async () => {
+  const alice = await makeUser('+12150001050')
+  const bob = await makeUser('+12150001051')
+  await server.inject({
+    method: 'POST',
+    url: '/v1/friends/requests',
+    headers: alice.auth,
+    payload: { phone: '+12150001051' },
+  })
+  const reqId = (
+    await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: bob.auth })
+  ).json().incoming[0].id
+  const res = await server.inject({
     method: 'PUT',
     url: `/v1/friends/requests/${reqId}`,
     headers: bob.auth,
     payload: { accept: false },
   })
-  expect(declined.json()).toEqual({ status: 'declined' })
-
-  // No connection, nothing pending.
-  expect(
-    (await server.inject({ method: 'GET', url: '/v1/friends', headers: alice.auth })).json()
-      .items,
-  ).toHaveLength(0)
-  expect(
-    (await server.inject({ method: 'GET', url: '/v1/friends/requests', headers: alice.auth }))
-      .json().outgoing,
-  ).toHaveLength(0)
-
-  // Re-request reopens it (decline is not a block) — still one edge.
-  const reopened = await server.inject({
-    method: 'POST',
-    url: '/v1/friends/requests',
-    headers: alice.auth,
-    payload: { phone: '+12150001041' },
-  })
-  expect(reopened.json()).toEqual({ status: 'requested' })
-  const [{ count }] = await server.sql<{ count: number }[]>`
-    select count(*)::int as count from friendship`
-  expect(count).toBe(1)
+  expect(res.statusCode).toBe(400) // schema enum [true] rejects false
 })
 
 test('only the requestee may respond; others get 404', async () => {


### PR DESCRIPTION
Implements `v2-ignore-and-recovery` — the *dismissal is silent and reversible* principle (#458) for friend requests, plus the shared **Ignored** recovery screen. Code catching up to spec: the friends backend still shipped `declined`, which the principle forbids.

## Backend
- **Schema/migration (0007):** `friendship.ignored_at`; enum drops `declined` → `requested|accepted`. Hand-edited the migration to convert existing `declined` rows → `requested` + `ignored_at` **while the column is text** (before the enum loses the value), so the re-cast can't throw.
- **Service/routes:** `accept()` (PUT enum-restricts `accept` to `true` — no decline), `ignore`/`unignore` (edge stays `requested`, so the **sender still sees pending**), incoming list excludes ignored, **outgoing unchanged**. New `GET /v1/ignored` aggregating ignored friend requests **+ want invites** by `type` (gives the want-invite ignore from #460 its recovery home).

## Client
- Incoming-request "Decline" (×) → **Ignore** (silent).
- **IgnoredScreen** (`/ignored`, from Profile): lists ignored requests + want invites, each with **un-ignore** (restores to incoming/invited).

## Validation
- `bun test` 62 pass; `flutter` suite 32 pass (+3: ignore action, Ignored empty + un-ignore, no-decline 400).
- Test DB verified: enum `{requested,accepted}`, `ignored_at` present, migration applied. No `declined` left in code.

Migrate-on-startup applies 0007 on deploy. Closes out `v2-ignore-and-recovery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)