### PR TITLE
feat(app): thread drawer — the right-side Slack-thread surface

### DIFF
--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/auth_controller.dart';
 import '../../providers/providers.dart';
 import '../../widgets/community_event_card.dart';
 import '../../widgets/message_attachments.dart';
+import '../../widgets/thread_drawer.dart';
 
 /// The active timeline, per the context selector (specs/behaviors/context-selector.md):
 /// My Friends (ideas/activities), a Squad (heterogeneous activities + messages), or a
@@ -415,7 +416,7 @@ class _ActivityTile extends StatelessWidget {
         ? '$base · ${a.eventRef!.communityIcon ?? '📣'} ${a.eventRef!.communityName ?? 'Community'}'
         : base;
     return ListTile(
-      onTap: () => context.push('/activity/${a.id}', extra: a),
+      onTap: () => showThreadDrawer(context, target: ThreadTarget.activity(a)),
       leading: CircleAvatar(
         child: Text((a.captainName ?? '?').characters.first),
       ),
@@ -439,7 +440,8 @@ class _MessageTile extends StatelessWidget {
     final m = message;
     return ListTile(
       key: Key('message_${m.id}'),
-      onTap: () => context.push('/thread/message/${m.id}', extra: m),
+      onTap: () =>
+          showThreadDrawer(context, target: ThreadTarget.squadMessage(m)),
       leading: CircleAvatar(
         backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
         child: Text((m.senderName ?? '?').characters.first),

--- a/app/lib/widgets/community_event_card.dart
+++ b/app/lib/widgets/community_event_card.dart
@@ -6,6 +6,7 @@ import '../models/activity.dart';
 import '../models/community.dart';
 import '../providers/active_context.dart';
 import '../providers/providers.dart';
+import 'thread_drawer.dart';
 
 /// A born-confirmed community event card with the dual-attendance display and the
 /// RSVP visibility gradient (specs/screens/communities.md): an anonymous headcount,
@@ -17,11 +18,16 @@ class CommunityEventCard extends ConsumerStatefulWidget {
     required this.communityId,
     required this.event,
     this.isLeader = false,
+    this.inThread = false,
   });
 
   final String communityId;
   final CommunityEvent event;
   final bool isLeader;
+
+  /// When true the card is the thread drawer's header: it drops its own tap-to-open
+  /// (you're already in the thread) and renders flush (no Card margin/elevation).
+  final bool inThread;
 
   @override
   ConsumerState<CommunityEventCard> createState() => _CommunityEventCardState();
@@ -89,14 +95,25 @@ class _CommunityEventCardState extends ConsumerState<CommunityEventCard> {
               '${e.publicGoing.length > 2 ? ' +${e.publicGoing.length - 2}' : ''} publicly';
 
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      // Tapping the card opens the event's thread (chat + RSVP discussion).
+      margin: widget.inThread
+          ? EdgeInsets.zero
+          : const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      // Tapping the card opens the event's thread drawer (chat + RSVP discussion).
       // The RSVP chips / leader menu have their own handlers, so they win their
-      // own taps; this catches the rest. See specs/screens/communities.md.
+      // own taps; this catches the rest. In-thread the card IS the drawer header,
+      // so it doesn't re-open itself. See specs/behaviors/thread-drawer.md.
       child: InkWell(
         key: Key('openEventThread_${e.id}'),
-        onTap: () =>
-            context.push('/thread/community_event/${e.id}', extra: null),
+        onTap: widget.inThread
+            ? null
+            : () => showThreadDrawer(
+                context,
+                target: ThreadTarget.communityEvent(
+                  communityId: widget.communityId,
+                  event: e,
+                  isLeader: widget.isLeader,
+                ),
+              ),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/app/lib/widgets/thread_drawer.dart
+++ b/app/lib/widgets/thread_drawer.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../api/api_exception.dart';
+import '../models/activity.dart';
+import '../models/community.dart';
+import '../models/message.dart';
+import '../providers/providers.dart';
+import 'community_event_card.dart';
+import 'message_attachments.dart';
+import 'thread_view.dart';
+import 'thread_vote_bar.dart';
+
+/// What a thread drawer is opened for (specs/behaviors/thread-drawer.md). The
+/// header + vote bar adapt to the variant; the conversation is the same for all.
+sealed class ThreadTarget {
+  const ThreadTarget();
+
+  factory ThreadTarget.activity(Activity activity) = ActivityTarget;
+  factory ThreadTarget.squadMessage(Message message) = SquadMessageTarget;
+  factory ThreadTarget.communityEvent({
+    required String communityId,
+    required CommunityEvent event,
+    bool isLeader,
+  }) = CommunityEventTarget;
+
+  /// (targetType, targetId) for the messages API + threadProvider key.
+  (String, String) get thread;
+}
+
+class ActivityTarget extends ThreadTarget {
+  const ActivityTarget(this.activity);
+  final Activity activity;
+  @override
+  (String, String) get thread => ('activity', activity.id);
+}
+
+class SquadMessageTarget extends ThreadTarget {
+  const SquadMessageTarget(this.message);
+  final Message message;
+  @override
+  (String, String) get thread => ('message', message.id);
+}
+
+class CommunityEventTarget extends ThreadTarget {
+  const CommunityEventTarget({
+    required this.communityId,
+    required this.event,
+    this.isLeader = false,
+  });
+  final String communityId;
+  final CommunityEvent event;
+  final bool isLeader;
+  @override
+  (String, String) get thread => ('community_event', event.id);
+}
+
+/// Slide-in-from-the-right thread drawer over the whole screen (covers app bar +
+/// any composer), leaving a sliver of the timeline behind a scrim — the
+/// "floating" feel from specs/behaviors/thread-drawer.md. Tap the scrim or X to close.
+Future<void> showThreadDrawer(
+  BuildContext context, {
+  required ThreadTarget target,
+}) {
+  return showGeneralDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: 'Close thread',
+    barrierColor: Colors.black54,
+    transitionDuration: const Duration(milliseconds: 220),
+    pageBuilder: (_, _, _) => Align(
+      alignment: Alignment.centerRight,
+      child: FractionallySizedBox(
+        widthFactor: 0.92,
+        heightFactor: 1,
+        child: _ThreadDrawer(target: target),
+      ),
+    ),
+    transitionBuilder: (_, anim, _, child) => SlideTransition(
+      position: Tween(
+        begin: const Offset(1, 0),
+        end: Offset.zero,
+      ).animate(CurvedAnimation(parent: anim, curve: Curves.easeOutCubic)),
+      child: child,
+    ),
+  );
+}
+
+class _ThreadDrawer extends ConsumerWidget {
+  const _ThreadDrawer({required this.target});
+  final ThreadTarget target;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final (targetType, targetId) = target.thread;
+    return Material(
+      color: Theme.of(context).colorScheme.surface,
+      child: SafeArea(
+        child: Column(
+          key: const Key('threadDrawer'),
+          children: [
+            // Close affordance + a thin title.
+            Row(
+              children: [
+                IconButton(
+                  key: const Key('closeThreadDrawer'),
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+                const Expanded(child: Text('Thread')),
+                const SizedBox(width: 8),
+              ],
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+                children: [
+                  _header(context, ref),
+                  const SizedBox(height: 8),
+                  const Divider(height: 1),
+                  ThreadView(
+                    targetType: targetType,
+                    targetId: targetId,
+                    showAudienceHint: true,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _header(BuildContext context, WidgetRef ref) => switch (target) {
+    ActivityTarget(:final activity) => _ActivityHeader(activity: activity),
+    CommunityEventTarget(:final communityId, :final event, :final isLeader) =>
+      CommunityEventCard(
+        communityId: communityId,
+        event: event,
+        isLeader: isLeader,
+        inThread: true,
+      ),
+    SquadMessageTarget(:final message) => _MessageHeader(message: message),
+  };
+}
+
+/// Idea/activity header: type + state + audience + inline response controls, plus the
+/// persistent vote bar (when the idea warrants one).
+class _ActivityHeader extends ConsumerStatefulWidget {
+  const _ActivityHeader({required this.activity});
+  final Activity activity;
+  @override
+  ConsumerState<_ActivityHeader> createState() => _ActivityHeaderState();
+}
+
+class _ActivityHeaderState extends ConsumerState<_ActivityHeader> {
+  late Activity _a = widget.activity;
+  bool _busy = false;
+
+  Future<void> _setResponse(String? value) async {
+    setState(() => _busy = true);
+    try {
+      final repo = ref.read(activityRepositoryProvider);
+      final updated = value == null
+          ? await repo.clearResponse(_a.id)
+          : await repo.setResponse(_a.id, value);
+      ref.invalidate(friendsTimelineProvider);
+      ref.invalidate(squadTimelineProvider);
+      if (mounted) setState(() => _a = updated);
+    } on ApiException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(e.message)));
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final a = _a;
+    final stateLine = a.isConfirmed
+        ? 'Confirmed · ${[a.confirmedTime, a.confirmedLocation].whereType<String>().join(' · ')}'
+        : 'Idea${a.audienceSummary != null ? ' · ${a.audienceSummary}' : ''}';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '${a.captainName ?? 'Someone'} · ${a.activityTypeLabel ?? ''}',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        Text(stateLine, key: const Key('threadHeaderState')),
+        const SizedBox(height: 8),
+        // Inline response controls.
+        Wrap(
+          spacing: 8,
+          children: [
+            for (final e in const {
+              'in': "I'm in",
+              'interested': 'Interested',
+              'next_time': 'Next time',
+            }.entries)
+              ChoiceChip(
+                key: Key('response_${e.key}'),
+                label: Text(e.value),
+                selected: a.yourResponse == e.key,
+                onSelected: _busy
+                    ? null
+                    : (sel) => _setResponse(sel ? e.key : null),
+              ),
+          ],
+        ),
+        Text(
+          '${a.inCount} in · ${a.interestedCount} interested',
+          key: const Key('responseCounts'),
+        ),
+        if (ThreadVoteBar.appliesTo(a))
+          ThreadVoteBar(
+            activity: a,
+            onChanged: (updated) => setState(() => _a = updated),
+          ),
+      ],
+    );
+  }
+}
+
+/// Squad message header: sender + body preview, no voting.
+class _MessageHeader extends StatelessWidget {
+  const _MessageHeader({required this.message});
+  final Message message;
+  @override
+  Widget build(BuildContext context) {
+    final m = message;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          m.senderName ?? 'Someone',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        if (m.body != null && m.body!.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Text(m.body!),
+        ],
+        MessageAttachmentThumbs(attachments: m.attachments),
+      ],
+    );
+  }
+}

--- a/app/lib/widgets/thread_view.dart
+++ b/app/lib/widgets/thread_view.dart
@@ -13,10 +13,15 @@ class ThreadView extends ConsumerStatefulWidget {
     super.key,
     required this.targetType,
     required this.targetId,
+    this.showAudienceHint = false,
   });
 
-  final String targetType; // 'activity' | 'message'
+  final String targetType; // 'activity' | 'community_event' | 'message'
   final String targetId;
+
+  /// When true, show the private-audience hint above the reply input
+  /// (specs/behaviors/thread-drawer.md: "Only participants in this thread can see replies").
+  final bool showAudienceHint;
 
   @override
   ConsumerState<ThreadView> createState() => _ThreadViewState();
@@ -93,6 +98,29 @@ class _ThreadViewState extends ConsumerState<ThreadView> {
                 ),
         ),
         const SizedBox(height: 8),
+        if (widget.showAudienceHint)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.lock_outline,
+                  size: 14,
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    'Only participants in this thread can see replies',
+                    key: const Key('threadAudienceHint'),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
         MessageAttachmentField(
           attachments: _attachments,
           enabled: !_busy,

--- a/app/lib/widgets/thread_vote_bar.dart
+++ b/app/lib/widgets/thread_vote_bar.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../api/api_exception.dart';
+import '../models/activity.dart';
+import '../providers/auth_controller.dart';
+import '../providers/providers.dart';
+
+/// The persistent vote bar for an idea (specs/behaviors/thread-drawer.md): a section
+/// between the thread header and the chat. **Collapsed** shows summary chips of the
+/// leading time/place; tapping expands to the full voting detail (all options, vote
+/// toggles, captain Confirm, "Suggest" when allow_suggestions). Brought-along ideas
+/// (event_ref) instead show "Time & place set by the event" + the captain Confirm.
+///
+/// Self-contained: owns the busy/error/expanded state and the repo calls, swaps its
+/// working copy of the activity on each action, and notifies [onChanged] so the host
+/// (drawer or fallback detail screen) can refresh + keep timelines in sync.
+class ThreadVoteBar extends ConsumerStatefulWidget {
+  const ThreadVoteBar({
+    super.key,
+    required this.activity,
+    this.onChanged,
+    this.initiallyExpanded = false,
+  });
+
+  final Activity activity;
+  final void Function(Activity updated)? onChanged;
+  final bool initiallyExpanded;
+
+  /// Whether this activity warrants a vote bar at all: an idea (not confirmed) that
+  /// either has options, invites suggestions, or is a brought-along plan to confirm.
+  static bool appliesTo(Activity a) =>
+      !a.isConfirmed &&
+      (a.timeOptions.isNotEmpty ||
+          a.locationOptions.isNotEmpty ||
+          a.allowSuggestions ||
+          a.eventRef != null);
+
+  @override
+  ConsumerState<ThreadVoteBar> createState() => _ThreadVoteBarState();
+}
+
+class _ThreadVoteBarState extends ConsumerState<ThreadVoteBar> {
+  late Activity _a = widget.activity;
+  late bool _expanded = widget.initiallyExpanded;
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void didUpdateWidget(ThreadVoteBar old) {
+    super.didUpdateWidget(old);
+    // Reseed only when the host swaps to a different activity.
+    if (old.activity.id != widget.activity.id) _a = widget.activity;
+  }
+
+  bool get _isCaptain {
+    final auth = ref.read(authControllerProvider);
+    final me = auth is SignedIn ? auth.profile.id : null;
+    return me != null && _a.captainId == me;
+  }
+
+  Future<void> _act(Future<Activity> Function() action) async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final updated = await action();
+      ref.invalidate(friendsTimelineProvider);
+      ref.invalidate(squadTimelineProvider);
+      if (mounted) setState(() => _a = updated);
+      widget.onChanged?.call(updated);
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } catch (_) {
+      setState(() => _error = 'Something went wrong. Please try again.');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _suggest(String kind) async {
+    final controller = TextEditingController();
+    final label = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(kind == 'time' ? 'Suggest a time' : 'Suggest a place'),
+        content: TextField(
+          key: const Key('suggestOptionField'),
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(
+            hintText: kind == 'time' ? 'Saturday morning' : 'The trailhead',
+          ),
+          onSubmitted: (v) => Navigator.pop(dialogContext, v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.pop(dialogContext, controller.text.trim()),
+            child: const Text('Suggest'),
+          ),
+        ],
+      ),
+    );
+    if (label == null || label.isEmpty) return;
+    await _act(
+      () => ref.read(activityRepositoryProvider).addOption(_a.id, kind, label),
+    );
+  }
+
+  ActivityOption? _leading(List<ActivityOption> opts) {
+    if (opts.isEmpty) return null;
+    return opts.reduce((a, b) => b.votes > a.votes ? b : a);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final broughtAlong = _a.eventRef != null;
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      key: const Key('threadVoteBar'),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(12),
+      child: broughtAlong
+          ? _broughtAlong()
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _collapsedHeader(),
+                if (_expanded) ...[
+                  const SizedBox(height: 4),
+                  _expandedDetail(),
+                ],
+                if (_error != null) _errorText(),
+              ],
+            ),
+    );
+  }
+
+  // Brought-along: time & place come from the community event; the captain just confirms.
+  Widget _broughtAlong() => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Row(
+        children: [
+          const Icon(Icons.event, size: 18),
+          const SizedBox(width: 8),
+          const Expanded(child: Text('Time & place set by the event')),
+          if (_isCaptain)
+            FilledButton(
+              key: const Key('confirmBroughtAlong'),
+              onPressed: _busy
+                  ? null
+                  : () => _act(
+                      () => ref.read(activityRepositoryProvider).confirm(_a.id),
+                    ),
+              child: const Text('Confirm'),
+            ),
+        ],
+      ),
+      if (_error != null) _errorText(),
+    ],
+  );
+
+  // Collapsed: leading time/place chips + an expand affordance for the full detail.
+  Widget _collapsedHeader() {
+    final t = _leading(_a.timeOptions);
+    final l = _leading(_a.locationOptions);
+    final chips = <Widget>[
+      if (t != null) Chip(label: Text('🕒 ${t.label}')),
+      if (l != null) Chip(label: Text('📍 ${l.label}')),
+    ];
+    return InkWell(
+      key: const Key('voteBarToggle'),
+      onTap: () => setState(() => _expanded = !_expanded),
+      child: Row(
+        children: [
+          Expanded(
+            child: chips.isEmpty
+                ? const Text('Vote on when & where')
+                : Wrap(spacing: 6, runSpacing: 4, children: chips),
+          ),
+          Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+        ],
+      ),
+    );
+  }
+
+  Widget _expandedDetail() => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      if (_a.timeOptions.isNotEmpty || _a.allowSuggestions) ...[
+        const _SectionLabel('When'),
+        for (final o in _a.timeOptions) _optionTile(o, kind: 'time'),
+        if (_a.allowSuggestions) _suggestButton('time'),
+      ],
+      if (_a.locationOptions.isNotEmpty || _a.allowSuggestions) ...[
+        const _SectionLabel('Where'),
+        for (final o in _a.locationOptions) _optionTile(o, kind: 'location'),
+        if (_a.allowSuggestions) _suggestButton('location'),
+      ],
+    ],
+  );
+
+  Widget _optionTile(ActivityOption o, {required String kind}) => ListTile(
+    contentPadding: EdgeInsets.zero,
+    dense: true,
+    leading: IconButton(
+      key: Key('vote_${o.id}'),
+      icon: Icon(o.youVoted ? Icons.thumb_up : Icons.thumb_up_outlined),
+      onPressed: _busy
+          ? null
+          : () => _act(
+              () => ref
+                  .read(activityRepositoryProvider)
+                  .vote(_a.id, o.id, voted: !o.youVoted),
+            ),
+    ),
+    title: Text(o.label),
+    subtitle: Text('${o.votes} vote${o.votes == 1 ? '' : 's'}'),
+    trailing: (_isCaptain && !_a.isConfirmed)
+        ? TextButton(
+            key: Key('confirm_${o.id}'),
+            onPressed: _busy
+                ? null
+                : () => _act(
+                    () => ref
+                        .read(activityRepositoryProvider)
+                        .confirm(
+                          _a.id,
+                          timeOptionId: kind == 'time' ? o.id : null,
+                          locationOptionId: kind == 'location' ? o.id : null,
+                        ),
+                  ),
+            child: const Text('Confirm'),
+          )
+        : null,
+  );
+
+  Widget _suggestButton(String kind) => Align(
+    alignment: Alignment.centerLeft,
+    child: TextButton.icon(
+      key: Key(kind == 'time' ? 'suggestTime' : 'suggestLocation'),
+      onPressed: _busy ? null : () => _suggest(kind),
+      icon: const Icon(Icons.add, size: 18),
+      label: Text(kind == 'time' ? 'Suggest a time' : 'Suggest a place'),
+    ),
+  );
+
+  Widget _errorText() => Padding(
+    padding: const EdgeInsets.only(top: 8),
+    child: Text(
+      _error!,
+      key: const Key('voteBarError'),
+      style: TextStyle(color: Theme.of(context).colorScheme.error),
+    ),
+  );
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.label);
+  final String label;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(top: 8, bottom: 2),
+    child: Text(
+      label,
+      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+    ),
+  );
+}

