### PR TITLE
feat(server): seed curated official activity types (unblock empty topics)

### DIFF
--- a/plans/v2-activity-types-seed.md
+++ b/plans/v2-activity-types-seed.md
@@ -1,0 +1,54 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/data-model.md
+issues: []
+pr:
+---
+
+# Plan: v2 seed curated official activity types (unblock)
+
+> **Live blocker:** `GET /v1/topics` reads an empty table in every fresh DB — there is no seed —
+> so nothing in the app that requires an activity type (ideas, wants) can be created. This plan
+> ships a small curated **official** seed to unblock all real testing. The full official/community
+> model (create-on-the-fly, categories, review/merge, v1-DB enrichment) is a separate, larger
+> effort — see `v2-activity-types-taxonomy`.
+
+## Scope
+
+**In:**
+
+- Add `topic.kind ∈ {official, community}` (default `official`). Official types are curated and
+  take preference everywhere; community types arrive with the taxonomy plan.
+- A seed migration inserting ~23 curated **official** topics (noun/verb/label) drawn from the
+  `origin/ctufts/topic-exploration` v7 prototype (Sports / Outdoors / Games / Food & Drink / Arts /
+  Social). Idempotent (no duplicate on re-run).
+- Update `specs/data-model.md` topic entry to document `kind`.
+- A test asserting the seed loaded + `GET /v1/topics` returns them.
+
+**Out:** categories on `topic` (taxonomy plan); user/community-created types + create-on-the-fly
+(taxonomy plan); the v1 topics-DB scan (needs Chris's export — feeds the *curated set* later, not
+this unblock); semantic search / related-topics (prototype-only, later).
+
+## Approach
+
+- `kind` is a pgEnum column, additive; existing rows (none in prod yet) default `official`.
+- Seed via a hand-written SQL migration (`INSERT … ON CONFLICT DO NOTHING` keyed on label) so it's
+  reproducible and runs on deploy via migrate-on-startup — no separate seed script to invoke.
+- Verbs absent in the prototype are assigned natural readings (e.g. "Go Rock Climbing", "Play Board
+  Games"); labels are low-stakes and refined later by the taxonomy work + v1 scan.
+
+## Validation
+
+- [ ] `topic.kind` column exists; seed migration inserts the curated official set; re-running is a
+      no-op. `GET /v1/topics` returns them. `bun test` + type-check; CI.
+- [ ] (post-merge) composing an idea / creating a want offers the seeded types — the blocker clears.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/plans/v2-activity-types-seed.md
+++ b/plans/v2-activity-types-seed.md
@@ -1,10 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/data-model.md
 issues: []
-pr:
+pr: 462
 ---
 
 # Plan: v2 seed curated official activity types (unblock)
@@ -41,14 +41,23 @@ this unblock); semantic search / related-topics (prototype-only, later).
 
 ## Validation
 
-- [ ] `topic.kind` column exists; seed migration inserts the curated official set; re-running is a
-      no-op. `GET /v1/topics` returns them. `bun test` + type-check; CI.
-- [ ] (post-merge) composing an idea / creating a want offers the seeded types — the blocker clears.
+- [x] `topic.kind` column exists (migration 0008); seed migration 0009 inserts 23 curated official
+      topics; re-run is a no-op (WHERE NOT EXISTS on label). `topics-seed.test.ts` asserts 23
+      official rows + idempotency. `bun test` 63 pass; type-check clean.
+- [x] verified end-to-end: `bin/reset-db` → a fresh DB migrates to exactly 23 official topics, so
+      composing an idea / creating a want now has types (blocker cleared). Prod gets them via
+      migrate-on-startup on deploy.
 
 ## Notes
 
-(closeout)
+PR #462. The seed is a **hand-written data migration** (0009), not drizzle-generated — so its
+journal entry was added manually. Idempotent via `WHERE NOT EXISTS` on label (no unique constraint
+needed). Verbs absent in the ctufts prototype were given natural readings ("Go Rock Climbing",
+"Grab Coffee", etc.); labels are intentionally low-stakes — they'll be refined by the taxonomy
+work + the v1-DB scan.
 
 ## Follow-ups
 
