### PR TITLE
fix(app): pre-fill time + location when bringing friends to an event

### DIFF
--- a/app/lib/screens/compose/compose_idea_screen.dart
+++ b/app/lib/screens/compose/compose_idea_screen.dart
@@ -29,6 +29,18 @@ class _ComposeIdeaScreenState extends ConsumerState<ComposeIdeaScreen> {
   String? _error;
 
   @override
+  void initState() {
+    super.initState();
+    // Bring-friends: the brought-along idea's time/place are fixed by the event
+    // (specs/behaviors/bring-friends-bridge.md), so pre-fill them from it.
+    final event = widget.broughtEvent;
+    if (event != null) {
+      if (event.time != null) _time.text = event.time!;
+      if (event.location != null) _location.text = event.location!;
+    }
+  }
+
+  @override
   void dispose() {
     _time.dispose();
     _location.dispose();

--- a/app/test/bring_friends_test.dart
+++ b/app/test/bring_friends_test.dart
@@ -29,6 +29,7 @@ void main() {
                 id: 'e1',
                 title: 'Cherry Blossoms Ride',
                 time: 'Wed 6:30pm',
+                location: 'Clark Park',
                 communityName: 'Wednesday Night Rides',
                 communityIcon: '🚲',
               ),
@@ -44,6 +45,10 @@ void main() {
       // a brought idea is still friends-scoped
       expect(find.byKey(const Key('composeDestination')), findsOneWidget);
       expect(find.textContaining('all your friends'), findsOneWidget);
+
+      // time + location are pre-filled from the event (fixed by the event).
+      expect(find.widgetWithText(TextField, 'Wed 6:30pm'), findsOneWidget);
+      expect(find.widgetWithText(TextField, 'Clark Park'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
When you "Bring friends" to a community event, the composer showed the event as a chip but left the **time/location fields blank** — forcing you to re-type what the event already specifies.

Per `specs/behaviors/bring-friends-bridge.md`, the brought-along idea's **"time/place [are] fixed by the event."** So they should arrive pre-filled.

**Fix:** seed the time + location controllers from the `EventRef` in `initState`.

`flutter analyze` clean, 49 tests pass — the bring-friends test now asserts both fields pre-fill from the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)