### PR TITLE
fix(server): allow PATCH/PUT/DELETE in CORS preflight

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -60,6 +60,11 @@ export const app: FastifyPluginAsync = async (fastify) => {
   const allowLocalhost = fastify.config.NODE_ENV !== 'production'
   await fastify.register(cors, {
     credentials: true,
+    // @fastify/cors defaults `methods` to GET,HEAD,POST — so cross-origin
+    // PATCH/PUT/DELETE preflights fail. The API uses all of these (e.g.
+    // PATCH /v1/me, PUT /v1/ideas/:id/response, DELETE /v1/wants/:id), so list
+    // them explicitly. See specs/api/conventions.md (CORS).
+    methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     // Off-list browser origins get no CORS headers echoed (browser blocks). Not an error.
     origin: (origin, cb) =>
       cb(null, isOriginAllowed(origin ?? undefined, allowedOrigins, allowLocalhost)),

--- a/server/test/cors.test.ts
+++ b/server/test/cors.test.ts
@@ -1,6 +1,9 @@
-import { expect, test } from 'bun:test'
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
 
 import { isOriginAllowed, parseAllowedOrigins } from '../src/app.ts'
+
+const { app } = await import('../src/app.ts')
 
 // CORS allow-list resolver (specs/api/conventions.md, behaviors/ci-cd.md).
 // Pure-function tested so we don't mutate process-wide NODE_ENV/ALLOWED_ORIGINS.
@@ -42,4 +45,31 @@ test('empty allow-list blocks every browser origin (safe default)', () => {
   expect(isOriginAllowed('https://v2.squadquest.app', none, false)).toBe(false)
   // but still never blocks a no-Origin request
   expect(isOriginAllowed(undefined, none, false)).toBe(true)
+})
+
+// Integration: the preflight must allow mutating verbs. @fastify/cors defaults
+// `methods` to GET,HEAD,POST, which silently breaks cross-origin PATCH/PUT/DELETE
+// (e.g. PATCH /v1/me) on the web build. Lock that in. See conventions.md (CORS).
+test('preflight allows all mutating methods (PATCH/PUT/DELETE)', async () => {
+  const server: FastifyInstance = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+  try {
+    const res = await server.inject({
+      method: 'OPTIONS',
+      url: '/v1/me',
+      headers: {
+        // dev posture (NODE_ENV !== production) → localhost origin is allowed
+        origin: 'http://localhost:4000',
+        'access-control-request-method': 'PATCH',
+      },
+    })
+    const allowed = (res.headers['access-control-allow-methods'] ?? '') as string
+    for (const verb of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(allowed).toContain(verb)
+    }
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:4000')
+  } finally {
+    await server.close()
+  }
 })

--- a/specs/api/conventions.md
+++ b/specs/api/conventions.md
@@ -26,6 +26,10 @@ governs only the **web** build.
   one allow-listed origin and needs no additional CORS entry.
 - An empty/unset `ALLOWED_ORIGINS` blocks all browser origins (safe default). Non-browser
   requests (no `Origin`) are never CORS-gated.
+- The preflight response must allow **every method the API uses** — `GET, HEAD, POST, PUT,
+  PATCH, DELETE, OPTIONS` — and `credentials`. A mutating verb missing from the allow-list
+  fails the browser preflight (e.g. `PATCH /v1/me`); native clients send no preflight, so a
+  gap here is invisible until exercised by the web build.
 
 ## Versioning
 


### PR DESCRIPTION
## Problem

New users hit **"Couldn't save. Try again"** when saving their initial profile. Console:

> Access to XMLHttpRequest at 'https://api.squadquest.app/v1/me' … blocked by CORS policy: Method PATCH is not allowed by Access-Control-Allow-Methods in preflight response.

## Cause

`@fastify/cors` v11 defaults `methods` to **`GET,HEAD,POST`**. We never set `methods`, so every cross-origin **PATCH/PUT/DELETE** preflight fails — not just `PATCH /v1/me`, but `PUT /v1/ideas/:id/response`, `DELETE /v1/wants/:id`, ignore/unignore, etc. Native clients send no preflight, so this was invisible until the web build exercised it.

This is the second face of the same "web is the first real cross-origin client" class as the SSE-CORS fix (#470).

## Fix

- Set `methods` explicitly to the full verb set the API uses: `GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS`.
- Add a **preflight integration test** (boots the app, asserts `OPTIONS /v1/me` allows PATCH) — the prior CORS test only covered the origin resolver, which is exactly why this slipped through.
- `specs/api/conventions.md`: specify the method allow-list, not just the origin allow-list.

71 server tests pass (+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)