### PR TITLE
feat(tf): switch backend database to shared-pg

### DIFF
--- a/tf/cloudrun.tf
+++ b/tf/cloudrun.tf
@@ -52,6 +52,10 @@ resource "google_cloud_run_v2_service" "backend" {
           cpu    = "1"
           memory = "512Mi"
         }
+        # Request-based billing with min=1 warm (2026-07 cost review): no cold
+        # starts for the app, CPU allocated only while requests (incl. open SSE
+        # streams) are in flight.
+        cpu_idle = true
       }
 
       env {

--- a/tf/cloudrun.tf
+++ b/tf/cloudrun.tf
@@ -30,9 +30,20 @@ resource "google_cloud_run_v2_service" "backend" {
     # the cadence humane. See specs/behaviors/realtime.md + plans/v2-realtime-sse.md.
     timeout = "3600s"
 
+    # Kept during the shared-pg transition so the old private-IP path stays
+    # reachable for rollback; remove (with the connector itself, ~$18/mo) in
+    # the post-cutover cleanup PR alongside cloudsql.tf.
     vpc_access {
       connector = google_vpc_access_connector.backend.id
       egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    # Shared-pg socket mount (see tf/secrets.tf for the URL composition)
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = ["jarvus-shared-postgres:us-east4:shared-pg"]
+      }
     }
 
     scaling {
@@ -56,6 +67,11 @@ resource "google_cloud_run_v2_service" "backend" {
         # starts for the app, CPU allocated only while requests (incl. open SSE
         # streams) are in flight.
         cpu_idle = true
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
       }
 
       env {

--- a/tf/secrets.tf
+++ b/tf/secrets.tf
@@ -8,6 +8,19 @@
 data "google_project" "current" {}
 
 # --- DATABASE_URL ------------------------------------------------------------
+# Shared-pg switchover (2026-07): the database now lives in the multi-tenant
+# jarvus-shared-postgres instance (see infra-ops projects/shared-postgres).
+# The tenant password is provisioned by that root into THIS project's Secret
+# Manager; we read it here to compose the URL. Connection is via the Cloud SQL
+# socket mount (cloudrun.tf), not the VPC private IP.
+locals {
+  shared_pg_connection = "jarvus-shared-postgres:us-east4:shared-pg"
+}
+
+data "google_secret_manager_secret_version" "shared_pg_password" {
+  secret = "shared-pg-squadquest-password"
+}
+
 resource "google_secret_manager_secret" "database_url" {
   secret_id = "database-url"
   replication {
@@ -17,7 +30,7 @@ resource "google_secret_manager_secret" "database_url" {
 
 resource "google_secret_manager_secret_version" "database_url" {
   secret      = google_secret_manager_secret.database_url.id
-  secret_data = "postgres://${google_sql_user.backend.name}:${random_password.db_password.result}@${google_sql_database_instance.backend.private_ip_address}:5432/${google_sql_database.backend.name}"
+  secret_data = "postgres://squadquest_app:${data.google_secret_manager_secret_version.shared_pg_password.secret_data}@/squadquest?host=/cloudsql/${local.shared_pg_connection}"
 }
 
 # --- JWT_SECRET --------------------------------------------------------------


### PR DESCRIPTION
Switches the v2 backend's database from the dedicated `squadquest-v2` Cloud SQL instance (private IP via VPC connector) to the multi-tenant `jarvus-shared-postgres:us-east4:shared-pg` instance (socket mount + tenant password provisioned by infra-ops `projects/shared-postgres`).

**Do not merge until the data is migrated** — cutover runbook in the commit message. Old instance, VPC connector, and private-IP path are deliberately retained for rollback; a cleanup PR follows the cooling-off period (instance ~$6/mo + connector ~$18/mo).

Also carries the cpu_idle=true declaration matching the live billing-mode change from the July cost review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UubgT92tLepcj9naR8K2Pq