### PR TITLE
feat: realtime — SSE /v1/stream + LISTEN/NOTIFY (server + client)

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'providers/providers.dart';
 import 'router.dart';
 
 class SquadQuestApp extends ConsumerWidget {
@@ -8,6 +9,9 @@ class SquadQuestApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Keep the realtime SSE connection alive for the app's lifetime (it self-gates
+    // on auth state; a dropped stream is harmless — see specs/behaviors/realtime.md).
+    ref.watch(realtimeConnectionProvider);
     return MaterialApp.router(
       title: 'SquadQuest',
       theme: ThemeData(

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -19,6 +19,7 @@ import '../repositories/token_store.dart';
 import '../repositories/topic_repository.dart';
 import '../repositories/upload_repository.dart';
 import '../repositories/want_repository.dart';
+import '../repositories/realtime_service.dart';
 import '../models/want.dart';
 import 'auth_controller.dart';
 
@@ -83,6 +84,46 @@ final communityRepositoryProvider = Provider<CommunityRepository>(
 final wantRepositoryProvider = Provider<WantRepository>(
   (ref) => ApiWantRepository(apiClient: ref.watch(apiClientProvider)),
 );
+
+final realtimeServiceProvider = Provider<RealtimeService>((ref) {
+  final svc = RealtimeService(
+    baseUrl: apiBaseUrl,
+    tokenStore: ref.read(tokenStoreProvider),
+  );
+  ref.onDispose(svc.dispose);
+  return svc;
+});
+
+/// Connects the SSE stream while signed in and turns each event into a Riverpod
+/// cache invalidation (a nudge to refetch — never the source of truth). A dropped
+/// stream just means staler-until-refresh; pull-to-refresh stays the fallback.
+/// See specs/behaviors/realtime.md. Kept alive by a watch in the app shell.
+final realtimeConnectionProvider = Provider<void>((ref) {
+  final auth = ref.watch(authControllerProvider);
+  final svc = ref.watch(realtimeServiceProvider);
+  if (auth is! SignedIn) {
+    svc.stop();
+    return;
+  }
+  final sub = svc.events.listen((event) {
+    switch (event.type) {
+      case 'activity.created':
+        ref.invalidate(friendsTimelineProvider);
+        final sq = event.squadId;
+        if (sq != null) ref.invalidate(squadTimelineProvider(sq));
+      case 'message.created':
+        final sq = event.squadId;
+        if (sq != null) ref.invalidate(squadTimelineProvider(sq));
+        final tType = event.threadTargetType;
+        final tId = event.threadTargetId;
+        if (tType != null && tId != null) {
+          ref.invalidate(threadProvider('$tType:$tId'));
+        }
+    }
+  });
+  ref.onDispose(sub.cancel);
+  svc.start();
+});
 
 /// The My Friends timeline (specs/screens/friends-timeline.md).
 final friendsTimelineProvider = FutureProvider<TimelinePage>(

--- a/app/lib/repositories/realtime_service.dart
+++ b/app/lib/repositories/realtime_service.dart
@@ -1,0 +1,140 @@
+// Public named ctor params map to private fields; initializing formals would force
+// underscore-prefixed public param names, which is worse for the API.
+// ignore_for_file: prefer_initializing_formals
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import 'token_store.dart';
+
+/// One realtime event from GET /v1/stream (specs/behaviors/realtime.md): a typed,
+/// id-only nudge to refetch. Unknown fields are tolerated.
+class RealtimeEvent {
+  const RealtimeEvent({required this.type, required this.data});
+  final String type; // 'activity.created' | 'message.created' | …
+  final Map<String, dynamic> data;
+
+  String? get squadId => data['squad_id'] as String?;
+  String? get threadTargetType => data['thread_target_type'] as String?;
+  String? get threadTargetId => data['thread_target_id'] as String?;
+}
+
+/// Consumes the server SSE stream and emits [RealtimeEvent]s. Pure enhancement:
+/// if it never connects or drops, the app still works via pull-to-refresh. The
+/// stream is treated as a nudge to refetch, never the source of truth.
+///
+/// Uses a streamed dio GET with the bearer token (works on all platforms, unlike
+/// browser EventSource which can't set headers). Reconnects with capped backoff.
+class RealtimeService {
+  RealtimeService({
+    required String baseUrl,
+    required TokenStore tokenStore,
+    Dio? client,
+  }) : _baseUrl = baseUrl,
+       _tokens = tokenStore,
+       _dio = client ?? Dio();
+
+  final String _baseUrl;
+  final TokenStore _tokens;
+  final Dio _dio;
+
+  final _events = StreamController<RealtimeEvent>.broadcast();
+  Stream<RealtimeEvent> get events => _events.stream;
+
+  bool _running = false;
+  int _attempt = 0;
+  CancelToken? _cancel;
+
+  void start() {
+    if (_running) return;
+    _running = true;
+    _connectLoop();
+  }
+
+  Future<void> stop() async {
+    _running = false;
+    _cancel?.cancel();
+    _cancel = null;
+  }
+
+  Future<void> _connectLoop() async {
+    while (_running) {
+      try {
+        await _connectOnce();
+        _attempt = 0; // a clean end resets backoff
+      } catch (_) {
+        // swallow — realtime is best-effort
+      }
+      if (!_running) break;
+      // Capped exponential backoff: 1s, 2s, 4s … max 30s.
+      final delayMs = (1000 * (1 << _attempt.clamp(0, 5))).clamp(1000, 30000);
+      _attempt++;
+      await Future<void>.delayed(Duration(milliseconds: delayMs));
+    }
+  }
+
+  Future<void> _connectOnce() async {
+    final token = _tokens.accessToken;
+    if (token == null) return;
+    _cancel = CancelToken();
+
+    final res = await _dio.get<ResponseBody>(
+      '$_baseUrl/v1/stream',
+      options: Options(
+        responseType: ResponseType.stream,
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Accept': 'text/event-stream',
+        },
+      ),
+      cancelToken: _cancel,
+    );
+
+    final body = res.data;
+    if (body == null) return;
+
+    // Parse the SSE byte stream line-by-line, accumulating event/data per frame
+    // (frames are separated by a blank line).
+    var buffer = '';
+    String? eventType;
+    final dataLines = <String>[];
+
+    void dispatch() {
+      if (eventType != null && dataLines.isNotEmpty) {
+        try {
+          final json = jsonDecode(dataLines.join('\n')) as Map<String, dynamic>;
+          _events.add(RealtimeEvent(type: eventType!, data: json));
+        } catch (_) {
+          /* ignore malformed frame */
+        }
+      }
+      eventType = null;
+      dataLines.clear();
+    }
+
+    await for (final chunk in body.stream) {
+      buffer += utf8.decode(chunk, allowMalformed: true);
+      var idx = buffer.indexOf('\n');
+      while (idx >= 0) {
+        final line = buffer.substring(0, idx).replaceAll('\r', '');
+        buffer = buffer.substring(idx + 1);
+        if (line.isEmpty) {
+          dispatch(); // frame boundary
+        } else if (line.startsWith(':')) {
+          // comment / heartbeat — ignore
+        } else if (line.startsWith('event:')) {
+          eventType = line.substring(6).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.add(line.substring(5).trim());
+        }
+        idx = buffer.indexOf('\n');
+      }
+    }
+  }
+
+  void dispose() {
+    stop();
+    _events.close();
+  }
+}

--- a/app/test/realtime_service_test.dart
+++ b/app/test/realtime_service_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/repositories/realtime_service.dart';
+import 'package:squadquest/repositories/token_store.dart';
+
+/// A TokenStore with a preset access token, no platform keychain.
+class _FakeTokenStore extends TokenStore {
+  _FakeTokenStore() {
+    accessToken = 'tok';
+  }
+  @override
+  Future<void> load() async {}
+}
+
+/// A dio HttpClientAdapter that streams the given SSE chunks as the response body.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this._chunks);
+  final List<String> _chunks;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final stream = Stream<Uint8List>.fromIterable(
+      _chunks.map((c) => Uint8List.fromList(utf8.encode(c))),
+    );
+    return ResponseBody(
+      stream,
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['text/event-stream'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _fakeDio(List<String> chunks) =>
+    Dio()..httpClientAdapter = _FakeAdapter(chunks);
+
+void main() {
+  test(
+    'parses SSE frames into typed events; ignores heartbeats + junk',
+    () async {
+      final svc = RealtimeService(
+        baseUrl: 'http://test',
+        tokenStore: _FakeTokenStore(),
+        client: _fakeDio([
+          ': connected\n\n',
+          'event: activity.created\n',
+          'data: {"id":"a1","scope":"friends"}\n\n',
+          ': ping\n\n',
+          // a frame split across chunks
+          'event: message.created\n',
+          'data: {"id":"m1",',
+          '"squad_id":"s1"}\n\n',
+          // malformed data — must be ignored, not crash
+          'event: message.created\n',
+          'data: not json{\n\n',
+        ]),
+      );
+
+      final received = <RealtimeEvent>[];
+      final sub = svc.events.listen(received.add);
+      svc.start();
+
+      // Let the stream drain + dispatch.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await svc.stop();
+      await sub.cancel();
+
+      expect(received.length, 2);
+      expect(received[0].type, 'activity.created');
+      expect(received[0].data['id'], 'a1');
+      expect(received[1].type, 'message.created');
+      expect(received[1].squadId, 's1');
+    },
+  );
+}

--- a/plans/v2-realtime-sse.md
+++ b/plans/v2-realtime-sse.md
@@ -1,9 +1,11 @@
 ---
-status: planned
+status: done
 depends: [v2-backend-infra]
-specs: []
+specs:
+  - specs/behaviors/realtime.md
+  - specs/api/conventions.md
 issues: []
-pr:
+pr: 465
 ---
 
 # Plan: v2 realtime (SSE + Postgres LISTEN/NOTIFY)
@@ -46,10 +48,16 @@ New `specs/behaviors/realtime.md` (the event set, delivery guarantees = best-eff
 
 ## Validation
 
-- [ ] server: NOTIFY on key writes; SSE delivers only visible events; suite + type-check.
-- [ ] client: a second session sees a new message/activity appear without manual refresh;
-      stream drop → app still works via pull-to-refresh.
-- [ ] (prod) SSE holds open on Cloud Run without premature timeout.
+- [x] server: NOTIFY on the key writes (activity.created on POST /ideas; message.created on squad
+      message + thread reply); SSE fan-out delivers only to subscribers who pass the same visibility
+      gate as REST. `realtime.test.ts`: gated delivery + unsubscribe + malformed-payload resilience.
+      `bun test` 66 pass; type-check clean.
+- [x] client: `RealtimeService` parses the SSE stream → invalidates the matching providers
+      (timelines/thread); connection self-gates on auth + reconnects with backoff; pull-to-refresh
+      remains the fallback. Parser unit-tested (split frames, heartbeats, junk). `flutter analyze`
+      clean; suite 34 pass.
+- [ ] **(prod, post-merge)** confirm SSE holds open on Cloud Run without premature timeout, and a
+      second signed-in session sees a new message/activity appear without manual refresh.
 
 ## Risks / unknowns
 
@@ -61,8 +69,25 @@ New `specs/behaviors/realtime.md` (the event set, delivery guarantees = best-eff
 
 ## Notes
 
-(closeout)
+PR #465. Spec written first (`behaviors/realtime.md` + a tightened conventions.md realtime section).
+
+Key implementation choices:
+
+- **Events are id-only nudges to refetch**, never authoritative state — so the REST visibility gates
+  stay the single source of truth and a missed event only causes staleness, never incorrectness.
+- **Visibility reuse, not reimplementation:** the fan-out's per-subscriber `canSee` calls
+  `ActivityService.canView` / `SquadService.isMember` / `MessageService.canSeeThread` (a new boolean
+  wrapper over the existing thread gate) — the load-bearing privacy rule.
+- **Dual auth on `/v1/stream`:** Bearer header (native) OR `?access_token=` (browser EventSource
+  can't set headers); a `verifyAccessToken` helper added to the auth plugin.
+- **Client uses streamed dio, not EventSource** — works uniformly on mobile + web and lets native
+  clients use the header path.
+- **publish() never blocks the write** — NOTIFY failures are logged and swallowed (enhancement).
 
 ## Follow-ups
 
-(closeout)
+- **(prod validation, above):** confirm long-lived SSE survives Cloud Run's request timeout — the
+  open question carried from `v2-backend-infra`. `min_instances=1` keeps a single LISTEN connection
+  sufficient; revisit fan-out (Redis) only if/when multi-instance.
+- **Deferred (out of scope):** more event types (`response.changed`, `vote.changed`, `rsvp.changed`)
+  — additive when wanted; presence/typing; offline replay (`Last-Event-ID`).

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import envPlugin from './plugins/env.ts'
 import dbPlugin from './db/index.ts'
 import clientVersionPlugin from './plugins/client-version.ts'
 import authPlugin from './plugins/auth.ts'
+import realtimePlugin from './realtime/index.ts'
 import { ApiError, sendError } from './contracts/errors.ts'
 import v1Routes from './routes/v1/index.ts'
 
@@ -45,6 +46,10 @@ export const app: FastifyPluginAsync = async (fastify) => {
   // specs/api/conventions.md).
   await fastify.register(clientVersionPlugin)
   await fastify.register(authPlugin)
+
+  // Realtime fan-out (SSE + LISTEN/NOTIFY) — decorates fastify.realtime. After db
+  // (uses fastify.sql.notify) + auth (stream route verifies tokens).
+  await fastify.register(realtimePlugin)
 
   // CORS allow-list (browser clients only — native apps send no Origin and are
   // never gated). Allowed origins come from ALLOWED_ORIGINS (comma-separated

--- a/server/src/domain/message/service.ts
+++ b/server/src/domain/message/service.ts
@@ -80,6 +80,21 @@ export class MessageService {
     }
   }
 
+  // Boolean form of the thread visibility gate (for realtime fan-out, which decides
+  // per-subscriber rather than throwing). Same rules as assertCanSeeTarget.
+  async canSeeThread(
+    viewerId: string,
+    targetType: ThreadTargetType,
+    targetId: string,
+  ): Promise<boolean> {
+    try {
+      await this.assertCanSeeTarget(viewerId, targetType, targetId)
+      return true
+    } catch {
+      return false
+    }
+  }
+
   async threadMessages(
     viewerId: string,
     targetType: ThreadTargetType,

--- a/server/src/plugins/auth.ts
+++ b/server/src/plugins/auth.ts
@@ -16,6 +16,10 @@ declare module 'fastify' {
     signAccessToken(profileId: string): string
     // preHandler that requires a valid bearer token; sets request.profileId.
     authenticate(request: FastifyRequest): Promise<void>
+    // Verify a raw access token → profile id, or null. For surfaces that can't use
+    // the preHandler (SSE accepts the token via ?access_token= since EventSource
+    // can't set headers). See specs/behaviors/realtime.md.
+    verifyAccessToken(token: string | undefined): string | null
   }
   interface FastifyRequest {
     profileId: string | null
@@ -42,6 +46,15 @@ export default fp(async (fastify) => {
   )
 
   fastify.decorateRequest('profileId', null)
+
+  fastify.decorate('verifyAccessToken', (token: string | undefined): string | null => {
+    if (!token) return null
+    try {
+      return (jwt.verify(token, secret) as AccessClaims).sub
+    } catch {
+      return null
+    }
+  })
 
   fastify.decorate('authenticate', async (request: FastifyRequest) => {
     const token = extractBearer(request)

--- a/server/src/realtime/index.ts
+++ b/server/src/realtime/index.ts
@@ -1,0 +1,89 @@
+import fp from 'fastify-plugin'
+import postgres from 'postgres'
+
+// Server→client live updates: SSE fanned out via Postgres LISTEN/NOTIFY. A pure
+// enhancement, never load-bearing — see specs/behaviors/realtime.md.
+
+const CHANNEL = 'sq_events'
+
+// A realtime event: a small id-only payload that nudges clients to refetch.
+export interface RealtimeEvent {
+  type: 'activity.created' | 'message.created'
+  // routing ids — just enough for a subscriber to decide relevance + invalidate.
+  [key: string]: unknown
+}
+
+// A connected SSE subscriber: their profile id, a per-event visibility predicate
+// (reuses the REST gates), and a sink that writes one event to their stream.
+export interface Subscriber {
+  profileId: string
+  canSee: (event: RealtimeEvent) => Promise<boolean>
+  send: (event: RealtimeEvent) => void
+}
+
+export interface Realtime {
+  add(sub: Subscriber): () => void // returns an unsubscribe fn
+  publish(event: RealtimeEvent): Promise<void>
+  subscriberCount(): number
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    realtime: Realtime
+  }
+}
+
+export default fp(async (fastify) => {
+  const subscribers = new Set<Subscriber>()
+
+  // Dedicated single LISTEN connection (separate from the query pool). On NOTIFY,
+  // fan out to the subscribers that may see the event.
+  const listener = postgres(fastify.config.DATABASE_URL, { max: 1 })
+
+  async function fanOut(raw: string) {
+    let event: RealtimeEvent
+    try {
+      event = JSON.parse(raw) as RealtimeEvent
+    } catch {
+      return // ignore malformed payloads
+    }
+    // Snapshot to avoid mutation-during-iteration; visibility is async + per-sub.
+    await Promise.all(
+      [...subscribers].map(async (sub) => {
+        try {
+          if (await sub.canSee(event)) sub.send(event)
+        } catch {
+          /* a failing visibility check just drops the event for that sub */
+        }
+      }),
+    )
+  }
+
+  await listener.listen(CHANNEL, (raw) => {
+    void fanOut(raw)
+  })
+
+  const realtime: Realtime = {
+    add(sub) {
+      subscribers.add(sub)
+      return () => subscribers.delete(sub)
+    },
+    // Publish via NOTIFY so every server process (and this one) fans out uniformly.
+    async publish(event) {
+      try {
+        await fastify.sql.notify(CHANNEL, JSON.stringify(event))
+      } catch (err) {
+        // Never let a realtime failure break the originating write — it's an
+        // enhancement. Log and move on.
+        fastify.log.warn({ err }, 'realtime publish failed')
+      }
+    },
+    subscriberCount: () => subscribers.size,
+  }
+
+  fastify.decorate('realtime', realtime)
+
+  fastify.addHook('onClose', async () => {
+    await listener.end({ timeout: 5 })
+  })
+})

--- a/server/src/routes/v1/ideas.ts
+++ b/server/src/routes/v1/ideas.ts
@@ -42,6 +42,13 @@ const ideaRoutes: FastifyPluginAsync = async (fastify) => {
         locationOptions: b.location_options,
         communityEventId: b.community_event_id,
       })
+      // Realtime nudge (enhancement; never blocks the write).
+      void fastify.realtime.publish({
+        type: 'activity.created',
+        id,
+        scope: b.scope ?? 'friends',
+        squad_id: b.squad_id,
+      })
       reply.code(201)
       return respond(request.profileId!, id)
     },

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -12,6 +12,7 @@ import messageRoutes from './messages.ts'
 import communityRoutes from './communities.ts'
 import uploadRoutes from './uploads.ts'
 import wantRoutes from './wants.ts'
+import streamRoutes from './stream.ts'
 
 // The /v1 contract surface. All client-facing endpoints register under here so
 // the URL major version is the coarse contract boundary (see
@@ -29,6 +30,7 @@ const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(communityRoutes)
   await fastify.register(uploadRoutes)
   await fastify.register(wantRoutes)
+  await fastify.register(streamRoutes)
 }
 
 export default v1Routes

--- a/server/src/routes/v1/messages.ts
+++ b/server/src/routes/v1/messages.ts
@@ -102,6 +102,12 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
         request.body.body ?? '',
         request.body.attachments ?? [],
       )
+      void fastify.realtime.publish({
+        type: 'message.created',
+        id: row.id,
+        thread_target_type: targetType,
+        thread_target_id: request.params.targetId,
+      })
       reply.code(201)
       return serializeMessage(fastify.db, row)
     },

--- a/server/src/routes/v1/squads.ts
+++ b/server/src/routes/v1/squads.ts
@@ -163,6 +163,11 @@ const squadRoutes: FastifyPluginAsync = async (fastify) => {
         request.body.body ?? '',
         request.body.attachments ?? [],
       )
+      void fastify.realtime.publish({
+        type: 'message.created',
+        id: row.id,
+        squad_id: request.params.id,
+      })
       reply.code(201)
       return serializeMessage(fastify.db, row)
     },

--- a/server/src/routes/v1/stream.ts
+++ b/server/src/routes/v1/stream.ts
@@ -1,0 +1,98 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { eq } from 'drizzle-orm'
+
+import { activity } from '../../db/schema/index.ts'
+import { ActivityService } from '../../domain/activity/service.ts'
+import { SquadService } from '../../domain/squad/service.ts'
+import { MessageService } from '../../domain/message/service.ts'
+import type { RealtimeEvent } from '../../realtime/index.ts'
+
+const HEARTBEAT_MS = 25_000
+
+// GET /v1/stream — authenticated SSE. Token via Authorization header OR
+// ?access_token= (EventSource can't set headers). Events are id-only nudges to
+// refetch; a subscriber only receives an event it could see via REST. See
+// specs/behaviors/realtime.md.
+const streamRoutes: FastifyPluginAsync = async (fastify) => {
+  const activities = new ActivityService(fastify.db)
+  const squads = new SquadService(fastify.db)
+
+  // Whether `viewer` may see the resource behind `event` — reuses the REST gates.
+  async function canSee(viewerId: string, event: RealtimeEvent): Promise<boolean> {
+    if (event.type === 'activity.created') {
+      const [act] = await fastify.db
+        .select()
+        .from(activity)
+        .where(eq(activity.id, String(event.id)))
+      return act ? activities.canView(viewerId, act) : false
+    }
+    if (event.type === 'message.created') {
+      // squad message → squad members; thread reply → reuse the thread gate.
+      if (event.squad_id) {
+        return squads.isMember(String(event.squad_id), viewerId)
+      }
+      if (event.thread_target_type && event.thread_target_id) {
+        return new MessageService(fastify.db).canSeeThread(
+          viewerId,
+          String(event.thread_target_type) as never,
+          String(event.thread_target_id),
+        )
+      }
+      return false
+    }
+    return false
+  }
+
+  fastify.get<{ Querystring: { access_token?: string } }>(
+    '/stream',
+    async (request, reply) => {
+      const headerToken = (() => {
+        const h = request.headers.authorization
+        if (!h) return undefined
+        const [scheme, t] = h.split(' ')
+        return scheme?.toLowerCase() === 'bearer' ? t : undefined
+      })()
+      const profileId = fastify.verifyAccessToken(
+        headerToken ?? request.query.access_token,
+      )
+      if (!profileId) {
+        reply.code(401).send({ error: { code: 'unauthorized', message: 'Auth required' } })
+        return
+      }
+
+      const res = reply.raw
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      })
+      res.write('retry: 3000\n\n') // client reconnect backoff hint
+      res.write(': connected\n\n')
+
+      const send = (event: RealtimeEvent) => {
+        res.write(`event: ${event.type}\n`)
+        res.write(`data: ${JSON.stringify(event)}\n\n`)
+      }
+
+      const unsubscribe = fastify.realtime.add({
+        profileId,
+        canSee: (event) => canSee(profileId, event),
+        send,
+      })
+
+      const heartbeat = setInterval(() => res.write(': ping\n\n'), HEARTBEAT_MS)
+
+      const cleanup = () => {
+        clearInterval(heartbeat)
+        unsubscribe()
+      }
+      request.raw.on('close', cleanup)
+
+      // Hand the socket to us; Fastify won't try to send its own response.
+      reply.hijack()
+    },
+  )
+}
+
+export default streamRoutes

--- a/server/test/realtime.test.ts
+++ b/server/test/realtime.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// Exercises the realtime fan-out + per-subscriber visibility gate directly via
+// fastify.realtime (an in-process SSE round-trip is awkward to assert; the gate is
+// the load-bearing part). See specs/behaviors/realtime.md.
+
+const { app } = await import('../src/app.ts')
+import type { RealtimeEvent } from '../src/realtime/index.ts'
+
+let server: FastifyInstance
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  await server.sql`truncate activity, message, squad, squad_membership, friendship, profile, topic cascade`
+})
+
+// Wait for the NOTIFY round-trip (publish → Postgres → LISTEN → fan-out).
+function tick(ms = 150) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+test('publish fans out only to subscribers who pass the visibility gate', async () => {
+  const seen: Record<string, RealtimeEvent[]> = { a: [], b: [] }
+
+  // Two subscribers: "a" can see everything, "b" can see nothing.
+  const offA = server.realtime.add({
+    profileId: 'a',
+    canSee: async () => true,
+    send: (e) => seen.a.push(e),
+  })
+  const offB = server.realtime.add({
+    profileId: 'b',
+    canSee: async () => false,
+    send: (e) => seen.b.push(e),
+  })
+
+  await server.realtime.publish({ type: 'activity.created', id: 'x1', scope: 'friends' })
+  await tick()
+
+  expect(seen.a).toHaveLength(1)
+  expect(seen.a[0]!.id).toBe('x1')
+  expect(seen.b).toHaveLength(0) // gated out
+
+  offA()
+  offB()
+})
+
+test('unsubscribe stops delivery; malformed payloads are ignored', async () => {
+  const got: RealtimeEvent[] = []
+  const off = server.realtime.add({
+    profileId: 'a',
+    canSee: async () => true,
+    send: (e) => got.push(e),
+  })
+
+  off() // immediately unsubscribe
+  await server.realtime.publish({ type: 'message.created', id: 'm1', squad_id: 's1' })
+  await tick()
+  expect(got).toHaveLength(0)
+
+  // A non-JSON NOTIFY must not throw / crash the listener.
+  await server.sql.notify('sq_events', 'not json{')
+  await tick()
+  expect(got).toHaveLength(0)
+})

--- a/specs/api/conventions.md
+++ b/specs/api/conventions.md
@@ -147,8 +147,13 @@ GET /v1/<list>?limit=50&before=<cursor>
   …) scoped to what the user may see.
 - Writes are ordinary POSTs; the resulting change fans out over SSE via Postgres
   `LISTEN/NOTIFY`.
-- Event payloads follow the same additive rule (only gain fields).
-- **Every screen must render correctly from a plain fetch**; SSE only makes it feel live.
+- Event payloads follow the same additive rule (only gain fields) and carry **ids only** — a nudge
+  to refetch through REST, never authoritative state.
+- **Auth:** the access token is accepted as the `Authorization: Bearer …` header **or** a
+  `?access_token=` query param (browser `EventSource` can't set headers). A `: ping` heartbeat
+  keeps the connection alive. Delivery is **best-effort / at-most-once** (no offline replay).
+- **Every screen must render correctly from a plain fetch**; SSE only makes it feel live. Full
+  contract + the per-subscriber visibility gate: [`behaviors/realtime.md`](../behaviors/realtime.md).
   See [realtime is an enhancement](../principles.md#realtime-is-an-enhancement-not-a-dependency).
 
 ## Storage (photos)

--- a/specs/behaviors/realtime.md
+++ b/specs/behaviors/realtime.md
@@ -1,0 +1,79 @@
+# Behavior: Realtime (SSE + Postgres LISTEN/NOTIFY)
+
+## Rule
+
+Server→client live updates stream over **SSE** at `GET /v1/stream`, so the timelines and open
+threads feel live without pull-to-refresh. Realtime is a **pure enhancement**: every screen renders
+correctly from a plain authenticated fetch, and the app stays fully functional if the stream never
+connects or drops mid-session (see
+[realtime is an enhancement](../principles.md#realtime-is-an-enhancement-not-a-dependency)).
+
+Events are a **nudge to refetch**, not the source of truth. A client receiving an event invalidates
+the relevant cached query and refetches through the normal REST path; it does not trust the event
+payload as authoritative state. This keeps the visibility/auth gates of the REST layer the single
+source of truth and means a missed event only causes staleness-until-next-fetch, never incorrectness.
+
+## Applies To
+
+- `api/conventions.md` (Realtime section — the transport contract), `api/messages.md`
+  (`message.created`), the friends/squad timeline screens and the thread drawer.
+- `server/src/realtime/` (the LISTEN connection + subscriber fan-out), `GET /v1/stream`.
+
+## The stream
+
+- **`GET /v1/stream`** — authenticated, `Content-Type: text/event-stream`, held open. Because
+  browser `EventSource` cannot set an `Authorization` header, the endpoint accepts the access token
+  **either** as the `Authorization: Bearer …` header (native clients) **or** as a `?access_token=`
+  query parameter (web). Same JWT, same validation.
+- Emits a periodic comment/heartbeat (`: ping`) so proxies and the client keep the connection alive
+  and can detect a dead link.
+- The client reconnects with backoff; on (re)connect it should also refetch the screens it cares
+  about, since events that occurred while disconnected were not buffered (best-effort, below).
+
+## Event set
+
+Each event is an SSE `event:` line + a small JSON `data:` payload (ids + just enough to route a
+cache invalidation — never the full resource):
+
+| event | when | payload |
+|---|---|---|
+| `activity.created` | a new idea/activity is posted | `{ id, scope, squad_id? }` |
+| `message.created` | a squad message or thread reply is posted | `{ id, squad_id?, thread_target_type?, thread_target_id? }` |
+
+The set is **extensible and additive** (future: `response.changed`, `vote.changed`,
+`rsvp.changed`) — payloads only ever gain fields, like the REST contract. Clients ignore event
+types they don't handle.
+
+## Delivery guarantees
+
+- **Best-effort, at-most-once, not durable.** Events are not queued for offline clients; there is no
+  replay/`Last-Event-ID` backfill at launch. A client that was disconnected catches up via its next
+  fetch (which the reconnect triggers). This is acceptable precisely because realtime is never
+  load-bearing.
+
+## Visibility (the privacy gate)
+
+A subscriber receives an event **only if they could see the underlying resource via REST** — the
+fan-out reuses the exact same gates (`ActivityService.canView`, squad membership, thread
+`assertCanSeeTarget`), never a parallel check. An event the subscriber couldn't fetch is never
+delivered. This is the load-bearing correctness rule: realtime must not become a side channel that
+leaks existence or content past the REST visibility boundary.
+
+## Infrastructure
+
+- A **single** Postgres `LISTEN` connection per server process (separate from the query pool);
+  domain writes `NOTIFY` a channel with the small JSON payload, and the process fans out to the
+  matching open SSE subscribers. `min_instances=1` on Cloud Run keeps one `LISTEN` connection
+  sufficient; multi-instance fan-out (e.g. Redis) is deferred until horizontal scaling is real.
+- Long-lived SSE on Cloud Run must hold open without premature request timeout — validated as part
+  of this work (flagged in `v2-backend-infra`).
+
+## Principles
+
+**Inherited:**
+
+- [Realtime is an enhancement, not a dependency](../principles.md#realtime-is-an-enhancement-not-a-dependency)
+  — the whole contract above is this principle made concrete: events nudge a refetch, correctness
+  never depends on the stream.
+- [Private-first](../principles.md#private-first-public-never-touches-the-friends-surface) — the
+  per-subscriber visibility gate ensures the live channel exposes nothing the REST layer wouldn't.


### PR DESCRIPTION
Implements `v2-realtime-sse` — live updates as a **pure enhancement** (never load-bearing). Spec written first (`behaviors/realtime.md`).

## How it works
- **Events are id-only nudges to refetch**, not authoritative state → REST visibility gates stay the single source of truth; a missed event = staleness, never incorrectness.
- **Server:** a `realtime/` plugin holds one dedicated Postgres `LISTEN` connection + a subscriber registry; domain writes `NOTIFY` a channel; the process fans out to open SSE subscribers. `publish()` swallows failures (never blocks the write).
- **`GET /v1/stream`:** authed SSE, token via **Bearer header OR `?access_token=`** (EventSource can't set headers), heartbeat + reconnect hint. Per-subscriber `canSee` **reuses** `ActivityService.canView` / `SquadService.isMember` / `MessageService.canSeeThread` — the privacy gate, never a parallel check.
- **NOTIFY on:** `activity.created` (POST /ideas), `message.created` (squad message + thread reply).
- **Client:** `RealtimeService` (streamed dio GET — works on mobile + web) parses SSE frames → `ref.invalidate` the matching providers (timelines/thread); self-gates on auth, reconnects with backoff. Pull-to-refresh stays the fallback.

## Validation
- `bun test` **66 pass** (+2: gated fan-out, unsubscribe + malformed-payload resilience); `flutter` **34 pass** (+1: SSE parser incl. split frames/heartbeats/junk); analyze + type-check clean.
- **Post-merge prod check:** confirm long-lived SSE survives Cloud Run's request timeout (the open question from `v2-backend-infra`) + a second session sees updates live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)