### PR TITLE
feat(app): wire 3 spec'd affordances the client was missing

### DIFF
--- a/app/lib/screens/activity/activity_detail_screen.dart
+++ b/app/lib/screens/activity/activity_detail_screen.dart
@@ -52,6 +52,44 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
     }
   }
 
+  // Suggest a new time/location option (when the idea allows suggestions).
+  // Prompts for a label, then posts it via addOption.
+  Future<void> _suggest(String activityId, String kind) async {
+    final controller = TextEditingController();
+    final label = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(kind == 'time' ? 'Suggest a time' : 'Suggest a place'),
+        content: TextField(
+          key: const Key('suggestOptionField'),
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(
+            hintText: kind == 'time' ? 'Saturday morning' : 'The trailhead',
+          ),
+          onSubmitted: (v) => Navigator.pop(dialogContext, v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.pop(dialogContext, controller.text.trim()),
+            child: const Text('Suggest'),
+          ),
+        ],
+      ),
+    );
+    if (label == null || label.isEmpty) return;
+    await _act(
+      () => ref
+          .read(activityRepositoryProvider)
+          .addOption(activityId, kind, label),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final a = _activity;
@@ -132,7 +170,10 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
                   key: const Key('responseCounts'),
                 ),
 
-                if (a.timeOptions.isNotEmpty) ...[
+                // Show When/Where when there are options OR the idea invites
+                // suggestions (so there's somewhere to add the first one).
+                if (a.timeOptions.isNotEmpty ||
+                    (a.allowSuggestions && !a.isConfirmed)) ...[
                   const Divider(height: 32),
                   Text('When', style: Theme.of(context).textTheme.titleMedium),
                   for (final o in a.timeOptions)
@@ -152,9 +193,20 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
                             )
                           : null,
                     ),
+                  if (a.allowSuggestions && !a.isConfirmed)
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: TextButton.icon(
+                        key: const Key('suggestTime'),
+                        onPressed: _busy ? null : () => _suggest(a.id, 'time'),
+                        icon: const Icon(Icons.add, size: 18),
+                        label: const Text('Suggest a time'),
+                      ),
+                    ),
                 ],
 
-                if (a.locationOptions.isNotEmpty) ...[
+                if (a.locationOptions.isNotEmpty ||
+                    (a.allowSuggestions && !a.isConfirmed)) ...[
                   const Divider(height: 32),
                   Text('Where', style: Theme.of(context).textTheme.titleMedium),
                   for (final o in a.locationOptions)
@@ -173,6 +225,18 @@ class _ActivityDetailScreenState extends ConsumerState<ActivityDetailScreen> {
                                   .confirm(a.id, locationOptionId: o.id),
                             )
                           : null,
+                    ),
+                  if (a.allowSuggestions && !a.isConfirmed)
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: TextButton.icon(
+                        key: const Key('suggestLocation'),
+                        onPressed: _busy
+                            ? null
+                            : () => _suggest(a.id, 'location'),
+                        icon: const Icon(Icons.add, size: 18),
+                        label: const Text('Suggest a place'),
+                      ),
                     ),
                 ],
 