-(closeout)
+- **Tracked — `v2-activity-types-taxonomy`:** the full official/community model (create-on-the-fly,
+  categories, review/merge), which also folds in the v1 topics-DB export (needs Chris to export the
+  live Supabase topics). The labels/verbs seeded here are provisional until then.

--- a/plans/v2-activity-types-taxonomy.md
+++ b/plans/v2-activity-types-taxonomy.md
@@ -1,0 +1,61 @@
+---
+status: planned
+depends: [v2-activity-types-seed]
+specs: []
+issues: []
+pr:
+---
+
+# Plan: v2 activity-types taxonomy (official + community, create + review/merge)
+
+> **Backlog stub** — the full model behind activity types, beyond the curated official seed
+> (`v2-activity-types-seed`). Captures intent; specs written first at pickup.
+
+## Vision (from the user)
+
+Two tiers of activity type:
+
+- **Official** — curated, high-quality, take **preference everywhere** (surfaced first, canonical
+  labels). Seeded + maintained by the team.
+- **Community / user** — created by users, either **on the fly** while composing (type a new one
+  and go) or via a dedicated flow. Lower precedence; visible but clearly secondary.
+
+A backend **review/merge process** lets the team curate the community tier: merge near-duplicate
+community types into each other and/or **into official types** (e.g. "bball" + "Hoops" → official
+"Play Basketball"), with references repointed so nothing breaks. Official always wins.
+
+## Data sources for the curated set
+
+- **`origin/ctufts/topic-exploration`** v7 prototype — 23 topics × 6 categories with verbs +
+  semantic-similarity + related-topic maps (a starting structure for categories + search/merge).
+- **The v1 topics database** — a large, messy, organically-grown real corpus. "The way I built them
+  sucked and people went wild, but it IS a good data source." **Needs a Chris export** (live
+  Supabase, not in-repo) — drives both the curated official set *and* the merge/dedupe heuristics.
+
+## Anticipated spec surface (specs-first at pickup)
+
+- `specs/data-model.md` — `topic` gains `category` (or a topic↔category join), `created_by`
+  (null for official), `merged_into` (a tombstone pointer for merged community types so references
+  resolve to the survivor); `kind` already shipped in the seed plan.
+- `specs/api/topics.md` (new) — list (official-first, search), **create** (community), and the
+  on-the-fly create path from the composer.
+- `specs/behaviors/topic-curation.md` (new) — the review/merge model: dedupe heuristics
+  (exact/normalized/semantic), merge = repoint references + tombstone, official-takes-preference,
+  who can merge (admin/leader?).
+- `specs/screens/…` — composer create-on-the-fly affordance; a manage/browse-by-category surface;
+  (admin) a review/merge queue.
+
+## Risks / unknowns
+
+- **Merge integrity:** activities/wants/subscriptions reference `topic_id`; merging must repoint or
+  tombstone-resolve so no row dangles. Spec the reference-repoint rule explicitly.
+- **On-the-fly create vs spam:** frictionless creation invites near-duplicates — that's expected
+  (the review/merge process is the cleanup), but guard against trivially-empty/abusive labels.
+- **v1 import is messy** — treat it as a *source to curate from*, not a bulk import; most of it
+  should inform official types or seed community types, not land verbatim.
+- Likely **splits at pickup** (e.g. create-community-types; categories + browse; the review/merge
+  admin backend) — it's a large arc.
+
+## Notes / Follow-ups
+
+(closeout)

--- a/server/migrations/0008_empty_old_lace.sql
+++ b/server/migrations/0008_empty_old_lace.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."topic_kind" AS ENUM('official', 'community');--> statement-breakpoint
+ALTER TABLE "topic" ADD COLUMN "kind" "topic_kind" DEFAULT 'official' NOT NULL;

