### PR TITLE
feat(server): community activity types — create + dedup + official-first list

### DIFF
--- a/server/migrations/0012_foamy_epoch.sql
+++ b/server/migrations/0012_foamy_epoch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "topic" ADD COLUMN "created_by" uuid;--> statement-breakpoint
+ALTER TABLE "topic" ADD CONSTRAINT "topic_created_by_profile_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."profile"("id") ON DELETE set null ON UPDATE no action;

--- a/server/migrations/meta/0012_snapshot.json
+++ b/server/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1573 @@
+{
+  "id": "05f8fd03-7129-40e4-8084-57d88ec3ead7",
+  "prevId": "d718eef5-21b1-4b98-9476-f01fa2175ded",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.friendship": {
+      "name": "friendship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requester": {
+          "name": "requester",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestee": {
+          "name": "requestee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friendship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_requester_profile_id_fk": {
+          "name": "friendship_requester_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requester"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_requestee_profile_id_fk": {
+          "name": "friendship_requestee_profile_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "requestee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "friendship_pair": {
+          "name": "friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "requester",
+            "requestee"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_phone_unique": {
+          "name": "profile_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "noun": {
+          "name": "noun",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verb": {
+          "name": "verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "topic_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'official'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_created_by_profile_id_fk": {
+          "name": "topic_created_by_profile_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_subscription": {
+      "name": "topic_subscription",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_subscription_topic_id_topic_id_fk": {
+          "name": "topic_subscription_topic_id_topic_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_subscription_profile_id_profile_id_fk": {
+          "name": "topic_subscription_profile_id_profile_id_fk",
+          "tableFrom": "topic_subscription",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_subscription_topic_id_profile_id_pk": {
+          "name": "topic_subscription_topic_id_profile_id_pk",
+          "columns": [
+            "topic_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_code": {
+      "name": "otp_code",
+      "schema": "",
+      "columns": {
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_token": {
+      "name": "refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_token_profile_id_profile_id_fk": {
+          "name": "refresh_token_profile_id_profile_id_fk",
+          "tableFrom": "refresh_token",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_token_token_hash_unique": {
+          "name": "refresh_token_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "captain_id": {
+          "name": "captain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "activity_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "activity_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audience_kind": {
+          "name": "audience_kind",
+          "type": "audience_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_friends'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmed_time_option_id": {
+          "name": "confirmed_time_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_location_option_id": {
+          "name": "confirmed_location_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_event_id": {
+          "name": "community_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_want_id": {
+          "name": "from_want_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_captain_id_profile_id_fk": {
+          "name": "activity_captain_id_profile_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "captain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_activity_type_id_topic_id_fk": {
+          "name": "activity_activity_type_id_topic_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_audience": {
+      "name": "activity_audience",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_audience_activity_id_activity_id_fk": {
+          "name": "activity_audience_activity_id_activity_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_audience_profile_id_profile_id_fk": {
+          "name": "activity_audience_profile_id_profile_id_fk",
+          "tableFrom": "activity_audience",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_audience_activity_id_profile_id_pk": {
+          "name": "activity_audience_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_option": {
+      "name": "activity_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "option_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_option_activity_id_activity_id_fk": {
+          "name": "activity_option_activity_id_activity_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_option_created_by_profile_id_fk": {
+          "name": "activity_option_created_by_profile_id_fk",
+          "tableFrom": "activity_option",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.option_vote": {
+      "name": "option_vote",
+      "schema": "",
+      "columns": {
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "option_vote_option_id_activity_option_id_fk": {
+          "name": "option_vote_option_id_activity_option_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "activity_option",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "option_vote_profile_id_profile_id_fk": {
+          "name": "option_vote_profile_id_profile_id_fk",
+          "tableFrom": "option_vote",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "option_vote_option_id_profile_id_pk": {
+          "name": "option_vote_option_id_profile_id_pk",
+          "columns": [
+            "option_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response": {
+      "name": "response",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "response_activity_id_activity_id_fk": {
+          "name": "response_activity_id_activity_id_fk",
+          "tableFrom": "response",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "response_profile_id_profile_id_fk": {
+          "name": "response_profile_id_profile_id_fk",
+          "tableFrom": "response",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "response_activity_id_profile_id_pk": {
+          "name": "response_activity_id_profile_id_pk",
+          "columns": [
+            "activity_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad": {
+      "name": "squad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.squad_membership": {
+      "name": "squad_membership",
+      "schema": "",
+      "columns": {
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "squad_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "squad_membership_squad_id_squad_id_fk": {
+          "name": "squad_membership_squad_id_squad_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "squad_membership_profile_id_profile_id_fk": {
+          "name": "squad_membership_profile_id_profile_id_fk",
+          "tableFrom": "squad_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "squad_membership_squad_id_profile_id_pk": {
+          "name": "squad_membership_squad_id_profile_id_pk",
+          "columns": [
+            "squad_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_target_type": {
+          "name": "thread_target_type",
+          "type": "thread_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_target_id": {
+          "name": "thread_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_sender_id_profile_id_fk": {
+          "name": "message_sender_id_profile_id_fk",
+          "tableFrom": "message",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_squad_id_squad_id_fk": {
+          "name": "message_squad_id_squad_id_fk",
+          "tableFrom": "message",
+          "tableTo": "squad",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community": {
+      "name": "community",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_event": {
+      "name": "community_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_event_community_id_community_id_fk": {
+          "name": "community_event_community_id_community_id_fk",
+          "tableFrom": "community_event",
+          "tableTo": "community",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_event_activity_type_id_topic_id_fk": {
+          "name": "community_event_activity_type_id_topic_id_fk",
+          "tableFrom": "community_event",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_event_rsvp": {
+      "name": "community_event_rsvp",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "going": {
+          "name": "going",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_event_rsvp_event_id_community_event_id_fk": {
+          "name": "community_event_rsvp_event_id_community_event_id_fk",
+          "tableFrom": "community_event_rsvp",
+          "tableTo": "community_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_event_rsvp_profile_id_profile_id_fk": {
+          "name": "community_event_rsvp_profile_id_profile_id_fk",
+          "tableFrom": "community_event_rsvp",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_event_rsvp_event_id_profile_id_pk": {
+          "name": "community_event_rsvp_event_id_profile_id_pk",
+          "columns": [
+            "event_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_membership": {
+      "name": "community_membership",
+      "schema": "",
+      "columns": {
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'follower'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_membership_community_id_community_id_fk": {
+          "name": "community_membership_community_id_community_id_fk",
+          "tableFrom": "community_membership",
+          "tableTo": "community",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_membership_profile_id_profile_id_fk": {
+          "name": "community_membership_profile_id_profile_id_fk",
+          "tableFrom": "community_membership",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_membership_community_id_profile_id_pk": {
+          "name": "community_membership_community_id_profile_id_pk",
+          "columns": [
+            "community_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.want": {
+      "name": "want",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type_id": {
+          "name": "activity_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "want_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "want_owner_id_profile_id_fk": {
+          "name": "want_owner_id_profile_id_fk",
+          "tableFrom": "want",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "want_activity_type_id_topic_id_fk": {
+          "name": "want_activity_type_id_topic_id_fk",
+          "tableFrom": "want",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "activity_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.want_invite": {
+      "name": "want_invite",
+      "schema": "",
+      "columns": {
+        "want_id": {
+          "name": "want_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "response_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "want_invite_want_id_want_id_fk": {
+          "name": "want_invite_want_id_want_id_fk",
+          "tableFrom": "want_invite",
+          "tableTo": "want",
+          "columnsFrom": [
+            "want_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "want_invite_profile_id_profile_id_fk": {
+          "name": "want_invite_profile_id_profile_id_fk",
+          "tableFrom": "want_invite",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "want_invite_want_id_profile_id_pk": {
+          "name": "want_invite_want_id_profile_id_pk",
+          "columns": [
+            "want_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.friendship_status": {
+      "name": "friendship_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "accepted"
+      ]
+    },
+    "public.topic_kind": {
+      "name": "topic_kind",
+      "schema": "public",
+      "values": [
+        "official",
+        "community"
+      ]
+    },
+    "public.activity_scope": {
+      "name": "activity_scope",
+      "schema": "public",
+      "values": [
+        "friends",
+        "squad"
+      ]
+    },
+    "public.activity_state": {
+      "name": "activity_state",
+      "schema": "public",
+      "values": [
+        "idea",
+        "confirmed"
+      ]
+    },
+    "public.audience_kind": {
+      "name": "audience_kind",
+      "schema": "public",
+      "values": [
+        "all_friends",
+        "people"
+      ]
+    },
+    "public.option_kind": {
+      "name": "option_kind",
+      "schema": "public",
+      "values": [
+        "time",
+        "location"
+      ]
+    },
+    "public.response_value": {
+      "name": "response_value",
+      "schema": "public",
+      "values": [
+        "in",
+        "interested",
+        "next_time"
+      ]
+    },
+    "public.squad_role": {
+      "name": "squad_role",
+      "schema": "public",
+      "values": [
+        "captain",
+        "member"
+      ]
+    },
+    "public.thread_target_type": {
+      "name": "thread_target_type",
+      "schema": "public",
+      "values": [
+        "activity",
+        "community_event",
+        "message"
+      ]
+    },
+    "public.community_role": {
+      "name": "community_role",
+      "schema": "public",
+      "values": [
+        "leader",
+        "follower"
+      ]
+    },
+    "public.want_kind": {
+      "name": "want_kind",
+      "schema": "public",
+      "values": [
+        "one_shot",
+        "ongoing"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1781290424087,
       "tag": "0011_expand_official_topics",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1781324231972,
+      "tag": "0012_foamy_epoch",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/contracts/topic.ts
+++ b/server/src/contracts/topic.ts
@@ -2,12 +2,14 @@ import type { topic } from '../db/schema/index.ts'
 
 type TopicRow = typeof topic.$inferSelect
 
-// Serialized topic (activity type) wire shape. See specs/api/ideas-activities.md.
+// Serialized topic (activity type) wire shape. See specs/api/topics.md.
 export function serializeTopic(row: TopicRow) {
   return {
     id: row.id,
     noun: row.noun,
     verb: row.verb,
     label: row.label,
+    kind: row.kind,
+    category: row.category,
   }
 }

--- a/server/src/db/schema/identity.ts
+++ b/server/src/db/schema/identity.ts
@@ -65,6 +65,9 @@ export const topic = pgTable('topic', {
   // Civic). Nullable for now; a richer category model (browse, multi-category)
   // belongs to the activity-types taxonomy plan. See specs/data-model.md.
   category: text('category'),
+  // The profile who created a community type; null for official. Community types
+  // are user-created (on-the-fly or dedicated). See specs/api/topics.md.
+  createdBy: uuid('created_by').references(() => profile.id, { onDelete: 'set null' }),
 })
 
 // Per-user interest subscriptions.

--- a/server/src/domain/topic/service.ts
+++ b/server/src/domain/topic/service.ts
@@ -1,0 +1,84 @@
+import { asc, desc, eq, ilike, sql } from 'drizzle-orm'
+
+import type { Database } from '../../db/index.ts'
+import { topic } from '../../db/schema/index.ts'
+import { errors } from '../../contracts/errors.ts'
+
+type TopicRow = typeof topic.$inferSelect
+
+// Normalize a label for dedup: lowercase, trim, collapse internal whitespace,
+// strip surrounding punctuation. "  Hiking! " and "hiking" → "hiking". The only
+// create-time dedup (fuzzy/semantic merge is v2-activity-types-merge).
+export function normalizeLabel(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/^[\p{P}\s]+|[\p{P}\s]+$/gu, '')
+}
+
+export class TopicService {
+  constructor(private readonly db: Database) {}
+
+  // Official-first list (official before community, then alphabetical), with an
+  // optional normalized substring search on the label.
+  async list(search?: string): Promise<TopicRow[]> {
+    const term = search?.trim()
+    return this.db
+      .select()
+      .from(topic)
+      .where(term ? ilike(topic.label, `%${term}%`) : undefined)
+      .orderBy(
+        // official (kind = 'official') first, then label A→Z.
+        desc(sql`(${topic.kind} = 'official')`),
+        asc(topic.label),
+      )
+  }
+
+  // Resolve a free-text label to a topic: reuse an existing one whose normalized
+  // label matches (official or community), else insert a new community topic. The
+  // single source of truth for both the dedicated create and the on-the-fly path.
+  async findOrCreate(
+    rawLabel: string,
+    createdBy: string,
+  ): Promise<{ topic: TopicRow; created: boolean }> {
+    const label = rawLabel.trim()
+    if (!label) throw errors.badRequest('label_required', 'A label is required')
+    const norm = normalizeLabel(label)
+
+    // Compare against the normalized form of existing labels.
+    const [existing] = await this.db
+      .select()
+      .from(topic)
+      .where(eq(sql`lower(regexp_replace(btrim(${topic.label}), '\\s+', ' ', 'g'))`, norm))
+      .limit(1)
+    if (existing) return { topic: existing, created: false }
+
+    // New community type. noun/verb derive from the label (label is the source of
+    // truth for community types — no noun-verb form). noun = the label, verb = ''.
+    const [row] = await this.db
+      .insert(topic)
+      .values({ noun: label, verb: '', label, kind: 'community', createdBy })
+      .returning()
+    return { topic: row!, created: true }
+  }
+
+  // Resolve an idea/want's activity type from either an id or a free-text label
+  // (exactly one). Returns the topic id to store. Backward-compatible: id-only
+  // callers are unaffected.
+  async resolveActivityType(
+    input: { activityTypeId?: string; activityTypeLabel?: string },
+    createdBy: string,
+  ): Promise<string> {
+    if (input.activityTypeId) {
+      const [t] = await this.db.select().from(topic).where(eq(topic.id, input.activityTypeId))
+      if (!t) throw errors.badRequest('topic_invalid', 'Unknown activity type')
+      return t.id
+    }
+    if (input.activityTypeLabel) {
+      const { topic: t } = await this.findOrCreate(input.activityTypeLabel, createdBy)
+      return t.id
+    }
+    throw errors.badRequest('topic_required', 'An activity type id or label is required')
+  }
+}

--- a/server/src/routes/v1/ideas.ts
+++ b/server/src/routes/v1/ideas.ts
@@ -3,11 +3,14 @@ import { eq } from 'drizzle-orm'
 
 import { activity } from '../../db/schema/index.ts'
 import { ActivityService } from '../../domain/activity/service.ts'
+import { TopicService } from '../../domain/topic/service.ts'
 import { serializeActivity } from '../../contracts/activity.ts'
 
 // Wire (snake_case) body for POST /ideas — mapped to the domain's CreateIdeaInput.
+// activity_type_id OR activity_type_label (on-the-fly create); exactly one.
 interface CreateIdeaBody {
-  activity_type_id: string
+  activity_type_id?: string
+  activity_type_label?: string
   scope?: 'friends' | 'squad'
   squad_id?: string
   audience: { kind: 'all_friends' | 'people'; person_ids?: string[] }
@@ -32,8 +35,14 @@ const ideaRoutes: FastifyPluginAsync = async (fastify) => {
     { preHandler: fastify.authenticate },
     async (request, reply) => {
       const b = request.body
+      // Resolve activity_type_id OR activity_type_label (on-the-fly create) → id.
+      const topics = new TopicService(fastify.db)
+      const activityTypeId = await topics.resolveActivityType(
+        { activityTypeId: b.activity_type_id, activityTypeLabel: b.activity_type_label },
+        request.profileId!,
+      )
       const id = await svc.createIdea(request.profileId!, {
-        activityTypeId: b.activity_type_id,
+        activityTypeId,
         scope: b.scope,
         squadId: b.squad_id,
         audience: { kind: b.audience.kind, personIds: b.audience.person_ids },

--- a/server/src/routes/v1/topics.ts
+++ b/server/src/routes/v1/topics.ts
@@ -1,16 +1,45 @@
 import type { FastifyPluginAsync } from 'fastify'
-import { asc } from 'drizzle-orm'
 
-import { topic } from '../../db/schema/index.ts'
+import { TopicService } from '../../domain/topic/service.ts'
 import { serializeTopic } from '../../contracts/topic.ts'
 
-// GET /v1/topics — the activity types available when composing an idea.
-// See specs/api/ideas-activities.md.
+// Activity types: official-first list + search, and community create (dedicated;
+// on-the-fly lives on the ideas/wants routes). See specs/api/topics.md.
 const topicRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get('/topics', { preHandler: fastify.authenticate }, async () => {
-    const rows = await fastify.db.select().from(topic).orderBy(asc(topic.label))
-    return { items: rows.map(serializeTopic) }
-  })
+  const svc = new TopicService(fastify.db)
+
+  fastify.get<{ Querystring: { search?: string } }>(
+    '/topics',
+    { preHandler: fastify.authenticate },
+    async (request) => {
+      const rows = await svc.list(request.query.search)
+      return { items: rows.map(serializeTopic) }
+    },
+  )
+
+  // Create a community type. Normalized-match reuse → 200 with the existing topic;
+  // a genuinely new label → 201 with the created community topic.
+  fastify.post<{ Body: { label: string } }>(
+    '/topics',
+    {
+      preHandler: fastify.authenticate,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['label'],
+          properties: { label: { type: 'string' } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { topic, created } = await svc.findOrCreate(
+        request.body.label,
+        request.profileId!,
+      )
+      reply.code(created ? 201 : 200)
+      return serializeTopic(topic)
+    },
+  )
 }
 
 export default topicRoutes

--- a/server/src/routes/v1/wants.ts
+++ b/server/src/routes/v1/wants.ts
@@ -3,12 +3,15 @@ import { eq } from 'drizzle-orm'
 
 import { activity } from '../../db/schema/index.ts'
 import { WantService } from '../../domain/want/service.ts'
+import { TopicService } from '../../domain/topic/service.ts'
 import { serializeWant, serializeWants } from '../../contracts/want.ts'
 import { serializeActivity } from '../../contracts/activity.ts'
 
 // Wants: a shared backlog of pre-activities (specs/api/wants.md). All authed.
+// activity_type_id OR activity_type_label (on-the-fly create); exactly one.
 interface CreateWantBody {
-  activity_type_id: string
+  activity_type_id?: string
+  activity_type_label?: string
   title?: string
   location?: string
   notes?: string
@@ -47,8 +50,12 @@ const wantRoutes: FastifyPluginAsync = async (fastify) => {
     { preHandler: fastify.authenticate },
     async (request, reply) => {
       const b = request.body
+      const activityTypeId = await new TopicService(fastify.db).resolveActivityType(
+        { activityTypeId: b.activity_type_id, activityTypeLabel: b.activity_type_label },
+        request.profileId!,
+      )
       const view = await svc.create(request.profileId!, {
-        activityTypeId: b.activity_type_id,
+        activityTypeId,
         title: b.title,
         location: b.location,
         notes: b.notes,

--- a/server/test/topics-community.test.ts
+++ b/server/test/topics-community.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// Community activity types: create (dedicated + on-the-fly), normalized-match
+// reuse, official-first listing + search. See specs/api/topics.md.
+
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, first_name, claimed_at)
+    values (${phone}, ${phone}, now()) returning id`
+  const token = server.signAccessToken(row.id)
+  return { id: row.id, auth: { authorization: `Bearer ${token}` } }
+}
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  await server.sql`truncate activity, want, friendship, profile, topic cascade`
+  // one official seed to test official-first ordering + reuse-across-tiers
+  await server.sql`insert into topic (noun, verb, label, kind) values ('Hiking','Go','Go Hiking','official')`
+})
+
+test('POST /v1/topics creates a community type with created_by', async () => {
+  const user = await makeUser('+12150006000')
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/topics',
+    headers: user.auth,
+    payload: { label: 'Disc Golf' },
+  })
+  expect(res.statusCode).toBe(201)
+  expect(res.json().label).toBe('Disc Golf')
+  expect(res.json().kind).toBe('community')
+
+  const [row] = await server.sql<{ created_by: string; kind: string }[]>`
+    select created_by, kind from topic where label = 'Disc Golf'`
+  expect(row.created_by).toBe(user.id)
+})
+
+test('normalized-match reuse returns the existing topic (200, no dup)', async () => {
+  const user = await makeUser('+12150006010')
+  // matches the seeded official "Go Hiking"? No — different label. Test reuse of a
+  // community one we just made, with messy casing/punctuation.
+  await server.inject({
+    method: 'POST',
+    url: '/v1/topics',
+    headers: user.auth,
+    payload: { label: 'Pickleball' },
+  })
+  const reuse = await server.inject({
+    method: 'POST',
+    url: '/v1/topics',
+    headers: user.auth,
+    payload: { label: '  pickleball! ' },
+  })
+  expect(reuse.statusCode).toBe(200) // reused, not created
+  const [{ n }] = await server.sql<{ n: number }[]>`
+    select count(*)::int as n from topic where lower(label) like 'pickleball%'`
+  expect(n).toBe(1) // only one row despite two POSTs
+})
+
+test('GET /v1/topics is official-first + search filters', async () => {
+  const user = await makeUser('+12150006020')
+  await server.inject({
+    method: 'POST',
+    url: '/v1/topics',
+    headers: user.auth,
+    payload: { label: 'Archery' }, // community, alphabetically before "Go Hiking"
+  })
+  const list = await server.inject({ method: 'GET', url: '/v1/topics', headers: user.auth })
+  const items = list.json().items
+  // official "Go Hiking" comes first despite "Archery" sorting earlier alphabetically.
+  expect(items[0].label).toBe('Go Hiking')
+  expect(items[0].kind).toBe('official')
+
+  const search = await server.inject({
+    method: 'GET',
+    url: '/v1/topics?search=arch',
+    headers: user.auth,
+  })
+  expect(search.json().items).toHaveLength(1)
+  expect(search.json().items[0].label).toBe('Archery')
+})
+
+test('on-the-fly: posting an idea with activity_type_label creates + uses it', async () => {
+  const user = await makeUser('+12150006030')
+  const res = await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: user.auth,
+    payload: { activity_type_label: 'Kubb', audience: { kind: 'all_friends' } },
+  })
+  expect(res.statusCode).toBe(201)
+  expect(res.json().activity_type.label).toBe('Kubb')
+
+  const [t] = await server.sql<{ kind: string; created_by: string }[]>`
+    select kind, created_by from topic where label = 'Kubb'`
+  expect(t.kind).toBe('community')
+  expect(t.created_by).toBe(user.id)
+
+  // posting again with the same label reuses the topic (no dup)
+  await server.inject({
+    method: 'POST',
+    url: '/v1/ideas',
+    headers: user.auth,
+    payload: { activity_type_label: 'kubb', audience: { kind: 'all_friends' } },
+  })
+  const [{ n }] = await server.sql<{ n: number }[]>`
+    select count(*)::int as n from topic where lower(label) = 'kubb'`
+  expect(n).toBe(1)
+})


### PR DESCRIPTION
Backend half of `v2-activity-types-community` (specs merged in #467). Client follows.

## What's here
- **`topic.created_by`** (migration 0012; null for official, set for community).
- **`TopicService`:** `normalizeLabel` + `findOrCreate` (normalized-match reuse → return existing official/community topic, else insert `kind=community`); `list()` **official-first** (`kind=official desc, label asc`) + `?search`; `resolveActivityType(id|label)`.
- **`POST /v1/topics`:** dedicated create — **201** new / **200** reuse on a normalized dupe. **`GET /v1/topics`** now official-first + search.
- **On-the-fly:** `POST /v1/ideas` + `POST /v1/wants` accept `activity_type_label` as an alternative to `activity_type_id` — type a new type and post in one step. Backward-compatible with id-only callers (bring-friends, wants-promote).
- Community types derive noun/verb from the label (no noun-verb form — frictionless).

## Verified
- 4 tests: create + `created_by`; normalized reuse (one row despite messy-cased re-POST); official-first ordering + search; on-the-fly idea create + reuse. `bun test` **70 pass**; type-check clean. Migrate-on-startup ships the column.

## Scope boundary
Normalized-match dedup only. Fuzzy/semantic merge + `merged_into` tombstones = `v2-activity-types-merge`; browse-by-category = `v2-activity-types-browse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)