### PR TITLE
feat(app): inline + collapsing response controls

### DIFF
--- a/app/lib/screens/timeline/timeline_screen.dart
+++ b/app/lib/screens/timeline/timeline_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/auth_controller.dart';
 import '../../providers/providers.dart';
 import '../../widgets/community_event_card.dart';
 import '../../widgets/message_attachments.dart';
+import '../../widgets/response_controls.dart';
 import '../../widgets/thread_drawer.dart';
 
 /// The active timeline, per the context selector (specs/behaviors/context-selector.md):
@@ -415,18 +416,32 @@ class _ActivityTile extends StatelessWidget {
     final subtitle = a.eventRef != null
         ? '$base · ${a.eventRef!.communityIcon ?? '📣'} ${a.eventRef!.communityName ?? 'Community'}'
         : base;
-    return ListTile(
-      onTap: () => showThreadDrawer(context, target: ThreadTarget.activity(a)),
-      leading: CircleAvatar(
-        child: Text((a.captainName ?? '?').characters.first),
-      ),
-      title: Text(
-        '${a.captainName ?? 'Someone'} · ${a.activityTypeLabel ?? ''}',
-      ),
-      subtitle: Text(subtitle),
-      trailing: a.isConfirmed
-          ? const Icon(Icons.event_available)
-          : Text('${a.inCount} in'),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          onTap: () =>
+              showThreadDrawer(context, target: ThreadTarget.activity(a)),
+          leading: CircleAvatar(
+            child: Text((a.captainName ?? '?').characters.first),
+          ),
+          title: Text(
+            '${a.captainName ?? 'Someone'} · ${a.activityTypeLabel ?? ''}',
+          ),
+          subtitle: Text(subtitle),
+          trailing: a.isConfirmed
+              ? const Icon(Icons.event_available)
+              : Text('${a.inCount} in'),
+        ),
+        // Inline response (specs/behaviors/response-system.md): respond without
+        // opening the drawer; collapses to a chip after choosing. Confirmed
+        // activities have no pending response to give.
+        if (!a.isConfirmed)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: ResponseControls(activity: a, dense: true),
+          ),
+      ],
     );
   }
 }

--- a/app/lib/widgets/response_controls.dart
+++ b/app/lib/widgets/response_controls.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../api/api_exception.dart';
+import '../models/activity.dart';
+import '../providers/providers.dart';
+
+/// The three-value response control (specs/behaviors/response-system.md): "I'm in" /
+/// "Interested" / "Next time" — no decline. **Inline + collapsing:** unresponded shows
+/// all three buttons; after responding it collapses to a single chip showing the choice,
+/// and tapping that chip re-expands to change or clear it.
+///
+/// Self-contained: owns its busy + collapsed state and the repo call, seeds from the
+/// activity's `your_response`, and notifies [onChanged] with the updated activity so the
+/// host can keep its own copy + the timelines in sync.
+class ResponseControls extends ConsumerStatefulWidget {
+  const ResponseControls({
+    super.key,
+    required this.activity,
+    this.onChanged,
+    this.dense = false,
+  });
+
+  final Activity activity;
+  final void Function(Activity updated)? onChanged;
+
+  /// Tighter layout for timeline tiles (vs. the roomier thread header).
+  final bool dense;
+
+  @override
+  ConsumerState<ResponseControls> createState() => _ResponseControlsState();
+}
+
+class _ResponseControlsState extends ConsumerState<ResponseControls> {
+  static const _labels = {
+    'in': "I'm in",
+    'interested': 'Interested',
+    'next_time': 'Next time',
+  };
+
+  late String? _response = widget.activity.yourResponse;
+  // Collapsed once you've responded; expand on demand to change.
+  late bool _expanded = widget.activity.yourResponse == null;
+  bool _busy = false;
+
+  @override
+  void didUpdateWidget(ResponseControls old) {
+    super.didUpdateWidget(old);
+    if (old.activity.id != widget.activity.id) {
+      _response = widget.activity.yourResponse;
+      _expanded = widget.activity.yourResponse == null;
+    }
+  }
+
+  Future<void> _set(String? value) async {
+    setState(() => _busy = true);
+    try {
+      final repo = ref.read(activityRepositoryProvider);
+      final updated = value == null
+          ? await repo.clearResponse(widget.activity.id)
+          : await repo.setResponse(widget.activity.id, value);
+      ref.invalidate(friendsTimelineProvider);
+      ref.invalidate(squadTimelineProvider);
+      if (mounted) {
+        setState(() {
+          _response = updated.yourResponse;
+          _expanded = updated.yourResponse == null; // collapse after choosing
+        });
+      }
+      widget.onChanged?.call(updated);
+    } on ApiException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(e.message)));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t save your response.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Collapsed: a single chip showing the choice; tap to re-expand.
+    if (!_expanded && _response != null) {
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: InputChip(
+          key: const Key('responseChip'),
+          avatar: const Icon(Icons.check, size: 18),
+          label: Text(_labels[_response] ?? _response!),
+          onPressed: _busy ? null : () => setState(() => _expanded = true),
+        ),
+      );
+    }
+
+    // Expanded: all three options (+ a clear affordance once a response exists).
+    return Wrap(
+      spacing: widget.dense ? 4 : 8,
+      children: [
+        for (final e in _labels.entries)
+          ChoiceChip(
+            key: Key('response_${e.key}'),
+            label: Text(e.value),
+            selected: _response == e.key,
+            onSelected: _busy ? null : (sel) => _set(sel ? e.key : null),
+          ),
+      ],
+    );
+  }
+}