--- a/app/test/community_event_card_test.dart
+++ b/app/test/community_event_card_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
 import 'package:squadquest/models/community.dart';
+import 'package:squadquest/models/message.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/message_repository.dart';
 import 'package:squadquest/widgets/community_event_card.dart';
 
 void main() {
@@ -43,36 +45,47 @@ void main() {
     expect(find.byKey(const Key('public_toggle_e1')), findsOneWidget);
   });
 
-  testWidgets('tapping the card opens the event thread', (tester) async {
-    String? pushedRoute;
-    final router = GoRouter(
-      initialLocation: '/',
-      routes: [
-        GoRoute(
-          path: '/',
-          builder: (_, _) => const Scaffold(
+  testWidgets('tapping the card opens the event thread drawer', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          messageRepositoryProvider.overrideWithValue(_FakeMessageRepository()),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
             body: CommunityEventCard(
               communityId: 'c1',
               event: CommunityEvent(id: 'e1', title: 'Cherry Blossoms Ride'),
             ),
           ),
         ),
-        GoRoute(
-          path: '/thread/:targetType/:targetId',
-          builder: (_, state) {
-            pushedRoute = state.uri.toString();
-            return const Scaffold(body: Text('thread'));
-          },
-        ),
-      ],
-    );
-    await tester.pumpWidget(
-      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+      ),
     );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key('openEventThread_e1')));
     await tester.pumpAndSettle();
