### PR TITLE
feat(app): squad members — view roster + captain adds members

### DIFF
--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -148,6 +148,12 @@ final squadsProvider = FutureProvider<List<Squad>>(
   (ref) => ref.watch(squadRepositoryProvider).list(),
 );
 
+/// A single squad's detail (roster + roles), keyed by squad id. Backs the
+/// squad-members screen (specs/screens/squads.md).
+final squadDetailProvider = FutureProvider.family<SquadDetail, String>(
+  (ref, squadId) => ref.watch(squadRepositoryProvider).get(squadId),
+);
+
 /// Activity types for the compose-idea form (specs/api/ideas-activities.md).
 final topicsProvider = FutureProvider<List<Topic>>(
   (ref) => ref.watch(topicRepositoryProvider).list(),

--- a/app/lib/router.dart
+++ b/app/lib/router.dart
@@ -16,6 +16,7 @@ import 'screens/ignored/ignored_screen.dart';
 import 'screens/login/login_screen.dart';
 import 'screens/profile/profile_screen.dart';
 import 'screens/squads/create_squad_screen.dart';
+import 'screens/squads/squad_detail_screen.dart';
 import 'screens/wants/wants_screen.dart';
 import 'screens/thread/thread_screen.dart';
 import 'screens/timeline/timeline_screen.dart';
@@ -60,6 +61,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/squads/new',
         builder: (_, _) => const CreateSquadScreen(),
+      ),
+      GoRoute(
+        path: '/squads/:id',
+        builder: (_, state) =>
+            SquadDetailScreen(squadId: state.pathParameters['id']!),
       ),
       GoRoute(
         path: '/communities',

--- a/app/lib/screens/squads/squad_detail_screen.dart
+++ b/app/lib/screens/squads/squad_detail_screen.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_exception.dart';
+import '../../models/friend.dart';
+import '../../models/squad.dart';
+import '../../providers/auth_controller.dart';
+import '../../providers/providers.dart';
+
+/// Squad members (specs/screens/squads.md). Shows the roster; the captain can add
+/// accepted friends who aren't already members. Removing/leaving is still deferred.
+class SquadDetailScreen extends ConsumerWidget {
+  const SquadDetailScreen({super.key, required this.squadId});
+
+  final String squadId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final detail = ref.watch(squadDetailProvider(squadId));
+    return Scaffold(
+      appBar: AppBar(title: Text(detail.value?.name ?? 'Squad')),
+      body: detail.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Text(
+              "Couldn't load this squad.\n$e",
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        data: (squad) {
+          final myId = ref
+              .read(authControllerProvider.notifier)
+              .currentProfile
+              ?.id;
+          final isCaptain = squad.members.any(
+            (m) => m.role == 'captain' && m.id == myId,
+          );
+          return ListView(
+            key: const Key('squadMembersList'),
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 16, 16, 4),
+                child: Text(
+                  'MEMBERS',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+                ),
+              ),
+              for (final m in squad.members)
+                ListTile(
+                  key: Key('squadMember_${m.id}'),
+                  leading: CircleAvatar(
+                    foregroundImage: (m.photo != null && m.photo!.isNotEmpty)
+                        ? NetworkImage(m.photo!)
+                        : null,
+                    child: Text((m.firstName ?? '?').characters.first),
+                  ),
+                  title: Text(m.firstName ?? 'Member'),
+                  trailing: m.role == 'captain'
+                      ? const Chip(label: Text('Captain'))
+                      : null,
+                ),
+              if (isCaptain) ...[
+                const Divider(height: 24),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: FilledButton.icon(
+                    key: const Key('addMembersButton'),
+                    onPressed: () => _openAddMembers(context, ref, squad),
+                    icon: const Icon(Icons.person_add_alt),
+                    label: const Text('Add members'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  void _openAddMembers(BuildContext context, WidgetRef ref, SquadDetail squad) {
+    final memberIds = squad.members.map((m) => m.id).toSet();
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetContext) =>
+          _AddMembersSheet(squadId: squadId, memberIds: memberIds),
+    );
+  }
+}
+
+/// Friend picker limited to accepted friends not already in the squad. Each tap
+/// adds one member (the backend is friend-gated + idempotent).
+class _AddMembersSheet extends ConsumerStatefulWidget {
+  const _AddMembersSheet({required this.squadId, required this.memberIds});
+  final String squadId;
+  final Set<String> memberIds;
+
+  @override
+  ConsumerState<_AddMembersSheet> createState() => _AddMembersSheetState();
+}
+
+class _AddMembersSheetState extends ConsumerState<_AddMembersSheet> {
+  final _adding = <String>{};
+  String? _error;
+
+  Future<void> _add(Friend friend) async {
+    setState(() {
+      _adding.add(friend.id);
+      _error = null;
+    });
+    try {
+      await ref
+          .read(squadRepositoryProvider)
+          .addMember(widget.squadId, friend.id);
+      ref.invalidate(squadDetailProvider(widget.squadId));
+      ref.invalidate(squadsProvider);
+      if (mounted) Navigator.pop(context);
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = "Couldn't add. Please try again.");
+    } finally {
+      if (mounted) setState(() => _adding.remove(friend.id));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final friends = ref.watch(friendsProvider);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: friends.when(
+          loading: () => const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (e, _) => Padding(
+            padding: const EdgeInsets.all(32),
+            child: Text(
+              "Couldn't load friends.\n$e",
+              textAlign: TextAlign.center,
+            ),
+          ),
+          data: (list) {
+            final candidates = list
+                .where((f) => !widget.memberIds.contains(f.id))
+                .toList();
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Add members',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ),
+                if (_error != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 4,
+                    ),
+                    child: Text(
+                      _error!,
+                      key: const Key('addMemberError'),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+                if (candidates.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.all(32),
+                    child: Text(
+                      'All your friends are already in this squad.',
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                else
+                  Flexible(
+                    child: ListView(
+                      key: const Key('addMemberPicker'),
+                      shrinkWrap: true,
+                      children: [
+                        for (final f in candidates)
+                          ListTile(
+                            key: Key('addFriend_${f.id}'),
+                            leading: CircleAvatar(
+                              foregroundImage:
+                                  (f.photo != null && f.photo!.isNotEmpty)
+                                  ? NetworkImage(f.photo!)
+                                  : null,
+                              child: Text(
+                                (f.firstName ?? '?').characters.first,
+                              ),
+                            ),
+                            title: Text(
+                              f.displayName.isEmpty ? 'Friend' : f.displayName,
+                            ),
+                            trailing: _adding.contains(f.id)
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Icon(Icons.add),
+                            onTap: _adding.contains(f.id)
+                                ? null
+                                : () => _add(f),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -22,6 +22,7 @@ class TimelineScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ctx = ref.watch(activeContextProvider);
     final isCommunity = ctx is CommunityContext;
+    final squadId = ctx is SquadContext ? ctx.id : null;
     final title = switch (ctx) {
       FriendsContext() => 'My Friends',
       SquadContext(:final name) => name,
@@ -54,6 +55,13 @@ class TimelineScreen extends ConsumerWidget {
               tooltip: 'Edit community',
               onPressed: () =>
                   context.push('/communities/new', extra: activeCommunity),
+            ),
+          if (squadId != null)
+            IconButton(
+              key: const Key('manageSquadButton'),
+              icon: const Icon(Icons.group_outlined),
+              tooltip: 'Squad members',
+              onPressed: () => context.push('/squads/$squadId'),
             ),
           IconButton(
             key: const Key('peopleButton'),

--- a/app/test/squad_members_test.dart
+++ b/app/test/squad_members_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/friend.dart';
+import 'package:squadquest/models/profile.dart';
+import 'package:squadquest/models/squad.dart';
+import 'package:squadquest/providers/auth_controller.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/friend_repository.dart';
+import 'package:squadquest/repositories/profile_repository.dart';
+import 'package:squadquest/repositories/squad_repository.dart';
+import 'package:squadquest/repositories/token_store.dart';
+import 'package:squadquest/screens/squads/squad_detail_screen.dart';
+
+/// Signed-in without touching the keychain (mirrors profile_screen_test).
+class _FakeTokenStore extends TokenStore {
+  _FakeTokenStore() {
+    accessToken = 'test-access';
+    refreshToken = 'test-refresh';
+  }
+  @override
+  Future<void> load() async {}
+}
+
+class _FakeProfileRepository implements ProfileRepository {
+  _FakeProfileRepository(this.profile);
+  final Profile profile;
+  @override
+  Future<Profile> me() async => profile;
+  @override
+  Future<Profile> updateProfile({
+    String? firstName,
+    String? lastName,
+    String? photo,
+  }) async => profile;
+}
+
+class _FakeFriendRepository implements FriendRepository {
+  _FakeFriendRepository(this._friends);
+  final List<Friend> _friends;
+  @override
+  Future<List<Friend>> list() async => _friends;
+  @override
+  Future<FriendRequests> requests() async => const FriendRequests();
+  @override
+  Future<String> sendRequest(String phone) async => 'requested';
+  @override
+  Future<void> accept(String requestId) async {}
+  @override
+  Future<void> ignore(String requestId) async {}
+  @override
+  Future<void> unignore(String requestId) async {}
+  @override
+  Future<List<IgnoredItem>> ignored() async => const [];
+}
+
+/// Records addMember calls; returns a fixed roster.
+class _FakeSquadRepository implements SquadRepository {
+  _FakeSquadRepository(this._detail);
+  final SquadDetail _detail;
+  final addedProfileIds = <String>[];
+
+  @override
+  Future<List<Squad>> list() async => const [];
+  @override
+  Future<SquadDetail> create(String name, List<String> memberIds) async =>
+      _detail;
+  @override
+  Future<SquadDetail> get(String squadId) async => _detail;
+  @override
+  Future<SquadDetail> addMember(String squadId, String profileId) async {
+    addedProfileIds.add(profileId);
+    return _detail;
+  }
+}
+
+/// Mounts the screen only once auth resolves to SignedIn (the captain check
+/// reads currentProfile), mirroring how the router gates the route.
+class _Gate extends ConsumerWidget {
+  const _Gate({required this.squadId});
+  final String squadId;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authControllerProvider);
+    return auth is SignedIn
+        ? SquadDetailScreen(squadId: squadId)
+        : const SizedBox.shrink();
+  }
+}
+
+void main() {
+  const me = Profile(id: 'me', firstName: 'Cap', phone: '+1');
+
+  Future<_FakeSquadRepository> pump(
+    WidgetTester tester, {
+    required SquadDetail detail,
+    required List<Friend> friends,
+  }) async {
+    final squadRepo = _FakeSquadRepository(detail);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tokenStoreProvider.overrideWithValue(_FakeTokenStore()),
+          profileRepositoryProvider.overrideWithValue(
+            _FakeProfileRepository(me),
+          ),
+          squadRepositoryProvider.overrideWithValue(squadRepo),
+          friendRepositoryProvider.overrideWithValue(
+            _FakeFriendRepository(friends),
+          ),
+        ],
+        child: const MaterialApp(home: _Gate(squadId: 's1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return squadRepo;
+  }
+
+  testWidgets('captain sees roster + can add a non-member friend', (
+    tester,
+  ) async {
+    final detail = SquadDetail(
+      id: 's1',
+      name: 'Wednesday Riders',
+      members: const [
+        SquadMember(id: 'me', firstName: 'Cap', role: 'captain'),
+        SquadMember(id: 'f1', firstName: 'Katie', role: 'member'),
+      ],
+    );
+    final repo = await pump(
+      tester,
+      detail: detail,
+      friends: const [
+        Friend(id: 'f1', firstName: 'Katie'), // already a member → excluded
+        Friend(id: 'f2', firstName: 'Mike'), // addable
+      ],
+    );
+
+    // Roster renders with the captain badge.
+    expect(find.byKey(const Key('squadMember_me')), findsOneWidget);
+    expect(find.text('Captain'), findsOneWidget);
+    expect(find.byKey(const Key('addMembersButton')), findsOneWidget);
+
+    // Open the picker → only the non-member friend is offered.
+    await tester.tap(find.byKey(const Key('addMembersButton')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('addFriend_f2')), findsOneWidget);
+    expect(find.byKey(const Key('addFriend_f1')), findsNothing);
+
+    // Tapping adds that friend via the repo.
+    await tester.tap(find.byKey(const Key('addFriend_f2')));
+    await tester.pumpAndSettle();
+    expect(repo.addedProfileIds, ['f2']);
+  });
+
+  testWidgets('non-captain member sees the roster read-only', (tester) async {
+    final detail = SquadDetail(
+      id: 's1',
+      name: 'Wednesday Riders',
+      members: const [
+        SquadMember(id: 'other', firstName: 'Boss', role: 'captain'),
+        SquadMember(id: 'me', firstName: 'Cap', role: 'member'),
+      ],
+    );
+    await pump(tester, detail: detail, friends: const []);
+    expect(find.byKey(const Key('squadMembersList')), findsOneWidget);
+    expect(find.byKey(const Key('addMembersButton')), findsNothing);
+  });
+}

--- a/plans/v2-squad-members.md
+++ b/plans/v2-squad-members.md
@@ -1,10 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/screens/squads.md
 issues: []
-pr:
+pr: 473
 ---
 
 # Plan: v2 squad members — view roster + captain adds members
@@ -51,12 +51,12 @@ friend-gated by the existing backend rule (no inviting non-friends).
 
 ## Validation
 
-- [ ] `SquadDetailScreen` renders the roster from `GET /v1/squads/:id` with a captain badge.
-- [ ] Captain sees "Add members"; the picker excludes current members; tapping calls
+- [x] `SquadDetailScreen` renders the roster from `GET /v1/squads/:id` with a captain badge.
+- [x] Captain sees "Add members"; the picker excludes current members; tapping calls
       `addMember(squadId, profileId)` and the roster refreshes.
-- [ ] A non-captain member sees the roster read-only (no add affordance).
-- [ ] App-bar manage icon appears only for a squad context and routes to `/squads/:id`.
-- [ ] `flutter analyze` clean; `flutter test` green (incl. the new test).
+- [x] A non-captain member sees the roster read-only (no add affordance).
+- [x] App-bar manage icon appears only for a squad context and routes to `/squads/:id`.
+- [x] `flutter analyze` clean; `flutter test` green (39 tests, +2).
 
 ## Risks / unknowns
 
@@ -66,8 +66,15 @@ friend-gated by the existing backend rule (no inviting non-friends).
 
 ## Notes
 
-(closeout)
+Client-only: the backend (`POST /v1/squads/:id/members`, captain-only + friend-gated +
+idempotent) and the repo's `addMember`/`get` already existed, so this was purely the missing
+UI. The captain check reads the squad detail's `members[].role` against the signed-in
+`currentProfile` id (the detail fetch is authoritative, not the context). Entry point is the
+squad timeline's app-bar manage icon (user's call over the context selector). Add path reuses
+the create-squad friend-picker pattern, filtered to non-members. Shipped in #473.
 
 ## Follow-ups
 
-(closeout)
+- **Deferred to plan** — removing members / leaving a squad, rename, captain transfer /
+  multiple captains, per-member roles beyond captain/member. No plan filed yet; will spin one
+  when membership editing is prioritized.

--- a/plans/v2-squad-members.md
+++ b/plans/v2-squad-members.md
@@ -1,0 +1,73 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/screens/squads.md
+issues: []
+pr:
+---
+
+# Plan: v2 squad members — view roster + captain adds members
+
+> `specs/screens/squads.md` marked "Captain-only membership management is **deferred** (later
+> plan)." This is that plan. The backend is already complete (`POST /v1/squads/:id/members`,
+> captain-only + friend-gated + idempotent; `GET /v1/squads/:id` returns the roster) and the
+> client repo already exposes `addMember`/`get` — the whole gap is the **client UI**: there is
+> no screen to see who's in a squad or to add someone to an existing one.
+
+## Scope
+
+**In:**
+
+- A **squad detail / members screen** at `/squads/:id`: shows the roster (avatar + name +
+  captain badge). For the **captain**, an "Add members" affordance opens a friend picker
+  (the create-squad pattern) limited to accepted friends **not already in the squad**; tapping
+  adds via `addMember`. Members (non-captain) see the roster read-only.
+- **Entry point:** a manage-members icon in the squad timeline's app bar (mirrors the existing
+  community-edit icon), shown only when the active context is a squad.
+- `squadDetailProvider` (family by squad id); invalidated after an add so the roster + the
+  context selector's member count refresh.
+
+**Out (still deferred):** removing members / leaving a squad; transferring or multiple
+captains; renaming a squad; per-member roles beyond captain/member. The add path is
+friend-gated by the existing backend rule (no inviting non-friends).
+
+## Implements
+
+- `specs/screens/squads.md` — replace the "deferred" line with the membership-management
+  display rules + actions (captain adds friends; everyone sees the roster), and a new
+  **Squad Members** screen section (route, data, display, actions, navigation).
+
+## Approach
+
+- **Client only** (backend + repo already done):
+  - `SquadDetailScreen` (Consumer) at `/squads/:id` reading `squadDetailProvider(id)`.
+  - Roster list; captain-only "Add members" → friend picker filtered to non-members →
+    `squadRepositoryProvider.addMember` → invalidate `squadDetailProvider(id)` + `squadsProvider`.
+  - App-bar `manageSquadButton` on the squad timeline → `context.push('/squads/$id')`.
+  - Route wiring in `router.dart`.
+- A widget test: captain sees the add affordance + a non-member friend is addable; the repo is
+  called with the right ids. (Member-viewer read-only path asserted too if cheap.)
+
+## Validation
+
+- [ ] `SquadDetailScreen` renders the roster from `GET /v1/squads/:id` with a captain badge.
+- [ ] Captain sees "Add members"; the picker excludes current members; tapping calls
+      `addMember(squadId, profileId)` and the roster refreshes.
+- [ ] A non-captain member sees the roster read-only (no add affordance).
+- [ ] App-bar manage icon appears only for a squad context and routes to `/squads/:id`.
+- [ ] `flutter analyze` clean; `flutter test` green (incl. the new test).
+
+## Risks / unknowns
+
+- The roster's captain/member role comes from `GET /v1/squads/:id` (`members[].role`), not the
+  context — fine, the detail fetch is authoritative.
+- Friend list vs member list both keyed by profile id — filter the picker by membership id set.
+
+## Notes
+
+(closeout)
+
+## Follow-ups
+
+(closeout)

--- a/specs/screens/squads.md
+++ b/specs/screens/squads.md
@@ -30,12 +30,64 @@ Title bar shows the squad badge + name, tappable to switch.
 - **Respond / vote / confirm** on squad ideas/activities (same lifecycle).
 - **Open any item** → [thread drawer](../behaviors/thread-drawer.md) (a message thread has a
   simpler header than an idea/activity thread; no voting).
-- Captain-only membership management is **deferred** (later plan).
+- **Manage members** → the [Squad Members](#squad-members) screen (app-bar icon, squad
+  context only). Everyone can view the roster; only the captain can add members.
 
 ## Navigation
 
 - Title bar → context selector.
 - Item → thread drawer.
+- App-bar manage-members icon → [Squad Members](#squad-members).
+
+---
+
+# Squad Members
+
+The roster of a squad, and the captain's affordance to grow it.
+
+## Route
+
+`/squads/:squadId`. Reached from the squad timeline's app-bar manage-members icon (shown only
+for a squad context).
+
+## Data Requirements
+
+- `GET /v1/squads/:squadId` — `{ id, name, members: [{ id, first_name, photo, role }] }`,
+  where `role ∈ {captain, member}`. Requires membership (404 otherwise).
+- The captain affordance also reads the viewer's accepted friends
+  (`GET /v1/friends`) to offer non-members.
+
+## Display Rules
+
+- The roster lists every member (avatar + name), the captain marked with a **Captain** badge.
+- **Captain only:** an **Add members** action. Non-captain members see the roster read-only —
+  no add affordance (membership is captain-controlled per the squad's closed model).
+
+## Actions
+
+- **Add a member** (captain) — pick from accepted friends **not already in the squad**;
+  `POST /v1/squads/:squadId/members`. Friend-gated and idempotent server-side: only accepted
+  friends can be added (`not_friends` otherwise), and re-adding is a no-op. On success the
+  roster and the context selector's member count refresh.
+- Removing members, leaving, renaming, and captain transfer are **deferred** (later plan).
+
+## Navigation
+
+- Back → the squad timeline.
+
+## Principles
+
+**Inherited:**
+
+- [Audience clarity at the moment of action](../principles.md#audience-clarity-at-the-moment-of-action)
+  — the roster makes "who is in this squad" (and thus who sees squad posts) explicit.
+
+**Local:**
+
+- **Membership is captain-controlled.** Mirrors the squad's closed model (see the squad
+  timeline's local principle) — only the captain mutates membership; everyone may see it.
+
+---
 
 ## Principles
 


### PR DESCRIPTION
> Adds a way to **add friends to an existing squad** — the gap was purely client UI; the backend (`POST /v1/squads/:id/members`, captain-only + friend-gated + idempotent) and the repo's `addMember`/`get` were already in place. `specs/screens/squads.md` had marked this "deferred (later plan)" — this is that plan (`v2-squad-members`).

## What

- **`SquadDetailScreen`** at `/squads/:id` — roster (avatar + name + **Captain** badge) from `squadDetailProvider`.
- **Captain only:** an "Add members" sheet — a friend picker filtered to accepted friends **not already in the squad** — calls `addMember`, then refreshes the roster + squads list. Non-captain members see the roster **read-only**.
- **Entry point:** an app-bar manage-members icon on the squad timeline (squad context only) → the screen. (Picked over the context-selector per your call.)
- `squadDetailProvider` (family by id) + route wiring.

## Spec

`specs/screens/squads.md`: replaced the "deferred" line with a **Squad Members** screen section (route, data, display, actions, navigation) + a local principle — *membership is captain-controlled; the roster is visible to all members*.

## Tests

Widget tests: captain add path (picker excludes current members; repo called with the right id) + non-captain read-only. `flutter analyze` clean, **39 tests pass** (+2).

## Deferred (called out in spec + plan)

Removing members / leaving, rename, captain transfer, multi-captain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)