--- a/app/lib/widgets/thread_drawer.dart
+++ b/app/lib/widgets/thread_drawer.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../api/api_exception.dart';
 import '../models/activity.dart';
 import '../models/community.dart';
 import '../models/message.dart';
-import '../providers/providers.dart';
 import 'community_event_card.dart';
 import 'message_attachments.dart';
+import 'response_controls.dart';
 import 'thread_view.dart';
 import 'thread_vote_bar.dart';
 
@@ -157,28 +156,6 @@ class _ActivityHeader extends ConsumerStatefulWidget {
 
 class _ActivityHeaderState extends ConsumerState<_ActivityHeader> {
   late Activity _a = widget.activity;
-  bool _busy = false;
-
-  Future<void> _setResponse(String? value) async {
-    setState(() => _busy = true);
-    try {
-      final repo = ref.read(activityRepositoryProvider);
-      final updated = value == null
-          ? await repo.clearResponse(_a.id)
-          : await repo.setResponse(_a.id, value);
-      ref.invalidate(friendsTimelineProvider);
-      ref.invalidate(squadTimelineProvider);
-      if (mounted) setState(() => _a = updated);
-    } on ApiException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(e.message)));
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -196,25 +173,12 @@ class _ActivityHeaderState extends ConsumerState<_ActivityHeader> {
         ),
         Text(stateLine, key: const Key('threadHeaderState')),
         const SizedBox(height: 8),
-        // Inline response controls.
-        Wrap(
-          spacing: 8,
-          children: [
-            for (final e in const {
-              'in': "I'm in",
-              'interested': 'Interested',
-              'next_time': 'Next time',
-            }.entries)
-              ChoiceChip(
-                key: Key('response_${e.key}'),
-                label: Text(e.value),
-                selected: a.yourResponse == e.key,
-                onSelected: _busy
-                    ? null
-                    : (sel) => _setResponse(sel ? e.key : null),
-              ),
-          ],
-        ),
+        // Inline + collapsing response controls (shared with the timeline tile).
+        if (!a.isConfirmed)
+          ResponseControls(
+            activity: a,
+            onChanged: (updated) => setState(() => _a = updated),
+          ),
         Text(
           '${a.inCount} in · ${a.interestedCount} interested',
           key: const Key('responseCounts'),

--- a/app/test/response_controls_test.dart
+++ b/app/test/response_controls_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:squadquest/models/activity.dart';
+import 'package:squadquest/providers/providers.dart';
+import 'package:squadquest/repositories/activity_repository.dart';
+import 'package:squadquest/widgets/response_controls.dart';
+
+/// Records set/clear and returns an activity reflecting the new response, so the
+/// collapse/expand transitions can be driven without a server.
+class _FakeActivityRepository implements ActivityRepository {
+  String? lastSet;
+  bool cleared = false;
+
+  Activity _with(String? response) =>
+      Activity(id: 'a1', state: 'idea', yourResponse: response);
+
+  @override
+  Future<Activity> setResponse(String activityId, String value) async {
+    lastSet = value;
+    return _with(value);
+  }
+
+  @override
+  Future<Activity> clearResponse(String activityId) async {
+    cleared = true;
+    return _with(null);
+  }
+
+  // Unused here:
+  @override
+  Future<Activity> createIdea({
+    String? activityTypeId,
+    String? activityTypeLabel,
+    bool allowSuggestions = false,
+    List<String> timeOptions = const [],
+    List<String> locationOptions = const [],
+    String? squadId,
+    String? communityEventId,
+  }) async => throw UnimplementedError();
+  @override
+  Future<Activity> vote(
+    String activityId,
+    String optionId, {
+    required bool voted,
+  }) async => throw UnimplementedError();
+  @override
+  Future<Activity> addOption(
+    String activityId,
+    String kind,
+    String label,
+  ) async => throw UnimplementedError();
+  @override
+  Future<Activity> confirm(
+    String activityId, {
+    String? timeOptionId,
+    String? locationOptionId,
+  }) async => throw UnimplementedError();
+}
+
+Future<_FakeActivityRepository> _pump(WidgetTester tester, Activity a) async {
+  final repo = _FakeActivityRepository();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [activityRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp(
+        home: Scaffold(body: ResponseControls(activity: a)),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return repo;
+}
+
+void main() {
+  testWidgets('unresponded shows all three options, no chip', (tester) async {
+    await _pump(tester, const Activity(id: 'a1', state: 'idea'));
+    expect(find.byKey(const Key('response_in')), findsOneWidget);
+    expect(find.byKey(const Key('response_interested')), findsOneWidget);
+    expect(find.byKey(const Key('response_next_time')), findsOneWidget);
+    expect(find.byKey(const Key('responseChip')), findsNothing);
+  });
+
+  testWidgets('choosing a response collapses to a chip', (tester) async {
+    final repo = await _pump(tester, const Activity(id: 'a1', state: 'idea'));
+    await tester.tap(find.byKey(const Key('response_in')));
+    await tester.pumpAndSettle();
+    expect(repo.lastSet, 'in');
+    // Row collapsed to a single chip showing the choice.
+    expect(find.byKey(const Key('responseChip')), findsOneWidget);
+    expect(find.byKey(const Key('response_in')), findsNothing);
+  });
+
+  testWidgets('already-responded starts collapsed; chip re-expands', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const Activity(id: 'a1', state: 'idea', yourResponse: 'interested'),
+    );
+    // Seeded collapsed.
+    expect(find.byKey(const Key('responseChip')), findsOneWidget);
+    expect(find.byKey(const Key('response_in')), findsNothing);
+
+    // Tap the chip → expands to the full row with the current choice selected.
+    await tester.tap(find.byKey(const Key('responseChip')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('response_interested')), findsOneWidget);
+    expect(find.byKey(const Key('response_in')), findsOneWidget);
+  });
+}


### PR DESCRIPTION
The last two functional bites from the styling-pass audit, both about the three-value response control (`specs/behaviors/response-system.md`).

## What

A shared **`ResponseControls`** widget implementing the spec's **"inline + collapsing"** rule:
- **Unresponded** → all three options in a row (I'm in / Interested / Next time).
- **After choosing** → collapses to a **single chip** showing the choice.
- **Tap the chip** → re-expands to change or clear it.

Wired in two places:
1. **Timeline `_ActivityTile`** — respond **inline** beneath the tile (dense), without opening the drawer. The spec wants the response available at the moment of discovery, not one navigation away.
2. **Thread drawer `_ActivityHeader`** — swapped its hand-rolled response chips for the same widget, so the tile and the header share **one** collapsing control (no drift).

## Verified

`flutter analyze` clean, **49 tests pass (+3)**: expanded shows three options; choosing collapses to a chip; an already-responded activity seeds collapsed and the chip re-expands.

No spec change — `response-system.md` already specified this exactly; this is conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)