-    expect(pushedRoute, '/thread/community_event/e1');
+    // The drawer slides in with the event as its header.
+    expect(find.byKey(const Key('threadDrawer')), findsOneWidget);
   });
+}
+
+/// Empty thread so the drawer's conversation section settles.
+class _FakeMessageRepository implements MessageRepository {
+  @override
+  Future<List<Message>> thread(String targetType, String targetId) async =>
+      const [];
+  @override
+  Future<Message> reply(
+    String targetType,
+    String targetId,
+    String body, {
+    List<MessageAttachment> attachments = const [],
+  }) async => const Message(id: 'm');
+  @override
+  Future<Message> postSquadMessage(
+    String squadId,
+    String body, {
+    List<MessageAttachment> attachments = const [],
+  }) async => const Message(id: 'm');
 }

--- a/app/test/thread_drawer_test.dart
+++ b/app/test/thread_drawer_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/activity.dart';
+import 'package:squadquest/models/community.dart';
+import 'package:squadquest/models/message.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/community_repository.dart';
+import 'package:squadquest/repositories/message_repository.dart';
+import 'package:squadquest/widgets/thread_drawer.dart';
+
+/// Empty thread + no-op reply, so the drawer's conversation section settles.
+class _FakeMessageRepository implements MessageRepository {
+  @override
+  Future<List<Message>> thread(String targetType, String targetId) async =>
+      const [];
+  @override
+  Future<Message> reply(
+    String targetType,
+    String targetId,
+    String body, {
+    List<MessageAttachment> attachments = const [],
+  }) async => const Message(id: 'm');
+  @override
+  Future<Message> postSquadMessage(
+    String squadId,
+    String body, {
+    List<MessageAttachment> attachments = const [],
+  }) async => const Message(id: 'm');
+}
+
+/// RSVP echo, unused reads.
+class _FakeCommunityRepository implements CommunityRepository {
+  @override
+  Future<List<Community>> discover({String? search}) async => const [];
+  @override
+  Future<Community> follow(String communityId, {required bool follow}) async =>
+      Community(id: communityId, name: '');
+  @override
+  Future<List<CommunityEvent>> events(String communityId) async => const [];
+  @override
+  Future<CommunityEvent> rsvp(
+    String eventId, {
+    required bool going,
+    required bool public,
+  }) async => CommunityEvent(id: eventId, title: '');
+  @override
+  Future<Community> create({
+    required String name,
+    String? tagline,
+    String? icon,
+    String? color,
+    String? photo,
+  }) async => const Community(id: 'c', name: '');
+  @override
+  Future<Community> update(
+    String communityId, {
+    String? name,
+    String? tagline,
+    String? icon,
+    String? color,
+    String? photo,
+  }) async => Community(id: communityId, name: '');
+  @override
+  Future<CommunityEvent> createEvent(
+    String communityId, {
+    required String title,
+    String? time,
+    String? recurrence,
+    String? location,
+  }) async => CommunityEvent(id: 'e', title: title);
+  @override
+  Future<CommunityEvent> updateEvent(
+    String eventId, {
+    String? title,
+    String? time,
+    String? recurrence,
+    String? location,
+  }) async => CommunityEvent(id: eventId, title: title ?? '');
+  @override
+  Future<void> deleteEvent(String eventId) async {}
+}
+
+Future<void> _pump(WidgetTester tester, ThreadTarget target) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        messageRepositoryProvider.overrideWithValue(_FakeMessageRepository()),
+        communityRepositoryProvider.overrideWithValue(
+          _FakeCommunityRepository(),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => showThreadDrawer(context, target: target),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('idea opens drawer with rich header + vote bar + audience hint', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      ThreadTarget.activity(
+        const Activity(
+          id: 'a1',
+          state: 'idea',
+          captainName: 'Katie',
+          activityTypeLabel: 'Paddleboarding',
+          audienceSummary: 'all friends',
+          allowSuggestions: true,
+          timeOptions: [ActivityOption(id: 'o1', label: 'Sat 7am', votes: 2)],
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('threadDrawer')), findsOneWidget);
+    expect(find.byKey(const Key('threadHeaderState')), findsOneWidget);
+    expect(find.byKey(const Key('threadVoteBar')), findsOneWidget);
+    expect(find.byKey(const Key('threadAudienceHint')), findsOneWidget);
+
+    // Vote bar starts collapsed (leading chip), expands to options + suggest.
+    expect(find.byKey(const Key('vote_o1')), findsNothing);
+    await tester.tap(find.byKey(const Key('voteBarToggle')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('vote_o1')), findsOneWidget);
+    expect(find.byKey(const Key('suggestTime')), findsOneWidget);
+  });
+
+  testWidgets('squad message opens drawer with sender header, no vote bar', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      ThreadTarget.squadMessage(
+        const Message(id: 'm1', senderName: 'Mike', body: 'yo'),
+      ),
+    );
+    expect(find.byKey(const Key('threadDrawer')), findsOneWidget);
+    expect(find.text('Mike'), findsOneWidget);
+    expect(find.byKey(const Key('threadVoteBar')), findsNothing);
+  });
+
+  testWidgets('community event opens drawer with event header + RSVP', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      ThreadTarget.communityEvent(
+        communityId: 'c1',
+        event: const CommunityEvent(
+          id: 'e1',
+          title: 'Cherry Blossoms Ride',
+          communityName: 'Wednesday Night Rides',
+        ),
+      ),
+    );
+    expect(find.byKey(const Key('threadDrawer')), findsOneWidget);
+    expect(find.text('Cherry Blossoms Ride'), findsOneWidget);
+    // RSVP control present; no vote bar for events.
+    expect(find.byKey(const Key('going_toggle_e1')), findsOneWidget);
+    expect(find.byKey(const Key('threadVoteBar')), findsNothing);
+  });
+
+  testWidgets('close button dismisses the drawer', (tester) async {
+    await _pump(tester, ThreadTarget.squadMessage(const Message(id: 'm1')));
+    expect(find.byKey(const Key('threadDrawer')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('closeThreadDrawer')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('threadDrawer')), findsNothing);
+  });
+}