--- a/server/migrations/0009_seed_official_topics.sql
+++ b/server/migrations/0009_seed_official_topics.sql
@@ -1,0 +1,37 @@
+-- Seed the curated set of OFFICIAL activity types (v2-activity-types-seed).
+-- Source: origin/ctufts/topic-exploration v7 prototype (23 topics, 6 categories).
+-- Verbs absent in the prototype are given natural readings here; labels are
+-- low-stakes and refined later by v2-activity-types-taxonomy + the v1 DB scan.
+--
+-- Idempotent: each row inserts only if no topic with that label exists yet, so
+-- re-running (and running against a DB that already has some) is a no-op. Hand-
+-- written (not drizzle-generated) — this is data, not schema.
+
+INSERT INTO "topic" ("noun", "verb", "label", "kind")
+SELECT v.noun, v.verb, v.label, 'official'::topic_kind
+FROM (VALUES
+  ('Basketball',    'Play',  'Play Basketball'),
+  ('Soccer',        'Play',  'Play Soccer'),
+  ('Tennis',        'Play',  'Play Tennis'),
+  ('Trail Running', 'Go',    'Go Trail Running'),
+  ('Road Running',  'Go',    'Go Road Running'),
+  ('Swimming',      'Go',    'Go Swimming'),
+  ('Hiking',        'Go',    'Go Hiking'),
+  ('Rock Climbing', 'Go',    'Go Rock Climbing'),
+  ('Camping',       'Go',    'Go Camping'),
+  ('Kayaking',      'Go',    'Go Kayaking'),
+  ('Board Games',   'Play',  'Play Board Games'),
+  ('Video Games',   'Play',  'Play Video Games'),
+  ('Trivia Night',  'Go to', 'Go to Trivia Night'),
+  ('Card Games',    'Play',  'Play Card Games'),
+  ('Cooking',       'Learn', 'Learn Cooking'),
+  ('Wine Tasting',  'Go',    'Go Wine Tasting'),
+  ('Coffee Meetup', 'Grab',  'Grab Coffee'),
+  ('Photography',   'Do',    'Do Photography'),
+  ('Painting',      'Make',  'Make Painting'),
+  ('Live Music',    'Watch', 'Watch Live Music'),
+  ('Movie Nights',  'Watch', 'Watch a Movie'),
+  ('Book Club',     'Join',  'Join Book Club'),
+  ('Karaoke',       'Sing',  'Sing Karaoke')
+) AS v(noun, verb, label)
+WHERE NOT EXISTS (SELECT 1 FROM "topic" t WHERE t.label = v.label);

