### PR TITLE
fix(app): chat-order timelines + Enter-to-submit on login

### DIFF
--- a/app/lib/screens/login/login_screen.dart
+++ b/app/lib/screens/login/login_screen.dart
@@ -42,6 +42,24 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     }
   }
 
+  void _submitPhone() {
+    if (_busy) return;
+    _run(
+      () => ref
+          .read(authControllerProvider.notifier)
+          .requestOtp(_phone.text.trim()),
+    );
+  }
+
+  void _submitCode() {
+    if (_busy) return;
+    _run(
+      () => ref
+          .read(authControllerProvider.notifier)
+          .verifyOtp(_code.text.trim()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final auth = ref.watch(authControllerProvider);
@@ -70,6 +88,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     controller: _phone,
                     keyboardType: TextInputType.phone,
                     autofocus: true,
+                    textInputAction: TextInputAction.go,
+                    onSubmitted: (_) => _submitPhone(),
                     decoration: const InputDecoration(
                       labelText: 'Phone number',
                       hintText: '+1 215 555 0100',
@@ -79,13 +99,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   const SizedBox(height: 16),
                   FilledButton(
                     key: const Key('requestOtpButton'),
-                    onPressed: _busy
-                        ? null
-                        : () => _run(
-                            () => ref
-                                .read(authControllerProvider.notifier)
-                                .requestOtp(_phone.text.trim()),
-                          ),
+                    onPressed: _busy ? null : _submitPhone,
                     child: Text(_busy ? 'Sending…' : 'Send code'),
                   ),
                 ] else ...[
@@ -99,6 +113,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     controller: _code,
                     keyboardType: TextInputType.number,
                     autofocus: true,
+                    textInputAction: TextInputAction.go,
+                    onSubmitted: (_) => _submitCode(),
                     decoration: const InputDecoration(
                       labelText: 'Code',
                       hintText: '123456',
@@ -108,13 +124,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   const SizedBox(height: 16),
                   FilledButton(
                     key: const Key('verifyOtpButton'),
-                    onPressed: _busy
-                        ? null
-                        : () => _run(
-                            () => ref
-                                .read(authControllerProvider.notifier)
-                                .verifyOtp(_code.text.trim()),
-                          ),
+                    onPressed: _busy ? null : _submitCode,
                     child: Text(_busy ? 'Verifying…' : 'Verify'),
                   ),
                   TextButton(

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -281,8 +281,13 @@ class _FeedBody extends ConsumerWidget {
                     ],
                   );
                 }
+                // Chat-like (group-text, not feed): newest at the bottom, scroll
+                // up for history. The wire is newest-first, so `reverse: true`
+                // lays items bottom-up and opens anchored to the newest.
+                // See specs/principles.md#group-text-not-social-feed.
                 return ListView.separated(
                   key: const Key('timelineList'),
+                  reverse: true,
                   padding: const EdgeInsets.symmetric(vertical: 8),
                   itemCount: items.length,
                   separatorBuilder: (_, _) => const Divider(height: 1),


### PR DESCRIPTION
Two client UX fixes.

## 1. Timelines were inverted (newest at top)

The friends/squad feeds rendered newest-at-**top** (social-feed style), violating the explicit spec rule and the **[Group text, not social feed](../blob/develop/specs/principles.md)** principle:

> Chat-like layout: reverse chronological with newest at the **bottom**, scroll **up** for history.

Fix: `reverse: true` on the feed `ListView.separated`. The wire is newest-first, so reverse lays items bottom-up and opens anchored to the newest — group-text feel, scroll up for history, no scroll controller needed. Community events stay forward-ordered (an upcoming-events schedule, not a chat). The thread drawer was already chat-ordered.

## 2. Enter didn't submit the login forms

The phone/code `TextField`s had no `onSubmitted`, so pressing Enter did nothing — you had to tap the button. Wired both to `textInputAction.go` + `onSubmitted`, sharing the same submit actions as the buttons.

`flutter analyze` clean, 37 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)