### PR TITLE
fix(app): left-align thread messages

### DIFF
--- a/app/lib/widgets/thread_view.dart
+++ b/app/lib/widgets/thread_view.dart
@@ -93,6 +93,9 @@ class _ThreadViewState extends ConsumerState<ThreadView> {
                 )
               : Column(
                   key: const Key('threadMessages'),
+                  // Left-align rows (flat group-text, not bubbles); without this
+                  // the Column defaults to center and each row floats inward.
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   // endpoint returns newest-first; show chronological
                   children: msgs.reversed.map(_MessageRow.new).toList(),
                 ),


### PR DESCRIPTION
Thread messages were drifting toward center (see the "yeah?" / "Chris" rows in the reported screenshot).

**Cause:** the thread message list `Column` had no `crossAxisAlignment`, so it defaulted to `center`; each row sizes to its own content, so short messages floated inward.

**Fix:** `crossAxisAlignment: CrossAxisAlignment.start` — flat left-aligned group-text rows.

A layout bug, not styling — independent of the upcoming visual design pass. `flutter analyze` clean, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)