--- a/server/migrations/meta/0008_snapshot.json
+++ b/server/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1547 @@
+{
+  "id": "7ed9f590-bbb5-4b32-8dfc-36d0f607959e",
+  "prevId": "83cc337c-44ae-4592-8d77-c1ad17e4f4bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester": {
+          "name": "requester",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestee": {
+          "name": "requestee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_requester_profile_id_fk": {
+          "name": "friendship_requester_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requester"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_requestee_profile_id_fk": {
+          "name": "friendship_requestee_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requestee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "friendship_pair": {
+          "name": "friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "requester",
+            "requestee"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_phone_unique": {
+          "name": "profile_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "noun": {
+          "name": "noun",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "topic_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'official'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_subscription": {
+      "name": "topic_subscription",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_subscription_topic_id_topic_id_fk": {
+          "name": "topic_subscription_topic_id_topic_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_subscription_profile_id_profile_id_fk": {
+          "name": "topic_subscription_profile_id_profile_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_subscription_topic_id_profile_id_pk": {
+          "name": "topic_subscription_topic_id_profile_id_pk",
+          "columns": [
+            "topic_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_code": {
+      "name": "otp_code",
+      "schema": "",
+      "columns": {
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_token": {
+      "name": "refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_token_profile_id_profile_id_fk": {
+          "name": "refresh_token_profile_id_profile_id_fk",
+          "tableFrom": "refresh_token",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_token_token_hash_unique": {
+          "name": "refresh_token_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "activity_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "activity_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_kind": {
+          "name": "audience_kind",
+          "type": "audience_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_friends'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmed_time_option_id": {
+          "name": "confirmed_time_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_location_option_id": {
+          "name": "confirmed_location_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_event_id": {
+          "name": "community_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_want_id": {
+          "name": "from_want_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_captain_id_profile_id_fk": {
+          "name": "activity_captain_id_profile_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_activity_type_id_topic_id_fk": {
+          "name": "activity_activity_type_id_topic_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_audience": {
+      "name": "activity_audience",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_audience_activity_id_activity_id_fk": {
+          "name": "activity_audience_activity_id_activity_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_audience_profile_id_profile_id_fk": {
+          "name": "activity_audience_profile_id_profile_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_audience_activity_id_profile_id_pk": {
+          "name": "activity_audience_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_option": {
+      "name": "activity_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "option_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_option_activity_id_activity_id_fk": {
+          "name": "activity_option_activity_id_activity_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_option_created_by_profile_id_fk": {
+          "name": "activity_option_created_by_profile_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.option_vote": {
+      "name": "option_vote",
+      "schema": "",
+      "columns": {
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "option_vote_option_id_activity_option_id_fk": {
+          "name": "option_vote_option_id_activity_option_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "activity_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "option_vote_profile_id_profile_id_fk": {
+          "name": "option_vote_profile_id_profile_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "option_vote_option_id_profile_id_pk": {
+          "name": "option_vote_option_id_profile_id_pk",
+          "columns": [
+            "option_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response": {
+      "name": "response",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "response_activity_id_activity_id_fk": {
+          "name": "response_activity_id_activity_id_fk",
+          "tableFrom": "response",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "response_profile_id_profile_id_fk": {
+          "name": "response_profile_id_profile_id_fk",
+          "tableFrom": "response",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "response_activity_id_profile_id_pk": {
+          "name": "response_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad": {
+      "name": "squad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad_membership": {
+      "name": "squad_membership",
+      "schema": "",
+      "columns": {
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "squad_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "squad_membership_squad_id_squad_id_fk": {
+          "name": "squad_membership_squad_id_squad_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "squad_membership_profile_id_profile_id_fk": {
+          "name": "squad_membership_profile_id_profile_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "squad_membership_squad_id_profile_id_pk": {
+          "name": "squad_membership_squad_id_profile_id_pk",
+          "columns": [
+            "squad_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_target_type": {
+          "name": "thread_target_type",
+          "type": "thread_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_target_id": {
+          "name": "thread_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_sender_id_profile_id_fk": {
+          "name": "message_sender_id_profile_id_fk",
+          "tableFrom": "message",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_squad_id_squad_id_fk": {
+          "name": "message_squad_id_squad_id_fk",
+          "tableFrom": "message",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community": {
+      "name": "community",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_event": {
+      "name": "community_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_event_community_id_community_id_fk": {
+          "name": "community_event_community_id_community_id_fk",
+          "tableFrom": "community_event",
+          "tableTo": "community",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_event_activity_type_id_topic_id_fk": {
+          "name": "community_event_activity_type_id_topic_id_fk",
+          "tableFrom": "community_event",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_event_rsvp": {
+      "name": "community_event_rsvp",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "going": {
+          "name": "going",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_event_rsvp_event_id_community_event_id_fk": {
+          "name": "community_event_rsvp_event_id_community_event_id_fk",
+          "tableFrom": "community_event_rsvp",
+          "tableTo": "community_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_event_rsvp_profile_id_profile_id_fk": {
+          "name": "community_event_rsvp_profile_id_profile_id_fk",
+          "tableFrom": "community_event_rsvp",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_event_rsvp_event_id_profile_id_pk": {
+          "name": "community_event_rsvp_event_id_profile_id_pk",
+          "columns": [
+            "event_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_membership": {
+      "name": "community_membership",
+      "schema": "",
+      "columns": {
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'follower'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_membership_community_id_community_id_fk": {
+          "name": "community_membership_community_id_community_id_fk",
+          "tableFrom": "community_membership",
+          "tableTo": "community",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_membership_profile_id_profile_id_fk": {
+          "name": "community_membership_profile_id_profile_id_fk",
+          "tableFrom": "community_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_membership_community_id_profile_id_pk": {
+          "name": "community_membership_community_id_profile_id_pk",
+          "columns": [
+            "community_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.want": {
+      "name": "want",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "want_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "want_owner_id_profile_id_fk": {
+          "name": "want_owner_id_profile_id_fk",
+          "tableFrom": "want",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "want_activity_type_id_topic_id_fk": {
+          "name": "want_activity_type_id_topic_id_fk",
+          "tableFrom": "want",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.want_invite": {
+      "name": "want_invite",
+      "schema": "",
+      "columns": {
+        "want_id": {
+          "name": "want_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "want_invite_want_id_want_id_fk": {
+          "name": "want_invite_want_id_want_id_fk",
+          "tableFrom": "want_invite",
+          "tableTo": "want",
+          "columnsFrom": [
+            "want_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "want_invite_profile_id_profile_id_fk": {
+          "name": "want_invite_profile_id_profile_id_fk",
+          "tableFrom": "want_invite",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "want_invite_want_id_profile_id_pk": {
+          "name": "want_invite_want_id_profile_id_pk",
+          "columns": [
+            "want_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted"
+      ]
+    },
+    "public.topic_kind": {
+      "name": "topic_kind",
+      "schema": "public",
+      "values": [
+        "official",
+        "community"
+      ]
+    },
+    "public.activity_scope": {
+      "name": "activity_scope",
+      "schema": "public",
+      "values": [
+        "friends",
+        "squad"
+      ]
+    },
+    "public.activity_state": {
+      "name": "activity_state",
+      "schema": "public",
+      "values": [
+        "idea",
+        "confirmed"
+      ]
+    },
+    "public.audience_kind": {
+      "name": "audience_kind",
+      "schema": "public",
+      "values": [
+        "all_friends",
+        "people"
+      ]
+    },
+    "public.option_kind": {
+      "name": "option_kind",
+      "schema": "public",
+      "values": [
+        "time",
+        "location"
+      ]
+    },
+    "public.response_value": {
+      "name": "response_value",
+      "schema": "public",
+      "values": [
+        "in",
+        "interested",
+        "next_time"
+      ]
+    },
+    "public.squad_role": {
+      "name": "squad_role",
+      "schema": "public",
+      "values": [
+        "captain",
+        "member"
+      ]
+    },
+    "public.thread_target_type": {
+      "name": "thread_target_type",
+      "schema": "public",
+      "values": [
+        "activity",
+        "community_event",
+        "message"
+      ]
+    },
+    "public.community_role": {
+      "name": "community_role",
+      "schema": "public",
+      "values": [
+        "leader",
+        "follower"
+      ]
+    },
+    "public.want_kind": {
+      "name": "want_kind",
+      "schema": "public",
+      "values": [
+        "one_shot",
+        "ongoing"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1781283036609,
       "tag": "0007_faithful_tenebrous",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1781289573040,
+      "tag": "0008_empty_old_lace",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1781289573041,
+      "tag": "0009_seed_official_topics",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema/identity.ts
+++ b/server/src/db/schema/identity.ts
@@ -50,12 +50,17 @@ export const friendship = pgTable(
   (t) => [unique('friendship_pair').on(t.requester, t.requestee)],
 )
 
+// official = curated, takes preference everywhere; community = user-created
+// (arrives with the activity-types taxonomy plan). See specs/data-model.md.
+export const topicKind = pgEnum('topic_kind', ['official', 'community'])
+
 // The interest taxonomy (noun-verb, e.g. "Go Hiking").
 export const topic = pgTable('topic', {
   id: uuid('id').primaryKey().defaultRandom(),
   noun: text('noun').notNull(),
   verb: text('verb').notNull(),
   label: text('label').notNull(),
+  kind: topicKind('kind').notNull().default('official'),
 })
 
 // Per-user interest subscriptions.

--- a/server/test/topics-seed.test.ts
+++ b/server/test/topics-seed.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// Verifies the curated official-topics seed migration (0009). We run the actual
+// migration SQL against a cleaned topic table so the test tracks the real file
+// rather than a copy. See plans/v2-activity-types-seed.md.
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+const SEED_SQL = await Bun.file(
+  new URL('../migrations/0009_seed_official_topics.sql', import.meta.url),
+).text()
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+
+test('seed inserts the curated official set and is idempotent', async () => {
+  // Start from a clean slate, then apply the seed twice.
+  await server.sql`truncate activity, want, friendship, profile, topic cascade`
+  await server.sql.unsafe(SEED_SQL)
+  await server.sql.unsafe(SEED_SQL) // re-run: must be a no-op
+
+  const rows = await server.sql<{ label: string; kind: string }[]>`
+    select label, kind from topic`
+  expect(rows.length).toBe(23)
+  // every seeded row is official, takes preference everywhere
+  expect(rows.every((r) => r.kind === 'official')).toBe(true)
+  // a couple of representative labels are present
+  const labels = rows.map((r) => r.label)
+  expect(labels).toContain('Go Hiking')
+  expect(labels).toContain('Play Basketball')
+})

--- a/specs/data-model.md
+++ b/specs/data-model.md
@@ -39,8 +39,14 @@ Unique on (requester, requestee).
 ### topic + topic_subscription
 
 The interest taxonomy (noun-verb, e.g. "Go Hiking", "Play Basketball") and per-user
-subscriptions. `topic`: id, noun, verb, display label. `topic_subscription`: (topic,
-profile). Used to surface ideas to friends who share an interest.
+subscriptions. `topic`: id, noun, verb, display label, `kind ∈ {official, community}`.
+`topic_subscription`: (topic, profile). Used to surface ideas to friends who share an interest.
+
+- **`kind`** — `official` types are curated and **take preference everywhere**; a starter set is
+  seeded (see `plans/v2-activity-types-seed.md`). `community` types are user-created and arrive
+  with the full taxonomy (create-on-the-fly + review/merge) — see
+  `plans/v2-activity-types-taxonomy.md`. Categories, `created_by`, and merge tombstones land with
+  that plan.
 
 ---
 


### PR DESCRIPTION
**Live blocker fix.** `GET /v1/topics` had no seed — the table was empty in every fresh DB, so nothing requiring an activity type (ideas, wants) could be created. This seeds a curated **official** set so the app is usable again.

## What's here
- **`topic.kind {official|community}`** (migration 0008, default official). Official types take preference everywhere; community arrives with the taxonomy plan.
- **23 curated official topics** (migration 0009, hand-written + idempotent) from the `origin/ctufts/topic-exploration` v7 prototype — Sports / Outdoors / Games / Food & Drink / Arts / Social. Runs on migrate-on-startup, so prod gets them on deploy.
- `data-model.md` documents `kind`.

## Verified
- `topics-seed.test.ts`: 23 official rows, idempotent re-run. `bun test` 63 pass; type-check clean.
- `bin/reset-db` → fresh DB migrates to exactly 23 official topics (blocker cleared end-to-end).

## Scope boundary
This is the **immediate unblock only**. The full official/community model — create-on-the-fly, categories, backend review/merge, and folding in the messy-but-rich v1 topics DB (needs a Chris export) — is planned separately as **`v2-activity-types-taxonomy`**. Seeded labels/verbs are provisional until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)