--- a/app/lib/screens/wants/wants_screen.dart
+++ b/app/lib/screens/wants/wants_screen.dart
@@ -104,6 +104,8 @@ class _OwnWantTile extends ConsumerWidget {
             switch (v) {
               case 'promote':
                 await _openPromote(context, ref, want);
+              case 'invites':
+                await _openManageInvites(context, ref, want);
               case 'edit':
                 await _openEditor(context, ref, existing: want);
               case 'delete':
@@ -113,6 +115,7 @@ class _OwnWantTile extends ConsumerWidget {
           },
           itemBuilder: (_) => const [
             PopupMenuItem(value: 'promote', child: Text('Promote to plan')),
+            PopupMenuItem(value: 'invites', child: Text('Manage invites')),
             PopupMenuItem(value: 'edit', child: Text('Edit')),
             PopupMenuItem(value: 'delete', child: Text('Delete')),
           ],
@@ -210,6 +213,148 @@ Future<void> _openEditor(
       child: _WantEditor(existing: existing),
     ),
   );
+}
+
+Future<void> _openManageInvites(
+  BuildContext context,
+  WidgetRef ref,
+  Want want,
+) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => _ManageInvitesSheet(want: want),
+  );
+}
+
+/// Add/remove invitees on an existing want (specs/api/wants.md — invite is what
+/// shares the want; only accepted friends are invitable). Each tap mutates one
+/// invite; the backend is friend-gated + idempotent.
+class _ManageInvitesSheet extends ConsumerStatefulWidget {
+  const _ManageInvitesSheet({required this.want});
+  final Want want;
+  @override
+  ConsumerState<_ManageInvitesSheet> createState() =>
+      _ManageInvitesSheetState();
+}
+
+class _ManageInvitesSheetState extends ConsumerState<_ManageInvitesSheet> {
+  // Local view of who's invited, seeded from the want and updated as we mutate
+  // (so the sheet reflects changes without a full refetch round-trip).
+  late final Set<String> _invited = {
+    for (final i in widget.want.invitees) i.profileId,
+  };
+  final _busy = <String>{};
+  String? _error;
+
+  Future<void> _toggle(Friend friend, bool invite) async {
+    setState(() {
+      _busy.add(friend.id);
+      _error = null;
+    });
+    try {
+      final repo = ref.read(wantRepositoryProvider);
+      if (invite) {
+        await repo.invite(widget.want.id, [friend.id]);
+        _invited.add(friend.id);
+      } else {
+        await repo.uninvite(widget.want.id, friend.id);
+        _invited.remove(friend.id);
+      }
+      ref.invalidate(ownWantsProvider);
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = "Couldn't update. Please try again.");
+    } finally {
+      if (mounted) setState(() => _busy.remove(friend.id));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final friends = ref.watch(friendsProvider);
+    return SafeArea(
+      child: friends.when(
+        loading: () => const Padding(
+          padding: EdgeInsets.all(32),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+        error: (e, _) => Padding(
+          padding: const EdgeInsets.all(32),
+          child: Text(
+            "Couldn't load friends.\n$e",
+            textAlign: TextAlign.center,
+          ),
+        ),
+        data: (list) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 12, 16, 4),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Manage invites',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 4,
+                ),
+                child: Text(
+                  _error!,
+                  key: const Key('manageInvitesError'),
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+            if (list.isEmpty)
+              const Padding(
+                padding: EdgeInsets.all(32),
+                child: Text(
+                  'No friends to invite yet.',
+                  textAlign: TextAlign.center,
+                ),
+              )
+            else
+              Flexible(
+                child: ListView(
+                  key: const Key('manageInvitesList'),
+                  shrinkWrap: true,
+                  children: [
+                    for (final f in list)
+                      CheckboxListTile(
+                        key: Key('inviteToggle_${f.id}'),
+                        value: _invited.contains(f.id),
+                        title: Text(
+                          f.displayName.isEmpty ? 'Friend' : f.displayName,
+                        ),
+                        secondary: _busy.contains(f.id)
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : null,
+                        onChanged: _busy.contains(f.id)
+                            ? null
+                            : (sel) => _toggle(f, sel ?? false),
+                      ),
+                  ],
+                ),
+              ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _WantEditor extends ConsumerStatefulWidget {

--- a/app/lib/widgets/community_event_card.dart
+++ b/app/lib/widgets/community_event_card.dart
@@ -90,112 +90,120 @@ class _CommunityEventCardState extends ConsumerState<CommunityEventCard> {
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    '${e.communityIcon ?? '📣'}  ${e.communityName ?? 'Community'}'
-                    '${e.recurrence != null ? ' · ${e.recurrence}' : ''}',
-                    style: Theme.of(context).textTheme.labelMedium,
-                  ),
-                ),
-                if (widget.isLeader)
-                  SizedBox(
-                    height: 28,
-                    child: PopupMenuButton<String>(
-                      key: Key('event_menu_${e.id}'),
-                      padding: EdgeInsets.zero,
-                      icon: const Icon(Icons.more_vert, size: 20),
-                      onSelected: (v) {
-                        if (v == 'edit') {
-                          context.push(
-                            '/communities/${widget.communityId}/events/new',
-                            extra: e,
-                          );
-                        } else if (v == 'delete') {
-                          _delete();
-                        }
-                      },
-                      itemBuilder: (_) => const [
-                        PopupMenuItem(value: 'edit', child: Text('Edit')),
-                        PopupMenuItem(
-                          value: 'delete',
-                          child: Text('Cancel event'),
-                        ),
-                      ],
+      // Tapping the card opens the event's thread (chat + RSVP discussion).
+      // The RSVP chips / leader menu have their own handlers, so they win their
+      // own taps; this catches the rest. See specs/screens/communities.md.
+      child: InkWell(
+        key: Key('openEventThread_${e.id}'),
+        onTap: () =>
+            context.push('/thread/community_event/${e.id}', extra: null),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${e.communityIcon ?? '📣'}  ${e.communityName ?? 'Community'}'
+                      '${e.recurrence != null ? ' · ${e.recurrence}' : ''}',
+                      style: Theme.of(context).textTheme.labelMedium,
                     ),
                   ),
-              ],
-            ),
-            const SizedBox(height: 6),
-            Text(e.title, style: Theme.of(context).textTheme.titleMedium),
-            if (e.time != null || e.location != null) ...[
-              const SizedBox(height: 4),
-              Text([e.time, e.location].whereType<String>().join(' · ')),
-            ],
-            const SizedBox(height: 10),
-            Text(
-              '${e.goingCount} going'
-              '${facePile != null ? '  ·  $facePile' : ''}',
-              key: Key('going_${e.id}'),
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              children: [
-                FilterChip(
-                  key: Key('going_toggle_${e.id}'),
-                  label: const Text('Going'),
-                  selected: e.youGoing,
-                  onSelected: _busy
-                      ? null
-                      : (sel) => _rsvp(
-                          going: sel,
-                          public: sel ? e.youPublic : false,
-                        ),
-                ),
-                FilterChip(
-                  key: Key('public_toggle_${e.id}'),
-                  label: const Text('Show my name'),
-                  selected: e.youPublic,
-                  onSelected: _busy
-                      ? null
-                      : (sel) => _rsvp(going: true, public: sel),
-                ),
-              ],
-            ),
-            const SizedBox(height: 4),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: TextButton.icon(
-                key: Key('bring_friends_${e.id}'),
-                icon: const Icon(Icons.group_add, size: 18),
-                label: const Text('Bring friends'),
-                // Switch to My Friends + open the composer pre-filled with this event
-                // (bring-friends bridge): posts a friends-scoped idea, never the public event.
-                onPressed: () {
-                  ref.read(activeContextProvider.notifier).toFriends();
-                  context.push(
-                    '/ideas/new',
-                    extra: EventRef(
-                      id: e.id,
-                      title: e.title,
-                      time: e.time,
-                      location: e.location,
-                      communityName: e.communityName,
-                      communityIcon: e.communityIcon,
+                  if (widget.isLeader)
+                    SizedBox(
+                      height: 28,
+                      child: PopupMenuButton<String>(
+                        key: Key('event_menu_${e.id}'),
+                        padding: EdgeInsets.zero,
+                        icon: const Icon(Icons.more_vert, size: 20),
+                        onSelected: (v) {
+                          if (v == 'edit') {
+                            context.push(
+                              '/communities/${widget.communityId}/events/new',
+                              extra: e,
+                            );
+                          } else if (v == 'delete') {
+                            _delete();
+                          }
+                        },
+                        itemBuilder: (_) => const [
+                          PopupMenuItem(value: 'edit', child: Text('Edit')),
+                          PopupMenuItem(
+                            value: 'delete',
+                            child: Text('Cancel event'),
+                          ),
+                        ],
+                      ),
                     ),
-                  );
-                },
+                ],
               ),
-            ),
-          ],
+              const SizedBox(height: 6),
+              Text(e.title, style: Theme.of(context).textTheme.titleMedium),
+              if (e.time != null || e.location != null) ...[
+                const SizedBox(height: 4),
+                Text([e.time, e.location].whereType<String>().join(' · ')),
+              ],
+              const SizedBox(height: 10),
+              Text(
+                '${e.goingCount} going'
+                '${facePile != null ? '  ·  $facePile' : ''}',
+                key: Key('going_${e.id}'),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                children: [
+                  FilterChip(
+                    key: Key('going_toggle_${e.id}'),
+                    label: const Text('Going'),
+                    selected: e.youGoing,
+                    onSelected: _busy
+                        ? null
+                        : (sel) => _rsvp(
+                            going: sel,
+                            public: sel ? e.youPublic : false,
+                          ),
+                  ),
+                  FilterChip(
+                    key: Key('public_toggle_${e.id}'),
+                    label: const Text('Show my name'),
+                    selected: e.youPublic,
+                    onSelected: _busy
+                        ? null
+                        : (sel) => _rsvp(going: true, public: sel),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  key: Key('bring_friends_${e.id}'),
+                  icon: const Icon(Icons.group_add, size: 18),
+                  label: const Text('Bring friends'),
+                  // Switch to My Friends + open the composer pre-filled with this event
+                  // (bring-friends bridge): posts a friends-scoped idea, never the public event.
+                  onPressed: () {
+                    ref.read(activeContextProvider.notifier).toFriends();
+                    context.push(
+                      '/ideas/new',
+                      extra: EventRef(
+                        id: e.id,
+                        title: e.title,
+                        time: e.time,
+                        location: e.location,
+                        communityName: e.communityName,
+                        communityIcon: e.communityIcon,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/test/activity_detail_test.dart
+++ b/app/test/activity_detail_test.dart
@@ -11,6 +11,8 @@ import 'package:squadquest/screens/activity/activity_detail_screen.dart';
 class FakeActivityRepository implements ActivityRepository {
   FakeActivityRepository(this.result);
   Activity result;
+  String? addedKind;
+  String? addedLabel;
 
   @override
   Future<Activity> createIdea({
@@ -38,7 +40,12 @@ class FakeActivityRepository implements ActivityRepository {
     String activityId,
     String kind,
     String label,
-  ) async => result;
+  ) async {
+    addedKind = kind;
+    addedLabel = label;
+    return result;
+  }
+
   @override
   Future<Activity> confirm(
     String activityId, {
@@ -94,6 +101,43 @@ void main() {
     await tester.tap(find.byIcon(Icons.thumb_up_outlined));
     await tester.pumpAndSettle();
     expect(find.text('2 votes'), findsOneWidget);
+  });
+
+  testWidgets('suggest-an-option appears when allowed and calls addOption', (
+    tester,
+  ) async {
+    const seed = Activity(
+      id: 'a1',
+      state: 'idea',
+      captainName: 'Katie',
+      activityTypeLabel: 'Paddleboarding',
+      allowSuggestions: true,
+    );
+    final repo = FakeActivityRepository(seed);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [activityRepositoryProvider.overrideWithValue(repo)],
+        child: const MaterialApp(home: ActivityDetailScreen(activity: seed)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Both suggest affordances show even with no options yet.
+    expect(find.byKey(const Key('suggestTime')), findsOneWidget);
+    expect(find.byKey(const Key('suggestLocation')), findsOneWidget);
+
+    // Suggest a time → dialog → submit → addOption('time', label).
+    await tester.tap(find.byKey(const Key('suggestTime')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('suggestOptionField')),
+      'Sunday brunch',
+    );
+    await tester.tap(find.text('Suggest'));
+    await tester.pumpAndSettle();
+    expect(repo.addedKind, 'time');
+    expect(repo.addedLabel, 'Sunday brunch');
   });
 
   testWidgets('shows fallback when opened without an activity', (tester) async {

--- a/app/test/community_event_card_test.dart
+++ b/app/test/community_event_card_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:squadquest/models/community.dart';
 import 'package:squadquest/widgets/community_event_card.dart';
 
@@ -40,5 +41,38 @@ void main() {
     // RSVP gradient toggles, reflecting state
     expect(find.byKey(const Key('going_toggle_e1')), findsOneWidget);
     expect(find.byKey(const Key('public_toggle_e1')), findsOneWidget);
+  });
+
+  testWidgets('tapping the card opens the event thread', (tester) async {
+    String? pushedRoute;
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const Scaffold(
+            body: CommunityEventCard(
+              communityId: 'c1',
+              event: CommunityEvent(id: 'e1', title: 'Cherry Blossoms Ride'),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/thread/:targetType/:targetId',
+          builder: (_, state) {
+            pushedRoute = state.uri.toString();
+            return const Scaffold(body: Text('thread'));
+          },
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('openEventThread_e1')));
+    await tester.pumpAndSettle();
+    expect(pushedRoute, '/thread/community_event/e1');
   });
 }

--- a/app/test/wants_screen_test.dart
+++ b/app/test/wants_screen_test.dart
@@ -2,10 +2,31 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:squadquest/models/activity.dart';
+import 'package:squadquest/models/friend.dart';
 import 'package:squadquest/models/want.dart';
 import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/friend_repository.dart';
 import 'package:squadquest/repositories/want_repository.dart';
 import 'package:squadquest/screens/wants/wants_screen.dart';
+
+class _FakeFriendRepository implements FriendRepository {
+  _FakeFriendRepository(this._friends);
+  final List<Friend> _friends;
+  @override
+  Future<List<Friend>> list() async => _friends;
+  @override
+  Future<FriendRequests> requests() async => const FriendRequests();
+  @override
+  Future<String> sendRequest(String phone) async => 'requested';
+  @override
+  Future<void> accept(String requestId) async {}
+  @override
+  Future<void> ignore(String requestId) async {}
+  @override
+  Future<void> unignore(String requestId) async {}
+  @override
+  Future<List<IgnoredItem>> ignored() async => const [];
+}
 
 class _FakeWantRepository implements WantRepository {
   _FakeWantRepository({this.own = const [], this.invited = const []});
@@ -14,6 +35,8 @@ class _FakeWantRepository implements WantRepository {
   String? respondedId;
   String? respondedValue;
   String? ignoredId;
+  final invitedProfileIds = <String>[];
+  final uninvitedProfileIds = <String>[];
 
   @override
   Future<List<Want>> listOwn({bool includeArchived = false}) async => own;
@@ -55,11 +78,17 @@ class _FakeWantRepository implements WantRepository {
   @override
   Future<void> delete(String id) async {}
   @override
-  Future<Want> invite(String id, List<String> profileIds) async =>
-      throw UnimplementedError();
+  Future<Want> invite(String id, List<String> profileIds) async {
+    invitedProfileIds.addAll(profileIds);
+    return own.firstWhere((w) => w.id == id);
+  }
+
   @override
-  Future<Want> uninvite(String id, String profileId) async =>
-      throw UnimplementedError();
+  Future<Want> uninvite(String id, String profileId) async {
+    uninvitedProfileIds.add(profileId);
+    return own.firstWhere((w) => w.id == id);
+  }
+
   @override
   Future<Want> clearResponse(String id) async => throw UnimplementedError();
   @override
@@ -87,11 +116,17 @@ Future<_FakeWantRepository> _pump(
   WidgetTester tester, {
   List<Want> own = const [],
   List<Want> invited = const [],
+  List<Friend> friends = const [],
 }) async {
   final repo = _FakeWantRepository(own: own, invited: invited);
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [wantRepositoryProvider.overrideWithValue(repo)],
+      overrides: [
+        wantRepositoryProvider.overrideWithValue(repo),
+        friendRepositoryProvider.overrideWithValue(
+          _FakeFriendRepository(friends),
+        ),
+      ],
       child: const MaterialApp(home: WantsScreen()),
     ),
   );
@@ -132,5 +167,43 @@ void main() {
       find.textContaining('Capture it here and make it happen'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('manage invites adds a new friend and removes an invitee', (
+    tester,
+  ) async {
+    final repo = await _pump(
+      tester,
+      own: [
+        _want(
+          'w1',
+          title: 'FDR lake',
+          invitees: const [WantInvitee(profileId: 'f1', name: 'Katie')],
+        ),
+      ],
+      friends: const [
+        Friend(id: 'f1', firstName: 'Katie'), // already invited
+        Friend(id: 'f2', firstName: 'Mike'), // not yet
+      ],
+    );
+
+    // Open the want menu → Manage invites.
+    await tester.tap(find.byKey(const Key('wantMenu_w1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Manage invites'));
+    await tester.pumpAndSettle();
+
+    // Current invitee is checked; the other friend isn't.
+    expect(find.byKey(const Key('manageInvitesList')), findsOneWidget);
+
+    // Invite Mike (toggle on) → invite() called with f2.
+    await tester.tap(find.byKey(const Key('inviteToggle_f2')));
+    await tester.pumpAndSettle();
+    expect(repo.invitedProfileIds, contains('f2'));
+
+    // Remove Katie (toggle off) → uninvite() called with f1.
+    await tester.tap(find.byKey(const Key('inviteToggle_f1')));
+    await tester.pumpAndSettle();
+    expect(repo.uninvitedProfileIds, contains('f1'));
   });
 }

--- a/plans/v2-journey-gap-fixes.md
+++ b/plans/v2-journey-gap-fixes.md
@@ -1,0 +1,83 @@
+---
+status: done
+depends: []
+specs:
+  - specs/screens/communities.md
+  - specs/screens/wants.md
+  - specs/behaviors/ideas-activities-lifecycle.md
+issues: []
+pr: 474
+---
+
+# Plan: v2 journey gap-fixes — wire spec'd affordances the client was missing
+
+> Came out of a **user-journey audit** (specs vs. implementation, all journeys fanned out in
+> parallel). The pattern this session keeps surfacing: a behavior is fully specified and the
+> backend + repo support it, but the **client affordance was never wired** — the same shape as
+> the squad-members gap (#473). The specs were already correct, so this is pure spec↔code
+> conformance, not a spec change. Three concrete dead-ends fixed.
+
+## Scope
+
+**In — three backend-ready affordances the UI was missing:**
+
+1. **Community event → thread** (HIGH). Tapping an event card did nothing; it now opens the
+   event's thread. Backend `GET/POST /v1/threads/community_event/:id/messages`, the
+   `/thread/:targetType/:targetId` route, and `event.thread_count` all already existed.
+2. **Manage invites on an existing want** (MEDIUM). The want menu was promote/edit/delete only;
+   to change who's invited you had to delete + recreate. Added a "Manage invites" sheet
+   (add/remove accepted friends) calling the already-present `invite`/`uninvite`.
+3. **Suggest an option** (MEDIUM). When an idea has `allow_suggestions`, there was no way to add
+   a time/place. Added "Suggest a time/place" affordances (incl. when there are no options yet)
+   calling the already-present `addOption`.
+
+**Out (correctly belongs elsewhere, flagged by the audit but not fixed here):**
+
+- Thread-as-a-right-side-**drawer** overlay, a persistent **vote bar inside** the thread, inline
+  response controls on **timeline tiles**, collapsing response chips — these are the
+  **`v2-styling-pass`** re-port (presentation/UX architecture). The functionality already works
+  on the activity detail screen; turning it into the mock's drawer is the styling effort.
+- Welcome-wizard intro **PageView** pages + an **Interests** bottom-nav tab — onboarding scope.
+- v1 **topic-subscription** carry in the migration — migration scope (needs verifying against
+  `v1-migration.md`; not a client gap).
+
+## Implements
+
+No spec changes — `specs/screens/communities.md` ("Open an event → thread"),
+`specs/screens/wants.md` ("Invite / remove friends on your want"), and
+`specs/behaviors/ideas-activities-lifecycle.md` (suggest when `allow_suggestions`) **already
+specified** all three. Code was brought into conformance.
+
+## Approach
+
+Client-only:
+
+- `community_event_card.dart` — wrap the card body in an `InkWell` → `push('/thread/community_event/:id')`; RSVP chips + leader menu keep their own gestures.
+- `wants_screen.dart` — "Manage invites" menu item → `_ManageInvitesSheet` (checkbox list of friends, seeded from current invitees, each toggle calls invite/uninvite + invalidates `ownWantsProvider`).
+- `activity_detail_screen.dart` — render When/Where when options exist **or** suggestions are open; add "Suggest a time/place" → label dialog → `addOption`.
+
+## Validation
+
+- [x] Tapping a community event card routes to `/thread/community_event/:id` (widget test).
+- [x] Want "Manage invites" adds a non-invitee (invite) and removes an invitee (uninvite) (widget test).
+- [x] "Suggest a time/place" shows when `allow_suggestions` (even with no options) and calls `addOption` (widget test).
+- [x] `flutter analyze` clean; `flutter test` green (42 tests, +3).
+
+## Risks / unknowns
+
+- The event-card InkWell nests buttons (RSVP chips, menu) — Material handles nested gesture
+  arenas, verified the chips still win their own taps (their `onSelected`/`onPressed` fire first).
+
+## Notes
+
+Found by fanning out parallel journey-audit subagents (onboarding+friends / ideas+thread+wants /
+communities+squads). One subagent falsely claimed captain-confirm/vote/response weren't wired on
+the activity detail screen — they are; verified before acting (don't over-trust the fan-out).
+The genuinely-missing items were these three dead-ends. Shipped in #474.
+
+## Follow-ups
+
+- **Deferred to plan** — the drawer-ification of threads + inline timeline-tile responses +
+  vote-bar-in-thread belong to `v2-styling-pass` (the mock re-port). Welcome intro pages +
+  Interests tab are onboarding scope; v1 topic-subscription carry is migration scope — none
+  filed as their own plans yet.


### PR DESCRIPTION
A **user-journey audit** (specs vs. implementation, fanned out across all journeys) found three dead-ends with the same shape as the squad-members gap (#473): the behavior is **specified**, the backend + repo **support it**, but the **client affordance was never wired**. Specs were already correct — this is spec↔code conformance, no spec change.

| # | Gap | Impact | Fix |
|---|---|---|---|
| 1 | **Community event → thread dead-end** — tapping an event did nothing | HIGH | Card `InkWell` → `/thread/community_event/:id`. Backend thread endpoints + route + `thread_count` already existed. |
| 2 | **Can't change want invites after creation** — menu was promote/edit/delete only | MEDIUM | "Manage invites" sheet (add/remove accepted friends) → existing `invite`/`uninvite`. |
| 3 | **No "Suggest an option"** — when an idea has `allow_suggestions` | MEDIUM | "Suggest a time/place" (shows even with no options yet) → existing `addOption`. |

## Verified

`flutter analyze` clean, **42 tests pass (+3)** — one widget test per fix (card tap routes to the thread; manage-invites calls invite+uninvite; suggest calls addOption).

## Deliberately out of scope (audit flagged, belongs elsewhere)

- Thread-as-**drawer** overlay, vote-bar-**in**-thread, inline response on **timeline tiles**, collapsing chips → **`v2-styling-pass`** (the mock re-port; the functionality already works on the detail screen).
- Welcome intro pages + Interests bottom-nav tab → onboarding scope.
- v1 topic-subscription migration carry → migration scope.

> One audit subagent falsely claimed captain-confirm/vote/response weren't wired on the activity detail screen — they **are**; I verified before acting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)