--- a/plans/v2-thread-drawer.md
+++ b/plans/v2-thread-drawer.md
@@ -1,0 +1,113 @@
+---
+status: done
+depends: []
+specs:
+  - specs/behaviors/thread-drawer.md
+issues: []
+pr: 475
+---
+
+# Plan: v2 thread drawer — the right-side Slack-thread surface
+
+> `specs/behaviors/thread-drawer.md` describes the central interaction: tapping any idea,
+> activity, community event, or squad message opens a **right-side drawer** with a rich
+> target-adaptive header, a persistent vote bar (ideas), and the conversation. Today these
+> tap to a **full-screen** `ActivityDetailScreen` (ideas/activities) or `ThreadScreen` (messages,
+> community events), with options/vote/confirm/suggest already working but laid out top-to-bottom
+> on a plain screen. This brings the surface into spec conformance: one drawer, all four targets.
+
+## Scope
+
+**In:**
+
+- A **`ThreadDrawer`** that slides in from the right (~92% width, scrim + X to close, full
+  height) via `showGeneralDialog` + a right-edge slide transition.
+- **Target-adaptive header:**
+  - *Idea/activity* — type + state (idea/confirmed) + response controls + audience.
+  - *Community event* — reuse `CommunityEventCard` (community/recurrence/time/place + RSVP
+    gradient + bring-friends), with a new `inThread` flag to disable its own self-tap.
+  - *Squad message* — sender + body preview, no voting.
+- **Vote bar (ideas with options only):** persistent section between header and chat.
+  **Collapsed** = summary chips of the leading time/place; **tap to expand** = full detail
+  (all options, vote toggles, captain Confirm, "Suggest" when `allow_suggestions`). Brought-along
+  ideas (`event_ref`) instead show "Time & place set by the event" + the captain Confirm.
+- **Conversation:** reuse the existing `ThreadView` message list + reply input, with the spec'd
+  **audience hint** on the input ("Only participants in this thread can see replies").
+- Repoint the three tap targets (`_ActivityTile`, `_MessageTile`, community event card) to open
+  the drawer.
+
+**Out (kept as-is / later):**
+
+- The full-screen `ActivityDetailScreen` + `/activity/:id` and `/thread/:targetType/:targetId`
+  routes stay wired as a **fallback** (deep-links still work) — user's call. The drawer becomes
+  the primary tap target.
+- **Voter avatars** in the vote bar — the `ActivityOption` model carries vote *counts* + your-vote
+  only, not the voter list; show counts + your-vote highlight, note the gap (model/serializer
+  change is its own follow-up).
+- Realtime patch-in of new messages/votes while the drawer is open — already an enhancement; the
+  drawer renders from the fetch and `threadProvider` invalidates on reply/vote as today.
+
+## Implements
+
+`specs/behaviors/thread-drawer.md` — the drawer chrome, the adaptive header, the persistent
+collapse/expand vote bar, and the audience-stamped thread input. No spec change (the spec is
+already correct; this is code→spec conformance).
+
+## Approach
+
+1. **Refactor `thread_view.dart`** minimally: keep `ThreadView` (used by the fallback detail
+   screen), but ensure the reply input carries the audience hint. Extract nothing structural the
+   drawer can't reuse directly.
+2. **`CommunityEventCard`** — add `inThread = false`; when true, drop the self-`InkWell` so it
+   renders as a static header inside the drawer.
+3. **`thread_drawer.dart`** — `showThreadDrawer(context, {required target})` where target is a
+   sealed/enum over {activity, communityEvent, squadMessage}. Builds the header + vote bar (for
+   activities, lifting the options/vote/confirm/suggest logic out of `ActivityDetailScreen` into a
+   shared `_VoteBar` widget so both surfaces share it) + `ThreadView`.
+4. **Repoint taps** in `timeline_screen.dart` (`_ActivityTile`, `_MessageTile`) + the community
+   card to call `showThreadDrawer` instead of `context.push`.
+5. Tests: drawer opens for each target; vote bar expands; reply input shows the audience hint.
+
+## Validation
+
+- [x] Tapping an idea/activity tile opens the drawer with the rich header + vote bar.
+- [x] Tapping a squad message opens the drawer (sender header, no vote bar).
+- [x] Tapping a community event opens the drawer (event header + RSVP, no vote bar).
+- [x] Vote bar starts collapsed (leading-option chips) and expands to options + vote/confirm +
+      Suggest (when `allow_suggestions`); brought-along shows the event-set + confirm variant.
+- [x] Thread reply input shows the private-audience hint.
+- [x] `flutter analyze` clean; `flutter test` green (46 tests, +4).
+
+## Risks / unknowns
+
+- `showGeneralDialog` slide-from-right + scrim is the lightest path to the "floating over the
+  app bar + input" feel without a router change; verify it covers the FAB + bottom composer.
+- Sharing the vote/confirm/suggest logic between the drawer and the fallback detail screen
+  without duplicating: extract a `_VoteBar`/controller used by both.
+- Nested gesture arenas again (RSVP chips inside the event header inside the drawer) — same
+  Material handling as the card fix; verify chips still win their taps.
+
+## Notes
+
+Drawer is `showGeneralDialog` + a right-edge `SlideTransition` (92% width, scrim, full height
+over the app bar + composer) — lightest path to the "floating" feel without a router change.
+The vote bar (`thread_vote_bar.dart`) is its own self-contained widget so the
+options/vote/confirm/suggest + collapse/expand logic lives in one place.
+
+**Deviation from the plan's step 1:** I did *not* retrofit the shared `ThreadVoteBar` into the
+fallback `ActivityDetailScreen`. That screen still has its own (working, tested) always-expanded
+options list, and since the drawer is now the primary tap target nobody reaches the detail screen
+in normal flow. Forcing the shared widget in would have changed the fallback's UX and broken its
+passing tests for zero user-facing gain — so the two intentionally differ for now. Shipped in #475.
+
+## Follow-ups
+
+- **Deferred** — voter avatars in the vote bar (the `ActivityOption` model/serializer carries
+  vote *counts* + your-vote only, not the voter list; needs a backend serializer change). Shows
+  counts + your-vote highlight for now.
+- **Deferred** — realtime patch-in of new messages/votes while the drawer is open (renders from
+  fetch + invalidates on action today; the stream-driven live update rides on the broader
+  realtime story).
+- **Tracked as** — the fallback `ActivityDetailScreen` could later be retired (or re-skinned to
+  reuse `ThreadVoteBar`) once the drawer is confirmed to cover every entry point; left wired as a
+  deep-link fallback per the scope decision.


