### PR TITLE
fix(server): CORS header on SSE /v1/stream (web client blocked)

### DIFF
--- a/server/src/routes/v1/stream.ts
+++ b/server/src/routes/v1/stream.ts
@@ -5,6 +5,7 @@ import { activity } from '../../db/schema/index.ts'
 import { ActivityService } from '../../domain/activity/service.ts'
 import { SquadService } from '../../domain/squad/service.ts'
 import { MessageService } from '../../domain/message/service.ts'
+import { isOriginAllowed, parseAllowedOrigins } from '../../app.ts'
 import type { RealtimeEvent } from '../../realtime/index.ts'
 
 const HEARTBEAT_MS = 25_000
@@ -14,6 +15,11 @@ const HEARTBEAT_MS = 25_000
 // refetch; a subscriber only receives an event it could see via REST. See
 // specs/behaviors/realtime.md.
 const streamRoutes: FastifyPluginAsync = async (fastify) => {
+  // This route hijacks the raw response (writeHead + reply.hijack), which bypasses
+  // @fastify/cors — so we must echo the CORS header here ourselves, reusing the same
+  // allow-list decision. Without this the web client (cross-origin) is blocked.
+  const allowedOrigins = parseAllowedOrigins(fastify.config.ALLOWED_ORIGINS)
+  const allowLocalhost = fastify.config.NODE_ENV !== 'production'
   const activities = new ActivityService(fastify.db)
   const squads = new SquadService(fastify.db)
 
@@ -60,12 +66,24 @@ const streamRoutes: FastifyPluginAsync = async (fastify) => {
         return
       }
 
+      // Echo the CORS origin (the hijacked raw response skips @fastify/cors).
+      const origin = request.headers.origin
+      const corsHeaders: Record<string, string> =
+        origin && isOriginAllowed(origin, allowedOrigins, allowLocalhost)
+          ? {
+              'Access-Control-Allow-Origin': origin,
+              'Access-Control-Allow-Credentials': 'true',
+              Vary: 'Origin',
+            }
+          : {}
+
       const res = reply.raw
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
         Connection: 'keep-alive',
         'X-Accel-Buffering': 'no',
+        ...corsHeaders,
       })
       res.write('retry: 3000\n\n') // client reconnect backoff hint
       res.write(': connected\n\n')


### PR DESCRIPTION
**Live web bug.** Console on `v2.squadquest.app`:
> Access to XMLHttpRequest at 'https://api.squadquest.app/v1/stream' from origin 'https://v2.squadquest.app' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present.

## Cause
The `/v1/stream` route hijacks the raw response (`reply.raw.writeHead` + `reply.hijack()`) to stream SSE — which **bypasses `@fastify/cors`**. Every normal route gets CORS headers from the plugin; the hijacked stream didn't. Native clients (no `Origin`) were unaffected, which is why this only showed up on web.

## Fix
Echo `Access-Control-Allow-Origin` (+ `Allow-Credentials`, `Vary: Origin`) directly in the stream's `writeHead`, reusing the exact same `isOriginAllowed` / `parseAllowedOrigins` decision the plugin uses (already covered by `cors.test.ts`).

## Verification
The hijacked-stream response can't be asserted via `server.inject` (it holds open and never ends), so the route-level wiring is verified by a live prod curl after merge: a request with `Origin: https://v2.squadquest.app` must come back with the matching `Access-Control-Allow-Origin`. `bun test` 70 pass; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)