### PR TITLE
fix(server): support unix-socket DATABASE_URL for the shared-pg cutover

### DIFF
--- a/server/src/db/connect.ts
+++ b/server/src/db/connect.ts
@@ -1,0 +1,26 @@
+// postgres.js cannot express a unix socket in a connection URL — ?host= and
+// ?path= query params are ignored and a percent-encoded authority resolves as
+// a DNS name (verified empirically against postgres.js 3.x during the 2026-07
+// shared-pg cutover). Cloud Run's Cloud SQL mount is a socket dir, so prod
+// URLs carry the libpq convention `?host=/cloudsql/<connection>` and this
+// helper translates them into an options-object connection. Dev URLs (plain
+// TCP against local postgres, no ?host=) pass through to postgres(url)
+// untouched — no GCP connector libraries, full dev/prod parity.
+import postgres from 'postgres'
+
+export function connectDb(url: string, options: postgres.Options<{}> = {}) {
+  const parsed = new URL(url.replace(/^postgres(ql)?:/, 'http:'))
+  const socketDir = parsed.searchParams.get('host')
+
+  if (!socketDir?.startsWith('/')) {
+    return postgres(url, options)
+  }
+
+  return postgres({
+    host: socketDir, // leading-slash host = unix socket dir to postgres.js
+    database: parsed.pathname.replace(/^\//, ''),
+    username: decodeURIComponent(parsed.username),
+    password: decodeURIComponent(parsed.password),
+    ...options,
+  })
+}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -1,5 +1,6 @@
 import fp from 'fastify-plugin'
 import postgres from 'postgres'
+import { connectDb } from './connect'
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 
 import * as schema from './schema/index.ts'
@@ -16,7 +17,7 @@ declare module 'fastify' {
 // Decorates `fastify.db` (Drizzle) + `fastify.sql` (raw postgres-js client) and
 // closes the pool on shutdown. DATABASE_URL is validated by the env plugin.
 export default fp(async (fastify) => {
-  const sql = postgres(fastify.config.DATABASE_URL, { max: 10 })
+  const sql = connectDb(fastify.config.DATABASE_URL, { max: 10 })
   const db = drizzle(sql, { schema })
 
   fastify.decorate('db', db)

--- a/server/src/migrate.ts
+++ b/server/src/migrate.ts
@@ -4,8 +4,8 @@
 // image needs neither drizzle-kit (a devDependency) nor a public DB IP — it runs
 // inside the VPC and reaches Cloud SQL over its private IP. Reads DATABASE_URL
 // from env; applies everything in ./migrations idempotently, then exits.
-import postgres from 'postgres'
 import { drizzle } from 'drizzle-orm/postgres-js'
+import { connectDb } from './db/connect'
 import { migrate } from 'drizzle-orm/postgres-js/migrator'
 
 const url = process.env.DATABASE_URL
@@ -14,7 +14,7 @@ if (!url) {
   process.exit(1)
 }
 
-const sql = postgres(url, { max: 1 })
+const sql = connectDb(url, { max: 1 })
 try {
   await migrate(drizzle(sql), { migrationsFolder: './migrations' })
   console.log('migrate: up to date')

--- a/server/src/realtime/index.ts
+++ b/server/src/realtime/index.ts
@@ -1,5 +1,6 @@
 import fp from 'fastify-plugin'
 import postgres from 'postgres'
+import { connectDb } from '../db/connect'
 
 // Server→client live updates: SSE fanned out via Postgres LISTEN/NOTIFY. A pure
 // enhancement, never load-bearing — see specs/behaviors/realtime.md.
@@ -38,7 +39,7 @@ export default fp(async (fastify) => {
 
   // Dedicated single LISTEN connection (separate from the query pool). On NOTIFY,
   // fan out to the subscribers that may see the event.
-  const listener = postgres(fastify.config.DATABASE_URL, { max: 1 })
+  const listener = connectDb(fastify.config.DATABASE_URL, { max: 1 })
 
   async function fanOut(raw: string) {
     let event: RealtimeEvent


### PR DESCRIPTION
Completes #480: the tf side deployed cleanly but the app crashed on startup — postgres.js has no URL syntax for unix sockets (`?host=`/`?path=` are ignored; verified empirically, details in the commit). `connectDb()` translates the libpq `?host=/cloudsql/...` convention to an options object; dev URLs pass through untouched, so local postgres workflows are unaffected and no GCP connector library is involved.

Old revision has been serving from the old DB throughout — no user impact. Once CI deploys this, the new revision picks up the already-fixed secret and completes the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UubgT92tLepcj9naR8K2Pq