### PR DESCRIPTION
Implements **`specs/behaviors/thread-drawer.md`** — the central interaction the client was approximating with full-screen detail/thread screens.

Tapping an **idea/activity**, **squad message**, or **community event** now opens a **right-side drawer** (slides in ~92% over the app bar + composer, scrim/X to close), instead of pushing a full screen.

## What's in it

- **`thread_drawer.dart`** — `showThreadDrawer` + a sealed `ThreadTarget` (activity / squadMessage / communityEvent). **Target-adaptive header:**
  - *Idea/activity* — type + state + inline response chips + the vote bar.
  - *Community event* — reuses `CommunityEventCard` (new `inThread` flag → static header with RSVP gradient + bring-friends).
  - *Squad message* — sender + body preview, no voting.
- **`thread_vote_bar.dart`** — the **persistent vote bar**: collapsed = leading time/place chips; tap to expand → all options, vote toggles, captain **Confirm**, **Suggest** (when `allow_suggestions`). Brought-along ideas show *"Time & place set by the event"* + confirm. Self-contained shared widget.
- **`thread_view.dart`** — private-audience hint on the reply input (*"Only participants in this thread can see replies"*).
- Repointed the timeline tiles + event card to the drawer.

## Scope decisions (per your call)

- **Full-spec vote bar** (collapse/expand) — done.
- **Kept** the full-screen `ActivityDetailScreen` + `/activity` & `/thread` routes as a **deep-link fallback**; the drawer is the primary tap target. (It intentionally keeps its own always-expanded vote UI — see plan Notes for why I didn't force the shared widget in.)

## Deferred (in plan)

Voter avatars in the vote bar (model carries counts + your-vote only); realtime patch-in while the drawer's open.

## Verified

`flutter analyze` clean, **46 tests pass (+4)** — drawer opens for each target, vote bar starts collapsed and expands to options + Suggest, close dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)