### PR TITLE
chore(bin): vendor agent-dev-workflow, add bin/stop

### DIFF
--- a/.agents/skills/agent-dev-workflow/README.md
+++ b/.agents/skills/agent-dev-workflow/README.md
@@ -1,0 +1,37 @@
+# agent-dev-workflow
+
+Scaffolds an **agent-friendly local dev workflow**: a `bin/` task-runner (modeled on GitHub's
+*scripts-to-rule-them-all*) over a shared Postgres container that gives **every git worktree its own
+isolated database and port**, plus a dedicated test database so tests can never wipe your dev data.
+
+## When you'd want it
+
+A Postgres-backed project where you want any of:
+
+- multiple copies of the backend running concurrently on one machine (one per worktree),
+- the `setup` / `run` / `cleanup` contract that AI agent orchestrators (Conductor and similar) expect,
+- a fullstack `bin/dev` that runs as an **attach-aware per-worktree singleton** — a second invocation
+  reuses the healthy running session (`KEY=VALUE` endpoints on stdout, `status`/`stop`/`logs`
+  subcommands, on-disk `.dev/logs/`) instead of double-booting,
+- a `bin/gc` that **sweeps merged agent worktrees** — proof-based (ancestry / `git cherry` / merged
+  PR), stopping their dev sessions and dropping their derived databases along the way,
+- a `bin/stop` that **shuts the shared Postgres container down** once it proves nothing is using it
+  — no live dev session in any worktree, no client connections — for when idle project containers
+  pile up on one machine,
+- an end to tests clobbering local dev/demo data,
+- a replacement for a docker-compose-just-for-local-Postgres setup.
+
+If there's no database — or no concurrency need *and* tests already use a separate DB — the payoff
+is small.
+
+## Install
+
+**Recommended scope: global.** You reach for this to *bootstrap* a project's dev workflow, often
+before the repo has any skills wired up — so it's most useful installed once for all your projects.
+
+```bash
+npx skills add --global JarvusInnovations/agent-skills --skill agent-dev-workflow
+```
+
+Then ask your agent to set up the bin/ workflow. See `SKILL.md` for the full scaffold and
+`references/` for the deep dives.

--- a/.agents/skills/agent-dev-workflow/SKILL.md
+++ b/.agents/skills/agent-dev-workflow/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: agent-dev-workflow
+description: Set up an agent-friendly local dev workflow — a bin/ task-runner (inspired by GitHub's scripts-to-rule-them-all) over a shared Postgres container that gives every git worktree its own isolated database and ports, plus a dedicated test database so tests never clobber dev data. Use this whenever a project needs worktree-isolated local development, when setting up for AI agent orchestrators (Conductor and similar) that spin up a worktree per session and register setup/run/cleanup commands, when multiple copies of a backend must run concurrently on one machine, when replacing a docker-compose-for-local-postgres setup, when deciding whether auxiliary dev services (a validator container, a local OIDC IdP) replicate per worktree or run shared, when merged agent worktrees pile up and need sweeping, when idle per-project Postgres containers or leftover dev servers accumulate on a machine and need auditing or shutting down, or when tests keep wiping local dev/demo data. Triggers on "bin/ scripts", "worktree isolation", "per-worktree database/port", "scripts to rule them all", "agent dev environment", "setup/run/cleanup scripts", "shared auxiliary services", "sweep merged worktrees", "stop/shut down the dev database container", "too many docker postgres instances", or tests clobbering the dev database.
+---
+
+# Agent-friendly dev workflow (bin/ + worktree isolation)
+
+This skill scaffolds a `bin/` task-runner that lets **many copies of a project run
+concurrently on one machine** — one per git worktree — each with its own database
+and port, sharing a single Postgres container. It's the contract AI agent
+orchestrators (Conductor and similar) want: register `setup` / `run` / `cleanup`
+once and every session gets an isolated environment for free. As a high-value side
+effect, tests run against a dedicated database and **can never wipe your dev data**.
+
+It's modeled on GitHub's *scripts-to-rule-them-all*, but uses `bin/` (the name
+`script/` never caught on) and adds the worktree-isolation layer.
+
+## When this is the right tool
+
+A project backed by Postgres where you want any of: concurrent worktree dev,
+orchestrator setup/run/cleanup hooks, an end to tests clobbering dev data, or a
+replacement for a docker-compose-just-for-local-postgres. If there's no database,
+most of this doesn't apply. If there's no concurrency need *and* tests already use
+a separate DB, the payoff is small.
+
+## The core idea: identity derives from the worktree
+
+One shared Postgres container (started once, reused by name — path-independent, so
+it survives worktree deletion). Each context gets a **database** and a **port per
+process it runs**, derived from its worktree path:
+
+| Context | Database | Port(s) |
+| --- | --- | --- |
+| Main checkout | the canonical name (durable dev data) | the default(s) (e.g. 4000) |
+| Each agent worktree | `app_<hash-of-path>` (isolated) | next free in each range |
+| The test runner | `app_test` (forced) | n/a |
+
+A worktree isn't necessarily one process: a repo may run an HTTP API + a gRPC
+service + a Vite frontend per worktree. The pattern generalizes cleanly — the
+project's port band claims **one range per process kind**, `_common.sh` grows one
+picker per kind, and `bin/setup` emits every derived port **plus the wiring vars
+that connect the processes** (e.g. `ORCHESTRATOR_URL`). One note: gRPC ports
+aren't curl-checkable — readiness-probe them with a plain TCP check.
+
+Because identity comes from the path, two sessions never collide and re-running
+setup is idempotent. Every derived value has an env override (`APP_DATABASE`,
+`APP_PG_PORT`, `PORT`, …) for explicit orchestrator control.
+
+## What's invariant vs. project-specific
+
+The whole point of distilling this from several real Postgres-backed projects is to
+know which parts you copy verbatim and which you adapt.
+
+**Invariant** (copy from `references/bin/`, just swap the `app`/`APP_` prefix):
+
+- worktree-aware DB naming (`app_db_name`, `app_db_name_for_root`,
+  `is_main_worktree`, `app_hash`)
+- shared-container management (`ensure_postgres`, `wait_for_postgres`, `app_psql`)
+  and its machine-scoped counterpart `bin/stop` (below)
+- DB create/recreate helpers; the `setup`/`reset-db`/`db`/`cleanup`/`stop`/`test`
+  scripts (keep these names — e.g. `db`, not `query` — so the muscle memory
+  transfers across repos)
+- port picking (`port_in_use`, `find_available_port`, `app_pick_port`) — **including
+  the macOS `lsof`/`ss` split; do not "simplify" it away** (see gotchas)
+- stdout=env / stderr=status discipline
+- the dev-session **state machine** (fullstack variant): the atomic noclobber
+  claim of `.dev/state.env` with `PHASE=booting` → `PHASE=running` only after
+  ports listen, snapshot-coherent reads, the ownership-checked EXIT/INT/TERM
+  trap, per-child process groups via `set -m` (never `kill 0`), and
+  `app_dev_stop`
+- **pid + start-time identity** (`app_pid_lstart`, `app_pid_is`) consulted
+  before every kill and every health verdict (see gotchas — pid recycling), and
+  the **TERM → KILL → verify** escalation in `app_dev_stop` (see gotchas — a
+  single SIGTERM is not a teardown)
+- deriving the session's child list from `state.env` (`app_dev_child_keys`)
+  rather than hardcoding it per stack (see gotchas)
+- the `bin/gc` proof structure: mandatory gates + at least one containment
+  proof, the long-lived-branch denylist, the canonical-DB guard, and the fd-3
+  record stream (see gotchas — stdin-slurping loops)
+
+**Project-specific** (the knobs you set):
+
+- the prefix, PG user/password/image, container/volume names
+- the **base port band** — the default PG port plus one worktree range **per
+  process kind** (backend HTTP, gRPC, frontend, …). This is the project's claim on
+  the machine: worktree isolation keeps a project's *own* copies apart, but the
+  base band is what keeps *different projects* from colliding when several run at
+  once. Pick a distinct, uncommon band per repo (see gotchas) and keep PG + every
+  process range in one coherent band.
+- the Postgres **major** — pin the same one production runs (`references/snapshots.md`)
+- `app_server_dir` — repo root (single package) vs a subdir (monorepo)
+- `app_migrate` — how migrations run → **`references/migrations-and-seeds.md`**
+- single-service `dev` (frontend runs separately) vs fullstack `dev` (an
+  attach-aware per-worktree singleton that starts both, supervises both, and
+  kills both) → use `references/bin/dev` or `references/bin/dev-fullstack`
+- `bin/gc`'s integration branch — `APP_GC_BASE_REF` defaults to `origin/main`;
+  set `origin/develop` in repos that integrate on develop
+- the **seed posture** — synthetic SQL, snapshot-as-seed, or empty + per-suite
+  fixtures (`references/migrations-and-seeds.md`), and whether it has prod snapshots
+  at all (`references/snapshots.md`)
+- whether the repo has **auxiliary services** and what shared endpoints to seed
+  into worktree envs (next section)
+
+## Auxiliary services: shared per machine, never per worktree
+
+What replicates per worktree is **the app + its database — nothing more**.
+Auxiliary services (a GTFS validator container, a local OIDC IdP, a fake object
+store) run **once per machine** and are shared by every worktree instance; each
+worktree's env just points at the shared endpoints. N worktrees hitting one
+validator is fine — one container instead of N is the difference between "docker
+is fine" and "my laptop is swapping".
+
+This fixes the docker-compose question cleanly:
+
+- **No aux services** (the dev flow is just app + DB) → **no compose at all**.
+  `bin/` owns the shared Postgres container directly, as prescribed.
+- **Aux services exist** → compose covers **only those**: `docker compose up -d`
+  once per machine. The compose file never contains the per-worktree app or
+  Postgres — those stay with `bin/`.
+
+Don't expand `bin/` into orchestrating aux containers; hold the boundary instead:
+**`bin/` = per-worktree identity** (DB, ports, app processes); **compose =
+machine-wide singletons**.
+
+**Env seeding** is the connective tissue: `bin/setup` emits the shared endpoints
+alongside the per-worktree values (e.g. `VALIDATOR_URL=http://localhost:9010`,
+overridable via env like everything else), so one stdout capture threads into the
+run step and every worktree converges on the same shared services.
+
+## Worktree lifecycle: create under `.claude/worktrees/`, sweep with `bin/gc`
+
+Agent worktrees should live under the repo's **`.claude/worktrees/`** directory
+(gitignore `**/.claude/worktrees/` so nested checkouts never show as untracked
+files). That location is what makes the end of the lifecycle automatic: a
+worktree is alive while its PR is in review and becomes garbage the moment it
+merges — but merges happen on the reviewer's schedule, with no local session
+listening. `bin/gc` closes that gap with a lazy, state-based sweep: it
+enumerates linked worktrees under any `*/.claude/worktrees/` path and removes
+only the ones it can **prove** merged (ancestry, `git cherry` patch
+containment, or a merged PR via `gh` — plus mandatory gates: clean, unlocked,
+not the main/current worktree, not a long-lived branch), stopping any recorded
+`bin/dev` session and dropping the derived database along the way. Everything
+unproven is skipped with a one-line reason; a `--nudge` mode is cheap enough to
+run from a SessionStart hook. Worktrees created *outside* `.claude/worktrees/`
+escape the sweep entirely — that's the trade you make by putting them
+elsewhere.
+
+## Teardown has two scopes — worktree and machine
+
+Every teardown script except one is **worktree-scoped**, and that is deliberate:
+`bin/cleanup` drops one derived database, `bin/dev stop` ends one session,
+`bin/gc` sweeps the worktrees it can prove merged. None of them stops the
+Postgres container, because no single worktree can know whether another still
+needs it.
+
+That leaves a real gap the first version of this skill didn't fill: nothing was
+able to say *"this container is idle machine-wide, stop it."* On a laptop
+running several of these repos at once, the containers accumulate and the only
+recourse is `docker stop` by hand — which loses every guard the rest of the
+pattern provides.
+
+`bin/stop` is that one machine-scoped script. It stops the shared container only
+after proving it idle: no live `bin/dev` session in **any** worktree of the repo
+(enumerated from git, so sessions in scratch dirs outside `.claude/worktrees/`
+still count), and no client backends connected to any database in it. Unproven →
+one-line reason, container left running, exit 0. Same prove-then-act shape as
+`bin/gc`; `--dry-run` and `--force` are combinable.
+
+Two things it deliberately does **not** do. It never removes the container or
+volume — stopping is non-destructive and `bin/setup` restarts it with every
+database intact. And it does not lock other sessions out: a concurrent
+`bin/setup` calling `ensure_postgres` will bring the container right back. That
+race is by design (availability beats shutdown), so a container that keeps
+reappearing is telling you another session is working in the repo — information,
+not a failure.
+
+### `bin/gc` vs `bin/stop` — complementary, not overlapping
+
+They share a shape — prove, act only on what's proven, skip the rest with a
+one-line reason, exit 0 either way — which makes them easy to confuse. They
+prove *different things* about *different scopes*:
+
+| | `bin/gc` | `bin/stop` |
+| --- | --- | --- |
+| Operates on | worktrees, branches, derived databases | the shared container |
+| Proves | **merged-ness** — this work is disposable | **idleness** — nothing is using this now |
+| Proof source | git history (ancestry, `git cherry`, merged PR) | live state (session files, `pg_stat_activity`) |
+| Reversible | no — deletes worktrees, branches, DBs | yes — `bin/setup` restarts it, data intact |
+| Facing a live `bin/dev` session | **kills it** | **refuses to act** |
+
+That last row is the real distinction. `bin/gc` finds a running session in a
+worktree it has *proven merged* and shuts it down — it earned the authority to
+kill by proving the work already landed on the integration branch. `bin/stop`
+has no such proof available, so a live session is a **veto**: someone is
+working, and pulling the database out from under them is never right. One
+treats a live process as garbage to collect; the other treats it as a stop sign.
+
+Their verdicts also age differently. Merged stays merged, so a `bin/gc` verdict
+computed a minute ago is still true. Idleness is a snapshot that can be
+invalidated a second later — hence `bin/stop`'s re-verify immediately before
+acting, and the documented race above.
+
+**The workflow is sequential: `bin/gc`, then `bin/stop`.** `gc` is what *makes*
+`stop` succeed — sweeping merged worktrees stops their sessions and drops their
+databases, which is exactly what turns a busy container into a provably idle
+one. `gc` then leaves the container running because it cannot know whether the
+main checkout still needs it; `stop` is the only thing entitled to answer that.
+Running `stop` first usually just prints a refusal.
+
+One caveat when reading `bin/stop`'s first proof: it enumerates worktrees of
+*this* repo. A **separate clone** of the same project shares the container by
+name but is invisible to `git worktree list`. That's why the connection check
+exists alongside the session check — a second clone running its own stack shows
+up as client backends even though its worktrees are unreachable from here.
+
+
+## Build order
+
+1. **Read the relevant references first** (below) — they encode hard-won bugs.
+2. Copy `references/bin/*` into the project's `bin/`, rename the prefix, fill the
+   constants in `_common.sh`. **Claim a base port band** well outside 5432 and
+   distinct from your other projects (see gotchas — or derive it from a hash of the
+   repo name). Pin the **same Postgres major as production** so snapshots restore
+   cleanly (`references/snapshots.md`).
+3. Set `app_server_dir` and `app_migrate` for this project
+   (`references/migrations-and-seeds.md`).
+4. Choose the `dev` variant (single-service vs `dev-fullstack`). The fullstack
+   variant carries the whole session protocol (singleton claim, attach,
+   status/stop/logs, supervision) — copy its mechanics verbatim and adapt only
+   the two child-launch blocks. Copy `bin/gc` alongside it and set
+   `APP_GC_BASE_REF` if the repo integrates on a branch other than `main`.
+5. Wire **test isolation** — the preload that points tests at `app_test`
+   (`references/test-isolation.md`). Do this when (or before) the project grows a
+   DB-backed test suite: it's the step that stops tests wiping dev data. It's a clean
+   add later, but if you know tests are coming, scaffolding `bin/test` + the preload
+   up front means the *first* test is born-isolated.
+6. `chmod +x bin/*` (not `_common.sh`). If a `docker-compose.yml` exists, evict
+   its Postgres (and app) services — delete the file outright if that's all it had;
+   keep it only as the once-per-machine aux-services runner (see "Auxiliary
+   services" and gotchas). Update `.env.example` + the project's agent docs
+   (CLAUDE.md or equivalent) to point at `bin/`.
+7. **Verify** end to end (don't assume): `bin/setup` on a clean checkout; the
+   sentinel-row test from `test-isolation.md`; `bin/dev` in two *worktrees* lands on
+   two different ports; `bin/dev` twice in the *same* worktree → the second
+   attaches (exit 0, `KEY=VALUE` block) instead of double-booting; kill one
+   child process → the whole stack exits loudly (no half-dead session);
+   `bin/gc --dry-run` reports sane verdicts; `bin/cleanup` in a throwaway
+   worktree leaves the main DB intact. `bash -n` every script.
+
+   Two teardown checks are worth doing explicitly, because both failures
+   report success: launch a child that ignores SIGTERM (`trap "" TERM`), then
+   confirm `bin/dev stop` **escalates to SIGKILL and reaps it** instead of
+   exiting 0 with the process still alive; and run `bin/stop --dry-run` both
+   with a live session up (must refuse) and with nothing running (must report
+   idle).
+
+## Reference files
+
+| File | Read when |
+| --- | --- |
+| `references/bin/` | always — the script templates you copy + adapt |
+| `references/test-isolation.md` | wiring tests to `app_test` (the preload), **and** authoring suites against it (in-process `inject`, scoped truncate, fixtures) — almost always |
+| `references/migrations-and-seeds.md` | setting `app_migrate`; deciding on seeds |
+| `references/gotchas.md` | **before writing port logic or picking a PG image** — the silent-failure bugs |
+| `references/orchestrator-integration.md` | wiring Conductor/orchestrator setup/run/cleanup; the stdout/stderr contract |
+| `references/snapshots.md` | only if the project has a production DB to snapshot (skip for greenfield) |
+
+## Where this meets `ci-quality-gates`
+
+This skill and **`ci-quality-gates`** are complementary and meet at exactly one
+seam: the **`test` script**. `ci-quality-gates` owns the script contract
+(`lint`/`format`/`format:check`/`typecheck`/`test`) and the CI workflow that runs
+`bun run test` against an **ephemeral service-container Postgres** with an explicit
+`DATABASE_URL`. This skill owns what that same `test` script connects to **locally**:
+`bin/test` + the `bunfig.toml` preload force an isolated `app_test` DB, and the
+preload's `??=` is the handshake that lets CI's explicit `DATABASE_URL` win. Adopt
+both together for a DB-backed app — the CI skill defines the gate, this skill keeps
+it from clobbering dev data. (SquadQuest is the worked example: a `"test": "bun test"`
+script, `bin/test`, and a `bunfig.toml` preload that defers via `??=`.)
+
+Some repos deliberately run CI with **no database at all** (live-DB suites
+self-skip). That's a legitimate posture too — but the preload must then skip
+when Postgres is unreachable instead of failing the run. See
+`test-isolation.md` §CI for both postures.
+
+## Guardrails
+
+- Keep the scripts to **database + process lifecycle**. Rich demo/fixture data is
+  the app's concern and churns fast — at most a thin idempotent seed hook
+  (`migrations-and-seeds.md`). A bloated `bin/` stops being portable.
+- These are dev-only. **CI keeps its own explicit `DATABASE_URL`** against an
+  ephemeral DB (a GitHub Actions service-container Postgres, owned by
+  **`ci-quality-gates`**); the test preload's `??=` defers to it. Verify CI stays
+  green; you shouldn't need to touch the CI workflow.
+- Don't drop the canonical dev DB casually — `bin/cleanup` guards it behind
+  `--force`; `bin/reset-db` is the intended "start the main DB over" path.

--- a/.agents/skills/agent-dev-workflow/references/bin/_common.sh
+++ b/.agents/skills/agent-dev-workflow/references/bin/_common.sh
@@ -1,0 +1,440 @@
+# Shared functions for <PROJECT> development scripts. Source this; don't run it.
+#
+# This is the invariant core of the agent-dev-workflow pattern. A single shared
+# Postgres container hosts a SEPARATE DATABASE per context (main checkout, each
+# agent worktree, the test runner), and each context binds a free port — so many
+# worktrees run at once without clobbering each other.
+#
+# TO ADAPT: replace the `app`/`APP_` prefix with a short one for your project
+# (e.g. a 2-3 letter initialism) and set the constants below. Pick a PG host port
+# well outside the common 5432 to avoid colliding with other local Postgres instances.
+
+set -euo pipefail
+
+APP_PG_USER="app"
+APP_PG_PASSWORD="app"
+# Pin the SAME Postgres major production runs (see gotchas.md). postgres:18
+# moved the data directory — if prod is 18, change BOTH lines together:
+#   APP_PG_IMAGE="postgres:18-alpine"
+#   APP_PG_DATA_DIR="/var/lib/postgresql"        # NOT .../data on 18
+APP_PG_IMAGE="postgres:17-alpine"
+APP_PG_DATA_DIR="/var/lib/postgresql/data"
+APP_CONTAINER_NAME="app-postgres"
+APP_VOLUME_NAME="app-pgdata"
+
+app_root() {
+  git rev-parse --show-toplevel
+}
+
+# Where the backend lives. Single-package repo → app_root; monorepo → a subdir
+# (e.g. "$(app_root)/server" or "$(app_root)/apps/server"). Adjust per project.
+app_server_dir() {
+  echo "$(app_root)"
+}
+
+app_pg_port() {
+  # CHANGE THIS. 5532 is a placeholder, not a recommendation — pick a port in
+  # this project's own band (see SKILL.md "base port band"). Never 5432: a
+  # host Postgres, a stray docker-compose, or another project using the
+  # default will collide, and the failure looks like "my data disappeared"
+  # rather than a port conflict.
+  echo "${APP_PG_PORT:-5532}"
+}
+
+# ── Database naming: one DB per context ──────────────────────────────────────
+# APP_DATABASE set → that name (the test runner / orchestrator forces this).
+# main worktree    → the canonical name (your durable dev data).
+# other worktree   → app_<hash-of-path> (isolated, stable per worktree).
+# The repo's main worktree — `git worktree list` always reports it first.
+# Single source of truth: is_main_worktree, app_db_name_for_root and bin/gc's
+# canonical-DB guard all resolve it through here. Takes an optional directory
+# to resolve from (any path inside the repo); defaults to the current context.
+app_main_worktree() {
+  git -C "${1:-$(app_root)}" worktree list --porcelain | head -1 | sed 's/^worktree //'
+}
+
+is_main_worktree() {
+  [ "$(app_root)" = "$(app_main_worktree)" ]
+}
+
+# Portable 8-char hex hash (md5sum on Linux/coreutils, md5 on BSD/macOS).
+app_hash() {
+  if command -v md5sum &>/dev/null; then
+    echo -n "$1" | md5sum | head -c 8
+  else
+    echo -n "$1" | md5 -q | head -c 8
+  fi
+}
+
+# Derived DB name for an ARBITRARY worktree root of this repo — bin/gc needs
+# it for worktrees other than the current one. Main worktree → the canonical
+# name; any other → app_<hash-of-path>. APP_DATABASE is deliberately NOT
+# consulted here: that override belongs to the *current* context only
+# (app_db_name below).
+app_db_name_for_root() {
+  local root="$1" main_worktree
+  main_worktree="$(app_main_worktree "$root")"
+  if [ "$root" = "$main_worktree" ]; then
+    echo "app"
+  else
+    echo "app_$(app_hash "$root")"
+  fi
+}
+
+app_db_name() {
+  if [ -n "${APP_DATABASE:-}" ]; then
+    echo "$APP_DATABASE"
+    return
+  fi
+  app_db_name_for_root "$(app_root)"
+}
+
+app_database_url() {
+  echo "postgres://${APP_PG_USER}:${APP_PG_PASSWORD}@localhost:$(app_pg_port)/$(app_db_name)"
+}
+
+# Not every app reads DATABASE_URL — some consume discrete DB_HOST/DB_PORT/…
+# vars. Emit BOTH forms from bin/setup (uncomment there), or better: teach the
+# app DATABASE_URL with a discrete-var fallback so one URL rules everywhere.
+app_db_env() {
+  echo "DB_HOST=localhost"
+  echo "DB_PORT=$(app_pg_port)"
+  echo "DB_NAME=$(app_db_name)"
+  echo "DB_USER=${APP_PG_USER}"
+  echo "DB_PASSWORD=${APP_PG_PASSWORD}"
+}
+
+# ── Snapshot load filter ─────────────────────────────────────────────────────
+# Managed-Postgres dumps carry directives a vanilla local Postgres chokes on,
+# so bin/setup pipes every snapshot through this hook. Identity by default:
+# a plain pg_dump needs no filtering, and an UNDEFINED function here aborts
+# `bin/setup <snapshot>` with a bare "command not found" (exit 127).
+# Override per provider — Cloud SQL (see snapshots.md):
+#   app_strip_snapshot() { grep -v -E '^\\(restrict|unrestrict) |cloudsqlsuperuser'; }
+app_strip_snapshot() {
+  cat
+}
+
+# ── Shared Postgres container ────────────────────────────────────────────────
+ensure_postgres() {
+  local container="$APP_CONTAINER_NAME" port
+  port="$(app_pg_port)"
+  if docker inspect "$container" &>/dev/null; then
+    if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
+      echo "Starting existing postgres container..." >&2
+      docker start "$container" >/dev/null
+    fi
+  else
+    echo "Creating postgres container on port ${port}..." >&2
+    docker run -d \
+      --name "$container" \
+      -p "${APP_PG_BIND:-127.0.0.1}:${port}:5432" \
+      -e POSTGRES_USER="$APP_PG_USER" \
+      -e POSTGRES_PASSWORD="$APP_PG_PASSWORD" \
+      -e POSTGRES_DB=app \
+      -v "${APP_VOLUME_NAME}:${APP_PG_DATA_DIR}" \
+      "$APP_PG_IMAGE" >/dev/null
+  fi
+  wait_for_postgres
+}
+
+wait_for_postgres() {
+  local container="$APP_CONTAINER_NAME" attempts=0
+  while ! docker exec "$container" pg_isready -U "$APP_PG_USER" -q 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "ERROR: postgres did not become ready after 30 seconds" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+# psql inside the container — no host psql needed. Default DB = maintenance 'postgres'.
+app_psql() {
+  docker exec -i "$APP_CONTAINER_NAME" psql -U "$APP_PG_USER" "$@"
+}
+
+app_ensure_db() {
+  local db="$1" exists
+  exists="$(app_psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '${db}'" 2>/dev/null || true)"
+  if [ "$exists" != "1" ]; then
+    echo "Creating database ${db}..." >&2
+    app_psql -d postgres -c "CREATE DATABASE ${db} OWNER ${APP_PG_USER}" >/dev/null
+  fi
+}
+
+app_recreate_db() {
+  local db="$1"
+  app_psql -d postgres -c "
+    SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+    WHERE datname = '${db}' AND pid <> pg_backend_pid()
+  " >/dev/null 2>&1 || true
+  echo "Dropping database ${db}..." >&2
+  app_psql -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null
+  echo "Creating database ${db}..." >&2
+  app_psql -d postgres -c "CREATE DATABASE ${db} OWNER ${APP_PG_USER}" >/dev/null
+}
+
+# Run migrations against a DATABASE_URL. PROJECT-SPECIFIC — see migrations-and-seeds.md.
+app_migrate() {
+  local url="$1"
+  echo "Running migrations..." >&2
+  (cd "$(app_server_dir)" && DATABASE_URL="$url" bun run db:migrate) >&2
+}
+
+# ── Per-context port picking ─────────────────────────────────────────────────
+# CRITICAL (see gotchas.md): use lsof on macOS, ss on Linux. `ss` does NOT exist
+# on macOS and fails *silently* — without this split every port reads "free" and
+# concurrent worktrees all collide on the same port. If neither tool exists,
+# assume "in use" so we skip rather than double-bind.
+port_in_use() {
+  if command -v lsof &>/dev/null; then
+    lsof -iTCP:"$1" -sTCP:LISTEN -P -n &>/dev/null
+  elif command -v ss &>/dev/null; then
+    ss -tlnp 2>/dev/null | grep -q ":$1 "
+  else
+    return 0
+  fi
+}
+
+# First free port in [start, end].
+find_available_port() {
+  local start="$1" end="$2" port
+  for port in $(seq "$start" "$end"); do
+    if ! port_in_use "$port"; then
+      echo "$port"
+      return
+    fi
+  done
+  echo "ERROR: no available port in range ${start}-${end}" >&2
+  return 1
+}
+
+# The backend port for this context. Always scans FROM the default so the main
+# port is reused when free (not skipped on worktree identity); collisions are
+# detected by real listen-state. Override with PORT.
+app_pick_port() {
+  if [ -n "${PORT:-}" ]; then echo "$PORT"; return; fi
+  if ! port_in_use 4000; then echo "4000"; return; fi
+  find_available_port 4001 4099
+}
+
+# The frontend (Vite) port — used by the fullstack dev variant; harmless to
+# keep in single-service repos. Override with VITE_PORT.
+app_pick_vite_port() {
+  if [ -n "${VITE_PORT:-}" ]; then echo "$VITE_PORT"; return; fi
+  if ! port_in_use 4100; then echo "4100"; return; fi
+  find_available_port 4101 4199
+}
+
+# Multi-process backends: a worktree may run SEVERAL processes (HTTP API + gRPC
+# service + Vite, …). Add one picker PER PROCESS KIND, each with a DISJOINT range
+# inside the project's band (e.g. HTTP 4000-4049, gRPC 4050-4099, Vite 4100-4199 —
+# shrink app_pick_port's range to match), and have bin/setup emit every derived
+# port plus the wiring vars between them (e.g. ORCHESTRATOR_URL). Readiness note:
+# gRPC ports aren't curl-checkable — probe with a plain TCP check, e.g.
+# `(exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null`.
+# app_pick_grpc_port() {
+#   if [ -n "${GRPC_PORT:-}" ]; then echo "$GRPC_PORT"; return; fi
+#   if ! port_in_use 4050; then echo "4050"; return; fi
+#   find_available_port 4051 4099
+# }
+
+# ── Dev session state (fullstack bin/dev singleton) ─────────────────────────
+# The fullstack bin/dev runs as a per-worktree SINGLETON. A running session
+# records itself in .dev/state.env (supervisor PID, child PIDs, chosen ports,
+# DATABASE_URL) and writes each service's output to .dev/logs/<service>.log.
+# These helpers are shared by bin/dev (attach/status/stop), bin/cleanup, and
+# bin/gc. Single-service repos (the plain `dev` template, which just execs)
+# don't use them — harmless to keep either way.
+#
+# The helpers assume the fullstack template's two children (SERVER + WEB) and
+# two ports (PORT + VITE_PORT). A stack with more processes only has to record
+# them in bin/dev as <NAME>_PID / <NAME>_PID_LSTART: the health check and the
+# stop sweep both DERIVE their child list from state.env (app_dev_child_keys),
+# so neither needs editing. Only the PORT list in app_dev_session_healthy is
+# still explicit, and deliberately so.
+
+app_dev_state_dir() { echo "$(app_root)/.dev"; }
+app_dev_state_file() { echo "$(app_dev_state_dir)/state.env"; }
+app_dev_log_dir() { echo "$(app_dev_state_dir)/logs"; }
+
+# ── PID identity ─────────────────────────────────────────────────────────────
+# A bare `kill -0 $pid` proves only that SOME process has that pid. state.env
+# survives a SIGKILLed supervisor and a reboot, and the OS recycles pids —
+# so every recorded pid is stored WITH its start time, and both the health
+# check and the stop path refuse to treat (or kill!) a recycled pid as ours.
+
+# Start time of a live process; empty when the pid is gone.
+app_pid_lstart() {
+  { ps -o lstart= -p "$1" 2>/dev/null || true; } | sed 's/^ *//;s/ *$//'
+}
+
+# True when $1 is alive AND is the exact process recorded as ($1, $2).
+# An empty recorded start time (state written by an older bin/dev) falls
+# back to plain liveness so in-flight sessions stay stoppable across the
+# upgrade.
+app_pid_is() {
+  local pid="$1" lstart="$2"
+  [ -n "$pid" ] || return 1
+  if [ -z "$lstart" ]; then
+    kill -0 "$pid" 2>/dev/null
+    return
+  fi
+  [ "$(app_pid_lstart "$pid")" = "$lstart" ]
+}
+
+# ── State reads ──────────────────────────────────────────────────────────────
+# Deliberately not `source`d: sourcing would clobber caller-provided env
+# overrides (PORT, VITE_PORT, ...) that the port pickers honor. The file can
+# vanish between any two reads (a dying supervisor's trap removes it), so
+# callers that need a COHERENT view take one app_dev_snapshot and read every
+# key from it — never a healthy-check against one read and an emit from
+# another.
+app_dev_snapshot() {
+  cat "$(app_dev_state_file)" 2>/dev/null || true
+}
+
+app_snap_get() {
+  printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -1
+}
+
+# One-off single-key read (no coherence needed). Empty when file is missing.
+app_dev_state_get() {
+  app_snap_get "$(app_dev_snapshot)" "$1"
+}
+
+# Healthy = the boot finished (PHASE=running), the supervisor and both
+# services are alive AND are the exact recorded processes (pid + start time),
+# and both ports are listening. Anything less is a half-dead stack that
+# should be torn down, not attached to — a dead backend behind a live
+# frontend port serves nothing but proxy errors, and a foreign listener on
+# our recorded port is someone else's stack, not ours.
+# Takes an optional snapshot; snapshots itself when not given one.
+app_dev_session_healthy() {
+  local snap="${1:-$(app_dev_snapshot)}"
+  local key port
+  [ -n "$snap" ] || return 1
+  [ "$(app_snap_get "$snap" PHASE)" = "running" ] || return 1
+  # Supervisor + every recorded child, derived from the state file (see
+  # app_dev_child_keys) so a stack that grows a process is covered here
+  # without a second list to keep in sync.
+  for key in DEV $(app_dev_child_keys "$snap"); do
+    app_pid_is "$(app_snap_get "$snap" "${key}_PID")" \
+      "$(app_snap_get "$snap" "${key}_PID_LSTART")" || return 1
+  done
+  # Ports stay EXPLICIT: which ports must be listening for the stack to be
+  # "up" is a real per-project assertion, and state.env also carries ports
+  # that are not liveness signals (an aux container's published port).
+  for key in PORT VITE_PORT; do
+    port="$(app_snap_get "$snap" "$key")"
+    [ -n "$port" ] || return 1
+    port_in_use "$port" || return 1
+  done
+}
+
+# Booting = state.env claimed (PHASE=booting) by a supervisor that is still
+# alive. Distinct from unhealthy: a boot in progress should be WAITED ON,
+# never torn down — the pre-state window (postgres ensure, migrate, seed) can
+# run 10+ seconds and would otherwise be indistinguishable from a half-dead
+# session.
+app_dev_session_booting() {
+  local snap="${1:-$(app_dev_snapshot)}"
+  [ -n "$snap" ] || return 1
+  [ "$(app_snap_get "$snap" PHASE)" = "booting" ] || return 1
+  app_pid_is "$(app_snap_get "$snap" DEV_PID)" "$(app_snap_get "$snap" DEV_PID_LSTART)"
+}
+
+# Every recorded child key in a snapshot — derived from the state file itself
+# (any KEY_PID=, minus the supervisor's own DEV_PID) rather than a hardcoded
+# list. The list used to be spelled out here AND in app_dev_session_healthy
+# AND in bin/dev's state writer; a stack that grew a third process had to
+# update all three, and forgetting the one here orphaned that process on every
+# stop while both other lists looked correct.
+app_dev_child_keys() {
+  printf '%s\n' "$1" | sed -n 's/^\([A-Z0-9_]*\)_PID=.*/\1/p' | grep -vx 'DEV' || true
+}
+
+# Signal one recorded (pid, lstart) pair by process GROUP and wait for it to
+# die. bin/dev runs under `set -m`, so each child leads its own group and the
+# group kill takes grandchildren (bun run → vite) down too; plain pid is the
+# fallback for pre-`set -m` state. Returns 0 when the process is gone.
+app_kill_wait() {
+  local pid="$1" lstart="$2" sig="$3" deadline="$4" i
+  app_pid_is "$pid" "$lstart" || return 0
+  kill -"$sig" -- -"$pid" 2>/dev/null || kill -"$sig" "$pid" 2>/dev/null || true
+  for i in $(seq 1 "$deadline"); do
+    app_pid_is "$pid" "$lstart" || return 0
+    sleep 0.2
+  done
+  ! app_pid_is "$pid" "$lstart"
+}
+
+# Stop the recorded session: TERM the supervisor (its signal-aware EXIT trap
+# kills each child's process group), then sweep anything that outlived it
+# (e.g. a SIGKILLed supervisor). Every kill is identity-checked — a recycled
+# pid is never signalled — and every TERM ESCALATES to KILL for anything that
+# ignores or is too slow to handle it. Also stops legacy .dev.pid-only
+# sessions from the pre-singleton fullstack template.
+#
+# Returns non-zero when something survived even SIGKILL, and in that case
+# DELIBERATELY LEAVES state.env in place: the file is the only record of the
+# survivor's pid + start time, and deleting it turns a findable orphan into an
+# untraceable process holding a port and a database open. A later bin/dev or
+# bin/cleanup re-reads it and retries the kill. Silent when nothing is running.
+app_dev_stop() {
+  local snap state pid lstart child clstart key survivors
+  state="$(app_dev_state_file)"
+  # Snapshot everything up front: the supervisor's own EXIT trap removes
+  # state.env, so it can vanish the moment the kill below lands.
+  snap="$(app_dev_snapshot)"
+  survivors=""
+  if [ -n "$snap" ]; then
+    pid="$(app_snap_get "$snap" DEV_PID)"
+    lstart="$(app_snap_get "$snap" DEV_PID_LSTART)"
+    if app_pid_is "$pid" "$lstart"; then
+      echo "Stopping dev session (PID ${pid})..." >&2
+      # 10s for the supervisor's trap to unwind its children gracefully.
+      if ! app_kill_wait "$pid" "$lstart" TERM 50; then
+        echo "bin/dev: supervisor ${pid} ignored SIGTERM — escalating to SIGKILL" >&2
+        app_kill_wait "$pid" "$lstart" KILL 25 || survivors="${survivors} DEV(${pid})"
+      fi
+    fi
+    # Sweep every recorded child that outlived the supervisor.
+    for key in $(app_dev_child_keys "$snap"); do
+      child="$(app_snap_get "$snap" "${key}_PID")"
+      clstart="$(app_snap_get "$snap" "${key}_PID_LSTART")"
+      app_pid_is "$child" "$clstart" || continue
+      if ! app_kill_wait "$child" "$clstart" TERM 25; then
+        echo "bin/dev: ${key} (PID ${child}) ignored SIGTERM — escalating to SIGKILL" >&2
+        app_kill_wait "$child" "$clstart" KILL 25 || survivors="${survivors} ${key}(${child})"
+      fi
+    done
+    if [ -n "$survivors" ]; then
+      echo "bin/dev: ERROR: survived SIGKILL:${survivors}" >&2
+      echo "bin/dev: keeping $(app_dev_state_file) so these stay identifiable" >&2
+      return 1
+    fi
+    rm -f "$state"
+  fi
+  local legacy
+  legacy="$(app_root)/.dev.pid"
+  if [ -f "$legacy" ]; then
+    pid="$(cat "$legacy" 2>/dev/null || true)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      echo "Stopping legacy dev session (PID ${pid})..." >&2
+      # The legacy supervisor traps only EXIT — a bare TERM kills it without
+      # its `kill 0` trap ever running, orphaning its children. When it
+      # leads its own process group (interactive launches), kill the whole
+      # group; only then is -$pid guaranteed to be ITS group and nobody else's.
+      if [ "$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')" = "$pid" ]; then
+        kill -- -"$pid" 2>/dev/null || true
+      else
+        kill "$pid" 2>/dev/null || true
+      fi
+    fi
+    rm -f "$legacy"
+  fi
+  return 0
+}

--- a/.agents/skills/agent-dev-workflow/references/bin/cleanup
+++ b/.agents/skills/agent-dev-workflow/references/bin/cleanup
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Drop this worktree's database (leaves the shared container running for others).
+# Refuses to drop the canonical main-worktree DB unless forced. Also stops a
+# `bin/dev` session left running in this worktree.
+#
+# Usage:
+#   bin/cleanup            # drop this worktree's derived DB
+#   bin/cleanup --force    # allow dropping the canonical dev DB
+#
+# Env overrides: APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# Stop any bin/dev session recorded for this worktree first (state.env
+# sessions and legacy .dev.pid ones alike). Single-service setups whose
+# bin/dev just execs in the foreground can omit this block.
+#
+# Abort if anything survived SIGKILL: that process still holds connections to
+# the database we are about to drop, so the DROP would fail anyway ("database
+# is being accessed by other users") — and if it somehow won the race, we'd be
+# pulling storage out from under a live process. app_dev_stop leaves state.env
+# in place on this path, so the survivor stays identifiable.
+if ! app_dev_stop; then
+  echo "Refusing to drop ${db:-the database}: a dev process survived shutdown (see above)." >&2
+  exit 1
+fi
+
+db="$(app_db_name)"
+if [ "$db" = "app" ] && [ "${1:-}" != "--force" ]; then
+  echo "Refusing to drop the canonical dev database. Use bin/reset-db, or --force." >&2
+  exit 1
+fi
+
+app_psql -d postgres -c "
+  SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+  WHERE datname = '${db}' AND pid <> pg_backend_pid()
+" >/dev/null 2>&1 || true
+app_psql -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null
+echo "Dropped database ${db}" >&2

--- a/.agents/skills/agent-dev-workflow/references/bin/db
+++ b/.agents/skills/agent-dev-workflow/references/bin/db
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run SQL against this context's database, or open an interactive psql shell.
+#
+# Usage:
+#   bin/db "SELECT count(*) FROM users"
+#   echo "SELECT 1" | bin/db
+#   bin/db                       # interactive shell
+#
+# Env overrides: APP_DATABASE, APP_PG_PORT.
+# (Some projects name this script `bin/query` — same thing.)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+db="$(app_db_name)"
+
+if [ $# -gt 0 ]; then
+  app_psql -d "$db" -c "$1"
+elif [ ! -t 0 ]; then
+  app_psql -d "$db"        # piped stdin
+else
+  docker exec -it "$APP_CONTAINER_NAME" psql -U "$APP_PG_USER" -d "$db"
+fi

--- a/.agents/skills/agent-dev-workflow/references/bin/dev
+++ b/.agents/skills/agent-dev-workflow/references/bin/dev
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Start the backend dev server with an auto-derived DATABASE_URL on a free port.
+#
+# This is the SINGLE-SERVICE variant (backend only) — correct when the frontend
+# runs separately (e.g. a native/mobile app, or you start the web app yourself).
+# For a fullstack repo that should start backend + frontend together and kill both
+# on exit, use the dev-fullstack template instead.
+#
+# Env overrides: DATABASE_URL, PORT, APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  ensure_postgres
+  DATABASE_URL="$(app_database_url)"
+fi
+
+PORT="$(app_pick_port)"
+
+echo "Backend:      http://localhost:${PORT}" >&2
+echo "DATABASE_URL: ${DATABASE_URL}" >&2
+
+cd "$(app_server_dir)"
+exec env DATABASE_URL="$DATABASE_URL" PORT="$PORT" bun run dev

--- a/.agents/skills/agent-dev-workflow/references/bin/dev-fullstack
+++ b/.agents/skills/agent-dev-workflow/references/bin/dev-fullstack
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# FULLSTACK variant: run the dev stack (backend + frontend) as a per-worktree
+# SINGLETON session with on-disk logs and one-dies-all-die supervision. Save as
+# `bin/dev` in a repo where one command should run the whole stack (e.g.
+# Fastify + Vite). Picks a free port for each service so concurrent worktrees
+# don't collide (see bin/_common.sh's port-band claim). Protocol ported from
+# the open-source continuous-gtfs repo's bin/dev (its PR #290) — copy the
+# mechanics verbatim, adapt only the service list.
+#
+#   bin/dev [--restart]
+#       Start the stack — or, if a healthy session is already running for
+#       this worktree, report its endpoints and exit 0 instead of starting a
+#       second one. A session still BOOTING (another bin/dev's pre-flight:
+#       postgres ensure, migrate) is waited on and then attached, never torn
+#       down. Attaching refuses (exit 2) when the running session doesn't
+#       match what was asked for — explicit DATABASE_URL/PORT/VITE_PORT
+#       overrides the session wasn't started with. A stale or half-dead
+#       session (any child gone, recycled pids) is torn down and replaced.
+#       --restart bounces whatever is there.
+#   bin/dev status
+#       Health-checked KEY=VALUE contract on stdout.
+#       Exit: 0 running / 1 stopped / 2 unhealthy / 3 starting.
+#   bin/dev stop
+#       Stop the recorded session (from any terminal).
+#   bin/dev logs [server|web]
+#       Follow the session logs (both interleaved when no service given).
+#
+# Session state lives in .dev/ (gitignore it): state.env records the
+# supervisor + child PIDs and the chosen ports; logs/<service>.log holds each
+# service's full output — fresh per session, kept after exit for
+# post-mortems. If any child exits, the whole stack tears down loudly — never
+# a half-dead session serving proxy errors from still-bound ports.
+#
+# Env overrides: DATABASE_URL, PORT, VITE_PORT, HOST, APP_DATABASE,
+# APP_PG_PORT, APP_DEV_LOG_CAP_BYTES.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+root="$(app_root)"
+
+# KEY=VALUE contract for the recorded session (stdout — human text goes to
+# stderr, same split as bin/setup, so orchestrators can capture just these).
+# Reads from one snapshot ($1) — never the live file, which a dying
+# supervisor's trap can remove between the health check and these reads,
+# yielding STATUS=running with empty values.
+emit_session() {
+  local snap="$1" key
+  for key in DEV_PID DATABASE_URL PORT VITE_PORT; do
+    echo "${key}=$(app_snap_get "$snap" "$key")"
+  done
+  echo "LOG_DIR=$(app_dev_log_dir)"
+}
+
+# ── Subcommands ────────────────────────────────────────────────────────────
+case "${1:-}" in
+  status)
+    snap="$(app_dev_snapshot)"
+    if app_dev_session_healthy "$snap"; then
+      echo "STATUS=running"
+      emit_session "$snap"
+      echo "Dev session healthy (PID $(app_snap_get "$snap" DEV_PID)); logs: $(app_dev_log_dir)/" >&2
+      exit 0
+    fi
+    if app_dev_session_booting "$snap"; then
+      echo "STATUS=starting"
+      echo "DEV_PID=$(app_snap_get "$snap" DEV_PID)"
+      echo "LOG_DIR=$(app_dev_log_dir)"
+      echo "Dev session is starting (PID $(app_snap_get "$snap" DEV_PID)) — re-check shortly, or run 'bin/dev' to wait for it and attach." >&2
+      exit 3
+    fi
+    if [ -n "$snap" ] || [ -f "$root/.dev.pid" ]; then
+      echo "STATUS=unhealthy"
+      echo "Recorded session is not fully up — 'bin/dev' (or --restart) will replace it; 'bin/dev stop' clears it." >&2
+      exit 2
+    fi
+    echo "STATUS=stopped"
+    echo "No dev session running in this worktree." >&2
+    exit 1
+    ;;
+  stop)
+    app_dev_stop
+    exit 0
+    ;;
+  logs)
+    log_dir="$(app_dev_log_dir)"
+    svc="${2:-}"
+    if [ -n "$svc" ]; then
+      if [ ! -f "$log_dir/$svc.log" ]; then
+        echo "bin/dev logs: no log for '$svc' (expected: server, web)" >&2
+        exit 2
+      fi
+      exec tail -n 100 -F "$log_dir/$svc.log"
+    fi
+    if [ ! -d "$log_dir" ]; then
+      echo "bin/dev logs: no session logs yet — start one with bin/dev" >&2
+      exit 2
+    fi
+    exec tail -n 30 -F "$log_dir/server.log" "$log_dir/web.log"
+    ;;
+esac
+
+# ── Args (start mode) ──────────────────────────────────────────────────────
+RESTART=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --restart) RESTART=1; shift ;;
+    *) echo "bin/dev: unknown argument '$1' (subcommands: status, stop, logs)" >&2; exit 2 ;;
+  esac
+done
+
+# Explicit caller overrides, captured BEFORE the pickers fill defaults — the
+# attach path must refuse a session that wasn't started with them, instead of
+# exiting 0 with settings the caller didn't ask for.
+req_DATABASE_URL="${DATABASE_URL:-}"
+req_PORT="${PORT:-}"
+req_VITE_PORT="${VITE_PORT:-}"
+
+# ── Singleton check ────────────────────────────────────────────────────────
+# One session per worktree. A healthy running session (no --restart) is
+# reported and reused — a second terminal or a coding agent should attach to
+# it (read .dev/logs/, hit the recorded ports), not race it. A session still
+# booting is waited on, then attached. Anything less — half-dead stack, stale
+# state, legacy pidfile — is torn down before starting fresh.
+if [ "$RESTART" = 0 ]; then
+  snap="$(app_dev_snapshot)"
+  if app_dev_session_booting "$snap"; then
+    echo "A dev session is already starting here (PID $(app_snap_get "$snap" DEV_PID)) — waiting to attach..." >&2
+    for i in $(seq 1 120); do
+      sleep 1
+      snap="$(app_dev_snapshot)"
+      app_dev_session_booting "$snap" || break
+    done
+    if app_dev_session_booting "$snap"; then
+      echo "bin/dev: session PID $(app_snap_get "$snap" DEV_PID) has been booting for over 2 minutes — check $(app_dev_log_dir)/, or replace it with 'bin/dev --restart'." >&2
+      exit 2
+    fi
+  fi
+  if app_dev_session_healthy "$snap"; then
+    # Never silently attach across an explicit env-override mismatch: a
+    # session on other settings is not the session that was asked for.
+    mismatch=0
+    for key in DATABASE_URL PORT VITE_PORT; do
+      eval "requested=\"\$req_${key}\""
+      recorded="$(app_snap_get "$snap" "$key")"
+      if [ -n "$requested" ] && [ "$requested" != "$recorded" ]; then
+        [ "$mismatch" = 0 ] && echo "bin/dev: a healthy session is already running with different settings" >&2
+        echo "  ${key}: running ${recorded:-<unset>}, requested ${requested}" >&2
+        mismatch=1
+      fi
+    done
+    if [ "$mismatch" = 1 ]; then
+      echo "Replace it with: bin/dev --restart (same env), or unset the overrides to attach." >&2
+      exit 2
+    fi
+    echo "Dev session already running for this worktree (PID $(app_snap_get "$snap" DEV_PID)) — reusing it." >&2
+    echo "Logs: $(app_dev_log_dir)/ · follow with 'bin/dev logs' · bounce with 'bin/dev --restart'" >&2
+    echo "STATUS=running"
+    emit_session "$snap"
+    exit 0
+  fi
+fi
+if [ -n "$(app_dev_snapshot)" ] || [ -f "$root/.dev.pid" ]; then
+  if [ "$RESTART" = 0 ]; then
+    echo "Previous dev session is stale or half-dead — cleaning it up before starting." >&2
+  fi
+  app_dev_stop
+fi
+
+# ── Claim the singleton ────────────────────────────────────────────────────
+# Atomic exclusive create (noclobber) of state.env, BEFORE the slow pre-boot
+# work — otherwise two concurrent bin/devs both pass the checks above during
+# the pre-state window and boot duplicate stacks. PHASE stays "booting" until
+# the services are up and the full state is written; status/attach treat that
+# phase as wait-don't-touch.
+mkdir -p "$(app_dev_state_dir)"
+state_file="$(app_dev_state_file)"
+if ! (set -C; {
+  echo "PHASE=booting"
+  echo "DEV_PID=$$"
+  echo "DEV_PID_LSTART=$(app_pid_lstart $$)"
+} >"$state_file") 2>/dev/null; then
+  echo "bin/dev: lost the singleton race — another bin/dev claimed this worktree just now. Re-run bin/dev to wait for it and attach." >&2
+  exit 2
+fi
+
+# From claim to exit, this session owns cleanup. Installed before the slow
+# pre-boot work so a failed/interrupted boot releases the claim. The INT/TERM
+# traps convert those signals into a normal exit so the EXIT trap actually
+# runs — an untrapped fatal signal would skip it (exactly how 'bin/dev stop'
+# and bin/cleanup would otherwise leave the claim and half-dead stacks
+# behind). Logs are deliberately kept.
+cleanup() {
+  # Ownership check: a slow-dying replaced supervisor must not delete the
+  # record of the session that took over (which would leave the new stack
+  # running untracked — unstoppable by bin/dev stop / bin/cleanup).
+  if [ "$(app_dev_state_get DEV_PID)" = "$$" ]; then
+    rm -f "$state_file"
+  fi
+  # Kill each child's own process group (see `set -m` below) — deliberately
+  # NOT `kill 0`: the caller of 'bin/dev stop'/bin/cleanup shares this
+  # script's group when both were launched from the same non-interactive
+  # shell, and kill 0 would take the caller down mid-cleanup.
+  local p
+  for p in "${server_pid:-}" "${web_pid:-}" "${tail_pid:-}"; do
+    if [ -n "$p" ]; then
+      kill -- -"$p" 2>/dev/null || kill "$p" 2>/dev/null || true
+    fi
+  done
+  return 0
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  ensure_postgres
+  # Ensure the database exists even when bin/setup hasn't run in this
+  # worktree — ensure-then-boot makes bin/dev standalone rather than
+  # crashing on a missing database.
+  app_ensure_db "$(app_db_name)"
+  DATABASE_URL="$(app_database_url)"
+fi
+
+PORT="$(app_pick_port)"
+VITE_PORT="$(app_pick_vite_port)"
+
+# If the app does NOT run migrations itself on boot, run them here — the
+# singleton is already claimed (PHASE=booting), so a concurrent bin/dev
+# waits on this instead of racing it:
+# app_migrate "$DATABASE_URL"
+
+log_dir="$(app_dev_log_dir)"
+mkdir -p "$log_dir"
+: >"$log_dir/server.log"
+: >"$log_dir/web.log"
+
+echo "Backend:      http://localhost:${PORT}" >&2
+echo "Frontend:     http://localhost:${VITE_PORT}" >&2
+echo "DATABASE_URL: ${DATABASE_URL}" >&2
+echo "Logs:         ${log_dir}/ (follow from elsewhere: bin/dev logs)" >&2
+
+# Children: `exec` so $! is the real service process (recorded in state.env
+# for app_dev_stop's orphan sweep); output goes to the log files only — the
+# tail below streams the combined view to this terminal, so interactive
+# behavior is unchanged while agents and post-mortems read the files.
+#
+# set -m: each background child becomes its OWN process-group leader, so
+# cleanup/app_dev_stop can `kill -- -pid` a service's whole subtree (bun run →
+# vite) without signalling this script's inherited group, which the caller of
+# 'bin/dev stop' can share. disown (below) drops them from the job table so
+# job-control status lines don't pollute stderr; kill -0 monitoring is
+# pid-based and unaffected.
+set -m
+
+# Backend. HOST defaults to LOOPBACK — widen to 0.0.0.0 only deliberately (LAN /
+# mobile-device testing), and NEVER while a dev-auth bypass is active: an
+# AUTH_DISABLED-style mode that treats every request as admin is only safe
+# because it's loopback-contained. Don't export 0.0.0.0 unconditionally.
+( cd "$(app_server_dir)" && exec env DATABASE_URL="$DATABASE_URL" PORT="$PORT" \
+  HOST="${HOST:-127.0.0.1}" bun run dev >>"$log_dir/server.log" 2>&1 ) &
+server_pid=$!
+
+# Repos with N backend processes per worktree (e.g. gRPC service + HTTP
+# gateway): start each the same way — own picker, own log file, own
+# <NAME>_PID + <NAME>_PID_LSTART in the state write below, and add it to the
+# health-check/stop key lists in _common.sh. Thread the wiring env into
+# dependents (e.g. ORCHESTRATOR_URL="localhost:${GRPC_PORT}").
+
+# Frontend — proxy to the actual backend port (important for non-default
+# worktree ports). Convention: name the var VITE_API_TARGET (the vite config
+# reads it to set server.proxy) rather than a bare API_TARGET. Proxy /auth as
+# well as /api when dev session cookies ride the proxy — a /api-only proxy
+# silently breaks login.
+( cd "$root/<web-subdir>" && exec env VITE_PORT="$VITE_PORT" \
+  VITE_API_TARGET="http://localhost:${PORT}" bun run dev >>"$log_dir/web.log" 2>&1 ) &
+web_pid=$!
+
+# Combined live stream for this terminal (-q: no per-file headers — the
+# per-service files are the labeled view).
+tail -q -n +1 -F "$log_dir/server.log" "$log_dir/web.log" 2>/dev/null &
+tail_pid=$!
+disown -a
+set +m
+
+# Hold PHASE=booting until both ports actually listen — there's a real window
+# where every process is alive but nothing is bound yet (deps loading, the app
+# self-migrating), and "running" must mean attachable (the health check that
+# status/attach run against this file checks the ports). A child dying during
+# the wait aborts the boot loudly instead.
+boot_ready=0
+for i in $(seq 1 120); do
+  boot_ready=1
+  for port in "$PORT" "$VITE_PORT"; do
+    if ! port_in_use "$port"; then
+      boot_ready=0
+      break
+    fi
+  done
+  if [ "$boot_ready" = 1 ]; then
+    break
+  fi
+  for entry in "server:${server_pid}" "web:${web_pid}"; do
+    if ! kill -0 "${entry##*:}" 2>/dev/null; then
+      echo "bin/dev: ${entry%%:*} exited during startup (see ${log_dir}/${entry%%:*}.log)" >&2
+      exit 1
+    fi
+  done
+  sleep 1
+done
+if [ "$boot_ready" != 1 ]; then
+  echo "bin/dev: services did not bind their ports within 2 minutes — tearing down (see ${log_dir}/)" >&2
+  exit 1
+fi
+
+# Full state, atomically replacing the PHASE=booting claim (write-then-mv so
+# a concurrent status/attach never reads a half-written file). Every pid is
+# recorded with its start time — the identity that keeps stale state from
+# ever matching (or killing) a recycled pid.
+{
+  echo "PHASE=running"
+  echo "DEV_PID=$$"
+  echo "DEV_PID_LSTART=$(app_pid_lstart $$)"
+  echo "DATABASE_URL=${DATABASE_URL}"
+  echo "PORT=${PORT}"
+  echo "VITE_PORT=${VITE_PORT}"
+  echo "SERVER_PID=${server_pid}"
+  echo "SERVER_PID_LSTART=$(app_pid_lstart "$server_pid")"
+  echo "WEB_PID=${web_pid}"
+  echo "WEB_PID_LSTART=$(app_pid_lstart "$web_pid")"
+  echo "TAIL_PID=${tail_pid}"
+  echo "TAIL_PID_LSTART=$(app_pid_lstart "$tail_pid")"
+  echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$state_file.tmp"
+mv "$state_file.tmp" "$state_file"
+
+# ── Supervise: one dies → all die, loudly ──────────────────────────────────
+# A plain `wait` here is exactly how half-dead stacks happen: one child
+# crashes and the other keeps serving errors from a bound port. Poll instead
+# (`wait -n` needs bash ≥ 4.3; macOS ships 3.2) and name the corpse.
+#
+# The same loop caps log growth for long-lived sessions (checked every ~60s):
+# past APP_DEV_LOG_CAP_BYTES (default 20 MB ≈ days of local noise) the last
+# half is kept in <service>.log.old and the live file is truncated IN PLACE —
+# safe because the children write with O_APPEND (>>), so their next write
+# lands at the new EOF, and the terminal's tail -F follows truncation. Lines
+# written between the tail-copy and the truncate are dropped; for dev logs
+# that sliver is acceptable.
+log_cap_bytes="${APP_DEV_LOG_CAP_BYTES:-20971520}"
+log_keep_bytes=$((log_cap_bytes / 2))
+tick=0
+while true; do
+  sleep 2
+  for entry in "server:${server_pid}" "web:${web_pid}"; do
+    if ! kill -0 "${entry##*:}" 2>/dev/null; then
+      name="${entry%%:*}"
+      echo "" >&2
+      echo "bin/dev: ${name} exited — tearing down the stack (see ${log_dir}/${name}.log)" >&2
+      exit 1
+    fi
+  done
+  tick=$((tick + 1))
+  if [ $((tick % 30)) -eq 0 ]; then
+    for name in server web; do
+      f="$log_dir/${name}.log"
+      size="$(wc -c <"$f" 2>/dev/null || echo 0)"
+      if [ "$size" -gt "$log_cap_bytes" ]; then
+        tail -c "$log_keep_bytes" "$f" >"${f}.old"
+        : >"$f"
+      fi
+    done
+  fi
+done

--- a/.agents/skills/agent-dev-workflow/references/bin/gc
+++ b/.agents/skills/agent-dev-workflow/references/bin/gc
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Sweep merged agent worktrees. Enumerates this repo's linked worktrees under
+# any */.claude/worktrees/ path (including nested registrations like
+# apps/web/.claude/worktrees/*), PROVES each one disposable, and for the
+# proven ones: stops any recorded bin/dev session, drops the derived
+# per-worktree database, removes the worktree, deletes the local branch, and
+# finally prunes stale remote-tracking refs. State-based, not event-based:
+# merged-ness is a property git can verify at any later time, so this runs
+# lazily — manually, or nudged at session start. Ported from the open-source
+# continuous-gtfs repo's bin/gc (its PRs #290/#293).
+#
+#   bin/gc            # sweep (applies by default)
+#   bin/gc --dry-run  # print the same verdicts; mutate nothing
+#   bin/gc --nudge    # SessionStart-hook mode: no fetch, no network, no
+#                     # mutation — cached refs + cheap gates only; prints one
+#                     # summary line when candidates exist, NOTHING when none
+#
+# Proof of disposability = ALL mandatory gates + AT LEAST ONE containment
+# proof. Containment is computed after a fresh `git fetch origin` (dry-run
+# fetches too — verdicts must never be read off a stale base ref; --nudge
+# alone skips the fetch):
+#
+#   Gates: not the main worktree; not the worktree gc is invoked from
+#   (fully-resolved path compare); clean working tree (no modifications, no
+#   untracked-unignored files); not locked; not a long-lived branch.
+#
+#   Containment (any one suffices):
+#     ancestry        — HEAD is an ancestor of the base ref
+#     patch-contained — every commit in <base>..HEAD reports `-` from
+#                       `git cherry` (catches PRs rebased remotely pre-merge)
+#     merged PR       — `gh pr list --head <branch> --state merged` hits
+#                       (catches squash merges, where patch-ids break).
+#                       Best-effort: silently unavailable when gh is missing
+#                       or errors. Never consulted for closed-unmerged PRs.
+#
+# Anything unproven is skipped with a one-line reason. Exit 0 either way.
+# Never touches the canonical main-worktree database, stashes (repo-global,
+# not attributable to a worktree), or remote branches (GitHub deletes those
+# on merge).
+#
+# Env overrides: APP_PG_PORT, APP_GC_BASE_REF.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# The ref merges land on — containment is proven against THIS. Set it to the
+# repo's integration branch: origin/main by default; export (or hard-code)
+# APP_GC_BASE_REF=origin/develop in repos that integrate on develop.
+base_ref="${APP_GC_BASE_REF:-origin/main}"
+
+usage() { echo "usage: bin/gc [--dry-run|--nudge]"; }
+
+mode="apply"
+case "${1:-}" in
+  "") ;;
+  --dry-run) mode="dry" ;;
+  --nudge) mode="nudge" ;;
+  -h|--help) usage; exit 0 ;;
+  *)
+    echo "bin/gc: unknown argument '$1'" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+# Fully-resolved physical path (macOS has no realpath pre-Ventura).
+gc_resolve() { (cd "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"; }
+
+# Anchor every repo-level git command on the script's own worktree — cwd may
+# be anywhere (the SessionStart hook runs from the project dir; a human may
+# run this from an unrelated directory).
+self_root="$(gc_resolve "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)")"
+main_root="$(gc_resolve "$(git -C "$self_root" worktree list --porcelain | head -1 | sed 's/^worktree //')")"
+# The worktree gc is invoked FROM can differ from the one it lives in (e.g.
+# running another worktree's bin/gc). Exclude both.
+invoke_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$invoke_root" ]; then
+  invoke_root="$(gc_resolve "$invoke_root")"
+fi
+
+# The one database this tool must never be able to drop.
+canonical_db="$(app_db_name_for_root "$main_root")"
+
+# Verdict lines (stdout). --nudge stays silent per-worktree — it only counts.
+report() { [ "$mode" = "nudge" ] || echo "$*"; }
+
+if [ "$mode" != "nudge" ]; then
+  if ! git -C "$self_root" fetch origin --quiet; then
+    # Stale refs can only UNDER-prove (the base ref moves forward), never
+    # over-prove — safe to continue, but say so.
+    echo "bin/gc: warning: git fetch origin failed — verdicts computed against cached refs" >&2
+  fi
+fi
+
+if ! git -C "$self_root" rev-parse --verify --quiet "$base_ref" >/dev/null; then
+  [ "$mode" = "nudge" ] || echo "bin/gc: ${base_ref} not found — nothing can be proven" >&2
+  exit 0
+fi
+
+# ── Enumerate linked worktrees ──────────────────────────────────────────────
+# Parse `git worktree list --porcelain` records into tab-separated lines
+# (path, branch, locked, prunable) — bash 3.2: no mapfile, no assoc arrays.
+records=""
+rec_wt="" rec_br="" rec_locked=0 rec_prunable=0
+gc_flush_record() {
+  if [ -n "$rec_wt" ]; then
+    records="${records}${rec_wt}"$'\t'"${rec_br}"$'\t'"${rec_locked}"$'\t'"${rec_prunable}"$'\n'
+  fi
+  rec_wt="" rec_br="" rec_locked=0 rec_prunable=0
+}
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) gc_flush_record; rec_wt="${line#worktree }" ;;
+    "branch refs/heads/"*) rec_br="${line#branch refs/heads/}" ;;
+    locked*) rec_locked=1 ;;
+    prunable*) rec_prunable=1 ;;
+  esac
+done < <(git -C "$self_root" worktree list --porcelain)
+gc_flush_record
+
+# ── Evaluate + act ──────────────────────────────────────────────────────────
+candidates=0
+nudge_count=0
+removed_any=0
+
+# The record stream rides fd 3, NOT stdin: commands inside the loop
+# (docker exec -i via app_psql, gh) read stdin and would silently slurp the
+# remaining records after the first removal — the rest of the sweep would
+# never happen.
+while IFS=$'\t' read -r -u 3 wt br locked prunable; do
+  [ -n "$wt" ] || continue
+  case "$wt" in
+    */.claude/worktrees/*) ;;
+    *) continue ;; # out of scope (includes the main worktree, structurally)
+  esac
+  candidates=$((candidates + 1))
+  rwt="$(gc_resolve "$wt")"
+  rel="${rwt#"$main_root"/}"
+
+  # Mandatory gates — all must hold before any containment proof is consulted.
+  if [ "$rwt" = "$main_root" ]; then
+    report "skipped ${rel}: main worktree"
+    continue
+  fi
+  if [ "$rwt" = "$self_root" ] || [ "$rwt" = "$invoke_root" ]; then
+    report "skipped ${rel}: current worktree (bin/gc invoked from it)"
+    continue
+  fi
+  if [ "$prunable" = 1 ] || [ ! -d "$rwt" ]; then
+    report "skipped ${rel}: directory missing (see 'git worktree prune')"
+    continue
+  fi
+  if [ "$locked" = 1 ]; then
+    report "skipped ${rel}: locked"
+    continue
+  fi
+  if [ -z "$br" ]; then
+    report "skipped ${rel}: detached HEAD"
+    continue
+  fi
+  # A long-lived branch checked out in an agent worktree is an anomaly, and
+  # the integration branch trivially proves ancestry-contained — without this
+  # gate the sweep would remove the worktree AND `git branch -D` it. Never
+  # evaluate one.
+  case "$br" in
+    main|master|develop)
+      report "skipped ${rel}: long-lived branch '${br}' checked out"
+      continue
+      ;;
+  esac
+  if ! dirty="$(git -C "$rwt" status --porcelain 2>/dev/null)"; then
+    report "skipped ${rel}: git status failed"
+    continue
+  fi
+  if [ -n "$dirty" ]; then
+    report "skipped ${rel}: dirty working tree (uncommitted or untracked files)"
+    continue
+  fi
+
+  # Containment proofs — any one suffices.
+  proof=""
+  if git -C "$rwt" merge-base --is-ancestor HEAD "$base_ref" 2>/dev/null; then
+    proof="ancestry: HEAD contained in ${base_ref}"
+  else
+    cherry="$(git -C "$rwt" cherry "$base_ref" HEAD 2>/dev/null)" || cherry="+ unavailable"
+    # Empty cherry output with failed ancestry proves nothing; require at
+    # least one commit, all reported `-` (patch present in the base ref).
+    if [ -n "$cherry" ] && ! printf '%s\n' "$cherry" | grep -q '^+'; then
+      proof="patch-contained: every ${base_ref}..HEAD commit already in ${base_ref} (git cherry)"
+    elif [ "$mode" != "nudge" ] && command -v gh >/dev/null 2>&1; then
+      # Best-effort gh layer (network) — never consulted in --nudge mode.
+      # `gh pr list --head` matches by branch NAME, so pin the merged PR's
+      # head OID to this worktree's HEAD before trusting it: a reused branch
+      # name carrying fresh commits (old merged PR, new unmerged work) must
+      # never prove anything. Costs a real case — a branch rebased remotely
+      # pre-merge no longer OID-matches its own PR and stays skipped — but
+      # in a deletion tool a false skip is noise, a false proof is data loss.
+      pr_line="$( (cd "$rwt" && gh pr list --head "$br" --state merged --limit 1 \
+        --json number,headRefOid --jq '.[] | "\(.number) \(.headRefOid)"') 2>/dev/null || true)"
+      if [ -n "$pr_line" ] && [ "${pr_line#* }" = "$(git -C "$rwt" rev-parse HEAD)" ]; then
+        proof="PR #${pr_line%% *} merged (head matches)"
+      fi
+    fi
+  fi
+  if [ -z "$proof" ]; then
+    report "skipped ${rel}: no containment proof (branch '${br}' not merged into ${base_ref})"
+    continue
+  fi
+
+  if [ "$mode" = "nudge" ]; then
+    nudge_count=$((nudge_count + 1))
+    continue
+  fi
+  if [ "$mode" = "dry" ]; then
+    echo "would remove ${rel} (${proof})"
+    continue
+  fi
+
+  # ── Apply ────────────────────────────────────────────────────────────────
+  echo "removing ${rel} (${proof})"
+
+  # Stop any recorded bin/dev session for THAT worktree: the session helpers
+  # compute paths from app_root of the current dir, so subshell-cd into it —
+  # the same way bin/dev's own children run.
+  (cd "$rwt" && app_dev_stop) || true
+
+  db="$(app_db_name_for_root "$rwt")"
+  # Structurally never the canonical DB (main worktree excluded above), but
+  # guard anyway — this tool must not be able to drop the canonical database.
+  if [ "$db" != "$canonical_db" ] &&
+    [ "$(docker inspect -f '{{.State.Running}}' "$APP_CONTAINER_NAME" 2>/dev/null || true)" = "true" ]; then
+    exists="$(app_psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '${db}'" 2>/dev/null || true)"
+    if [ "$exists" = "1" ]; then
+      app_psql -d postgres -c "
+        SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+        WHERE datname = '${db}' AND pid <> pg_backend_pid()
+      " >/dev/null 2>&1 || true
+      # A client reconnecting between the terminate and the drop (a user
+      # psql/GUI session — the worktree's own bin/dev is already stopped)
+      # makes DROP fail; under set -e an unguarded failure would abort the
+      # whole sweep mid-run, breaking the exit-0-either-way contract. Skip
+      # this worktree instead — the next sweep retries.
+      if ! app_psql -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null 2>&1; then
+        echo "skipped ${rel}: DROP DATABASE ${db} failed (still in use?) — retry next sweep"
+        continue
+      fi
+      echo "  dropped database ${db}"
+    fi
+  fi
+
+  # `git worktree remove` refusing (dirty/locked race since our check) is a
+  # feature — treat it as a skip, not an error.
+  if err="$(git -C "$self_root" worktree remove "$rwt" 2>&1)"; then
+    echo "  worktree removed"
+  else
+    echo "skipped ${rel}: git worktree remove refused (${err})"
+    continue
+  fi
+
+  # -D, not -d: a remotely-rebased-then-merged branch is not an ancestor of
+  # its own upstream, so plain -d refuses even though the PR merged.
+  if git -C "$self_root" branch -D "$br" >/dev/null 2>&1; then
+    echo "  branch ${br} deleted"
+  else
+    echo "  branch ${br} not deleted (already gone or checked out elsewhere)"
+  fi
+  removed_any=1
+done 3<<<"$records"
+
+if [ "$mode" = "nudge" ]; then
+  # One line when there is something to do; NOTHING when there isn't — this
+  # runs at every session start and must not pollute quiet ones.
+  if [ "$nudge_count" -gt 0 ]; then
+    echo "bin/gc: ${nudge_count} worktree(s) look merged — run bin/gc to sweep"
+  fi
+  exit 0
+fi
+
+if [ "$candidates" -eq 0 ]; then
+  echo "no agent worktrees found (nothing under */.claude/worktrees/)"
+fi
+
+if [ "$removed_any" = 1 ]; then
+  git -C "$self_root" remote prune origin >/dev/null 2>&1 || true
+  echo "pruned stale remote-tracking refs (git remote prune origin)"
+fi
+
+exit 0

--- a/.agents/skills/agent-dev-workflow/references/bin/reset-db
+++ b/.agents/skills/agent-dev-workflow/references/bin/reset-db
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Drop and recreate this context's database, then migrate (+ seed if the project seeds).
+#
+# Env overrides: APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+ensure_postgres
+db="$(app_db_name)"
+app_recreate_db "$db"
+app_migrate "$(app_database_url)"
+# Seeds, if any: app_psql -d "$db" < "$(app_server_dir)/seed.sql" >/dev/null 2>&1
+echo "Database ${db} reset complete" >&2

--- a/.agents/skills/agent-dev-workflow/references/bin/setup
+++ b/.agents/skills/agent-dev-workflow/references/bin/setup
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Ensure postgres + this context's database + deps + migrations. One-command
+# onboarding for a fresh checkout or worktree.
+#
+# Usage:
+#   bin/setup                       # empty DB + migrations (+ seed, if project seeds)
+#   bin/setup path/to/snapshot.sql  # load a snapshot first (see snapshots.md)
+#   bin/setup gs://bucket/x.sql     # load a GCS snapshot first (see snapshots.md)
+#
+# Status → stderr; machine-parseable env (KEY=VALUE) → stdout for orchestrators.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+snapshot="${1:-}"
+if [ -n "$snapshot" ] && [[ "$snapshot" != gs://* ]] && [ ! -f "$snapshot" ]; then
+  echo "ERROR: snapshot not found: $snapshot" >&2
+  exit 1
+fi
+
+echo "Installing tool versions (asdf)..." >&2
+(cd "$(app_root)" && asdf install) >&2 || echo "asdf install skipped/failed — continuing" >&2
+
+ensure_postgres
+
+db="$(app_db_name)"
+# A snapshot load wants a clean DB; otherwise just ensure it exists (preserve data).
+if [ -n "$snapshot" ]; then
+  app_recreate_db "$db"
+else
+  app_ensure_db "$db"
+fi
+
+if [ ! -d "$(app_server_dir)/node_modules" ]; then
+  echo "Installing dependencies..." >&2
+  (cd "$(app_server_dir)" && bun install --frozen-lockfile) >&2
+fi
+
+url="$(app_database_url)"
+if [ -n "$snapshot" ]; then
+  echo "Loading snapshot: ${snapshot}..." >&2
+  if [[ "$snapshot" == gs://* ]]; then
+    gcloud storage cat "$snapshot" | app_strip_snapshot | app_psql -d "$db" >/dev/null
+  else
+    app_strip_snapshot < "$snapshot" | app_psql -d "$db" >/dev/null
+  fi
+fi
+
+app_migrate "$url"
+
+# If the project has seeds, run them on a fresh (non-snapshot) DB. See migrations-and-seeds.md.
+# [ -z "$snapshot" ] && app_psql -d "$db" < "$(app_server_dir)/seed.sql" >/dev/null 2>&1
+
+echo "DATABASE_URL=${url}"
+echo "APP_DATABASE=${db}"
+echo "PORT=$(app_pick_port)"
+# Emit EVERY derived port (one per process kind) plus the wiring vars that
+# connect the processes, and the shared aux-service endpoints (SKILL.md
+# "Auxiliary services") — the orchestrator captures this one stdout block:
+#   grpc_port="$(app_pick_grpc_port)"
+#   echo "GRPC_PORT=${grpc_port}"
+#   echo "ORCHESTRATOR_URL=http://localhost:${grpc_port}"
+#   echo "VALIDATOR_URL=${VALIDATOR_URL:-http://localhost:9010}"
+# Apps that read discrete DB_* vars instead of DATABASE_URL: also emit both forms.
+#   app_db_env

--- a/.agents/skills/agent-dev-workflow/references/bin/stop
+++ b/.agents/skills/agent-dev-workflow/references/bin/stop
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Stop the shared Postgres container — the machine-scoped counterpart to
+# `ensure_postgres`. Every other teardown script in this set is worktree-scoped
+# (bin/cleanup drops one derived DB, bin/dev stop ends one session, bin/gc
+# sweeps merged worktrees); none of them stops a container, deliberately: no
+# single worktree can know whether another still needs it. This script is the
+# one place allowed to make that machine-wide call, and it only does so after
+# PROVING the container is idle.
+#
+#   bin/stop                     # stop the container iff nothing is using it
+#   bin/stop --dry-run           # print the same verdict; mutate nothing
+#   bin/stop --force             # stop it regardless of sessions/connections
+#   bin/stop --force --dry-run   # combinable: preview what --force would do
+#
+# Idleness proof — ALL must hold (mirrors bin/gc's prove-then-act structure):
+#
+#   no live dev session — every worktree of this repo is checked for a
+#                         .dev/state.env recording a live supervisor
+#                         (pid + start time, never bare `kill -0`)
+#   no client backends  — no non-superuser client connected to any database
+#                         in the container, other than this script's own psql
+#
+# Anything unproven is reported with a one-line reason and the container is
+# left running. Exit 0 either way; --dry-run and a refusal are not errors.
+#
+# Data is on a named volume, so stopping is non-destructive — the next
+# `bin/setup` starts the same container with every database intact.
+#
+# RACE, by design: a concurrent `bin/setup` in another session calls
+# ensure_postgres and brings the container straight back. Availability wins
+# over shutdown — this script re-verifies immediately before stopping to keep
+# the window small, but it does not lock other sessions out. If a container
+# keeps coming back, another session is actively working in the repo; that is
+# information, not a failure.
+#
+# Env overrides: APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+usage() { echo "usage: bin/stop [--dry-run] [--force]"; }
+
+# --dry-run and --force are ORTHOGONAL and combinable: --force says "ignore the
+# idleness proof", --dry-run says "don't mutate anything". Parsing them as one
+# mutually-exclusive mode makes `bin/stop --force --dry-run` silently perform a
+# real stop when a preview was asked for — a destructive misread of the flag
+# that reads as the safest possible invocation.
+dry=0
+force=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry=1 ;;
+    --force) force=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "bin/stop: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+container="$APP_CONTAINER_NAME"
+
+if ! docker inspect "$container" &>/dev/null; then
+  echo "no container named ${container} — nothing to stop"
+  exit 0
+fi
+if [ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo false)" != "true" ]; then
+  echo "${container} already stopped"
+  exit 0
+fi
+
+# ── Proof 1: no live bin/dev session in any worktree of this repo ────────────
+# Worktrees are enumerated from git, not from a directory glob: a worktree
+# registered outside .claude/worktrees/ (a scratch dir, ~/.worktrees/, /tmp)
+# still holds a session, and missing it would strand a running stack.
+live_sessions=""
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  [ -d "$wt" ] || continue
+  snap="$(cat "${wt}/.dev/state.env" 2>/dev/null || true)"
+  [ -n "$snap" ] || continue
+  # A booting session counts as live too — its ports are not up yet, so a
+  # port/connection check alone would call it idle and pull the DB out from
+  # under a stack that is still coming up.
+  if app_pid_is "$(app_snap_get "$snap" DEV_PID)" \
+                "$(app_snap_get "$snap" DEV_PID_LSTART)"; then
+    live_sessions="${live_sessions}  ${wt} (PHASE=$(app_snap_get "$snap" PHASE), PID $(app_snap_get "$snap" DEV_PID))"$'\n'
+  fi
+done < <(git -C "$SCRIPT_DIR" worktree list --porcelain | sed -n 's/^worktree //p')
+
+# ── Proof 2: no client backends on any database in the container ────────────
+# Excludes this script's own psql (pg_backend_pid) and background workers /
+# autovacuum (backend_type filter). Counts connections to EVERY database, not
+# just this worktree's: another repo checkout or a stray tool may hold one.
+clients="$(app_psql -d postgres -tAc "
+  SELECT coalesce(string_agg(DISTINCT datname || ' <- ' || coalesce(host(client_addr), 'local') || ' (' || usename || ')', '; '), '')
+  FROM pg_stat_activity
+  WHERE backend_type = 'client backend' AND pid <> pg_backend_pid()
+" 2>/dev/null | tr -d '\r' || true)"
+
+blocked=0
+if [ -n "$live_sessions" ]; then
+  echo "in use: live bin/dev session(s):"
+  printf '%s' "$live_sessions"
+  blocked=1
+fi
+if [ -n "$clients" ]; then
+  echo "in use: client connection(s): ${clients}"
+  blocked=1
+fi
+
+if [ "$blocked" -eq 1 ] && [ "$force" -eq 0 ]; then
+  echo "refusing to stop ${container} — run bin/stop --force to override, or stop the sessions first"
+  exit 0
+fi
+if [ "$blocked" -eq 0 ]; then
+  echo "idle: no dev sessions, no client connections"
+fi
+
+if [ "$dry" -eq 1 ]; then
+  echo "would stop ${container}"
+  exit 0
+fi
+
+# Re-verify liveness immediately before acting: between the proof above and
+# here, another session's bin/setup may have started a stack. Cheap, and it
+# shrinks (never closes — see RACE above) the window.
+if [ "$force" -eq 0 ]; then
+  while IFS= read -r wt; do
+    [ -n "$wt" ] || continue
+    [ -d "$wt" ] || continue
+    snap="$(cat "${wt}/.dev/state.env" 2>/dev/null || true)"
+    [ -n "$snap" ] || continue
+    if app_pid_is "$(app_snap_get "$snap" DEV_PID)" \
+                  "$(app_snap_get "$snap" DEV_PID_LSTART)"; then
+      echo "aborted: a dev session started in ${wt} while checking — container left running"
+      exit 0
+    fi
+  done < <(git -C "$SCRIPT_DIR" worktree list --porcelain | sed -n 's/^worktree //p')
+fi
+
+docker stop "$container" >/dev/null
+echo "stopped ${container} (data preserved on volume ${APP_VOLUME_NAME}; bin/setup restarts it)"

--- a/.agents/skills/agent-dev-workflow/references/bin/test
+++ b/.agents/skills/agent-dev-workflow/references/bin/test
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run the backend test suite against a DEDICATED test database (app_test), never
+# the dev database. Ensures the DB exists + is migrated, then runs the suite.
+#
+# Pair this with a test-runner preload so a bare `bun test` (no bin/) is ALSO
+# safe — see test-isolation.md. That preload is what makes this robust; this
+# script is the ergonomic entry point.
+#
+# Usage: bin/test [args forwarded to the test runner]
+# Env overrides: APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+ensure_postgres
+
+export APP_DATABASE="app_test"     # force the test DB regardless of worktree
+db="$(app_db_name)"
+url="$(app_database_url)"
+
+app_ensure_db "$db"
+app_migrate "$url"
+
+cd "$(app_server_dir)"
+exec env DATABASE_URL="$url" bun test "$@"

--- a/.agents/skills/agent-dev-workflow/references/gotchas.md
+++ b/.agents/skills/agent-dev-workflow/references/gotchas.md
@@ -1,0 +1,245 @@
+# Gotchas — the bugs every implementation re-derives if not warned
+
+These are real failures hit while building this pattern across projects. Each one
+costs an hour of debugging if you don't know it up front.
+
+## `ss` doesn't exist on macOS — and fails silently
+
+The single worst one. A naive port check uses `ss -tlnp` (Linux). On macOS `ss`
+isn't installed, the command fails, `2>/dev/null` swallows the error, the grep
+matches nothing → **every port reads "free"** → every concurrent worktree picks
+the *same* port and they collide. It looks like the port logic is broken; really
+the detector is no-op'ing.
+
+Fix (already in the `_common.sh` template): branch on the tool.
+
+```bash
+port_in_use() {
+  if command -v lsof &>/dev/null; then
+    lsof -iTCP:"$1" -sTCP:LISTEN -P -n &>/dev/null   # macOS + most Linux
+  elif command -v ss &>/dev/null; then
+    ss -tlnp 2>/dev/null | grep -q ":$1 "            # Linux without lsof
+  else
+    return 0                                          # unknown → assume in use
+  fi
+}
+```
+
+Also: **always scan from the default port**, not from `default+1` for worktrees.
+If a worktree starts scanning at 4001, it skips a free 4000. Reuse the canonical
+port whenever it's actually free; let real listen-state — not worktree identity —
+decide collisions.
+
+## Two collision axes: worktrees *and* other projects
+
+The port logic above solves **intra-project** collisions — two worktrees of the
+*same* repo never grab the same port. It does nothing about **inter-project**
+collisions: run several Jarvus repos at once and they'd fight over ports if they
+shared a base. In practice they don't, because each repo claims a distinct **base
+port band** — e.g. one project in `25xx`, another in `35xx`, another's Postgres at
+`5532`. That base is a per-project constant *you* choose; the worktree logic only
+ranges within it.
+
+Two ways to choose it:
+
+- **Hand-pick** a distinct, uncommon high band per repo and keep PG + backend +
+  frontend coherent within it (e.g. PG `N530`, backend `N531–N599`, frontend
+  `N600–N699`). The traps: forgetting which bands are already taken, and splitting a
+  repo across unrelated bands (one real repo runs Postgres on `5532` but its server
+  on `4001–4099` — avoid that incoherence).
+- **Derive it from a hash of the repo name** — collision-resistant with no registry
+  to remember, the same trick the DB names use for worktree *paths*, applied at repo
+  granularity:
+
+  ```bash
+  # deterministic base in a high block (20000–59990), distinct per repo name
+  app_base_port() {
+    local n; n=$(basename "$(app_root)" | cksum | cut -d' ' -f1)
+    echo $(( 20000 + (n % 4000) * 10 ))
+  }
+  # then PG = base, backend range = base+1..base+49, frontend = base+50..base+99
+  ```
+
+## postgres:18 changed the data directory layout
+
+On `postgres:18` the volume must mount at `/var/lib/postgresql`, **not**
+`/var/lib/postgresql/data` (the path used through 17). Mount the wrong one and the
+container's healthcheck never goes ready and `wait_for_postgres` times out after
+30s.
+
+**Pin the same major production runs.** Whatever major your prod DB is (Cloud SQL,
+RDS, …), pin that in `_common.sh` so `app_strip_snapshot`'d snapshots restore without
+version-mismatch surprises. That rule cuts both ways: when prod runs 18, you don't
+get to stay on the 17 template default to dodge the mount change. The `_common.sh`
+template carries the mount as `APP_PG_DATA_DIR` — for 18, change **both** lines
+together:
+
+```bash
+APP_PG_IMAGE="postgres:18-alpine"
+APP_PG_DATA_DIR="/var/lib/postgresql"     # NOT /var/lib/postgresql/data
+```
+
+Across Jarvus repos the major currently drifts (16 / 17 / 18 all in use) — match
+*your* prod. And remember container-reuse (below): switching majors on an existing
+container/volume needs a deliberate `docker rm` + volume removal.
+
+## docker-compose can't do per-context isolation — evict Postgres from it
+
+Compose pins one fixed DB name and one fixed host port — exactly what defeats
+per-worktree databases and ports. It also breaks in this workflow specifically:
+compose ties operations to the directory it was first run from, so when an agent
+worktree is deleted while its compose containers keep running, you can't manage
+them without recreating that exact path. So once these scripts exist, **remove the
+Postgres service (and the app itself) from compose** — the `bin/` scripts manage a
+path-independent shared container by name instead. Keeping a compose Postgres
+alongside the bin/ one invites "which Postgres am I talking to?" confusion.
+
+That's an eviction, not necessarily a deletion. Compose keeps exactly one job:
+the **once-per-machine auxiliary-services runner** (a validator container, a local
+OIDC IdP — see SKILL.md "Auxiliary services"). Those are shared across all
+worktrees, never replicated per worktree, so compose's one-fixed-port model is
+correct for them. If the file only templated Postgres, delete it outright.
+
+## `cd` inside a piped/exec'd script
+
+When a script needs to run a command in a subdir AND `exec`/background it with a
+specific env, `cd "$dir"` before the `exec` is cleaner than wrapping in
+`bash -c 'cd … && …'`. The single-service `dev` template does the former. The
+fullstack `dev` backgrounds two children, so it uses subshells `( cd … && … ) &`.
+
+## Container reuse vs. recreate
+
+`ensure_postgres` reuses a container that already exists (just `docker start`s it
+if stopped) and only creates one when absent. This is what lets many worktrees
+share one Postgres. Don't `docker run` unconditionally — you'll get a name clash
+or orphaned data. If you ever change Postgres image/version, you must `docker rm`
+the old container (and possibly the volume) once, deliberately.
+
+## md5 binary differs across platforms
+
+Linux/coreutils has `md5sum`; BSD/macOS has `md5 -q`. The `app_hash` helper
+branches on which exists so worktree DB names are stable on both. Don't hard-code
+`md5sum`.
+
+## `trap 'kill 0' EXIT` can kill the caller
+
+`kill 0` signals the **whole process group** — which is not "my children". A
+script launched from a non-interactive shell (another script, a CI step, an
+agent's exec call) *shares* its caller's process group, so a supervisor that
+traps `kill 0` on EXIT takes the caller down with it the moment anything asks it
+to stop. This is exactly the failure the old fullstack `dev` template had:
+`bin/cleanup` would kill the dev session and then die mid-cleanup, killed by the
+session's own trap.
+
+Fix (in the current `dev-fullstack` template): `set -m` before backgrounding
+children so **each child leads its own process group**, record the child pids,
+and have the trap `kill -- -$child_pid` each group individually. That kills each
+service's whole subtree (`bun run` → vite) without ever signalling the script's
+inherited group.
+
+## PIDs get recycled — record and verify start-time identity before killing
+
+A pid file (or a `state.env`) can outlive its process: SIGKILL skips traps,
+reboots reset the pid space, and the OS reuses pids. A later `kill -0 $pid`
+proving "something is alive at that pid" is not proof it's *your* process — and
+blindly `kill`ing it can shoot an innocent bystander. Record each pid **with its
+start time** and re-verify before every liveness verdict and every kill:
+
+```bash
+app_pid_lstart() {          # start time of a live process; empty when gone
+  { ps -o lstart= -p "$1" 2>/dev/null || true; } | sed 's/^ *//;s/ *$//'
+}
+# store: echo "SERVER_PID_LSTART=$(app_pid_lstart "$server_pid")"
+# check: [ "$(app_pid_lstart "$pid")" = "$recorded_lstart" ]
+```
+
+The `_common.sh` template carries this as `app_pid_is`; the fullstack `dev` and
+`gc` templates consult it before every kill and every health verdict.
+
+## A single SIGTERM is not a teardown — escalate, then verify
+
+`kill $pid` is a *request*. A process that traps SIGTERM and takes its time, or
+ignores it outright, keeps running — and a stop path that fires one TERM,
+deletes its state file, and returns 0 reports success while leaving a live
+process holding a port and a database open. Observed in the wild: a `bin/dev
+stop` exited 0, cleared `state.env`, and left a backend child alive for days;
+it needed SIGKILL.
+
+Deleting the state file is the part that turns a bug into an incident. That file
+is the only record of the survivor's pid **and start time**, so once it's gone
+the orphan can't be identified — you can't safely kill a bare pid (see pid
+recycling above), so the process becomes unkillable-in-practice until reboot.
+
+Every stop path therefore: TERM → wait → **KILL** → wait → **verify dead**, and
+on survival keeps `state.env` and returns non-zero:
+
+```bash
+if ! app_kill_wait "$pid" "$lstart" TERM 25; then
+  app_kill_wait "$pid" "$lstart" KILL 25 || survivors="${survivors} ${key}(${pid})"
+fi
+[ -n "$survivors" ] && return 1     # and do NOT rm state.env
+```
+
+Callers must honor the non-zero: `bin/cleanup` aborts rather than dropping a
+database out from under a surviving process (the `DROP` would fail with
+"database is being accessed by other users" anyway).
+
+## Derive the child list from `state.env`, don't hardcode it in three places
+
+The fullstack session records one `<NAME>_PID` per child. Early templates then
+spelled that list out **three times** — the writer in `bin/dev`, the liveness
+loop in `app_dev_session_healthy`, and the sweep loop in `app_dev_stop`. A stack
+that grows a third process (an orchestrator, a worker) has to update all three,
+and the failure is asymmetric: forget the *health* list and you get a false
+"healthy"; forget the *sweep* list and every stop silently orphans that process,
+while the other two lists still look correct in review.
+
+Derive it from the state file instead — one list, no drift:
+
+```bash
+app_dev_child_keys() {   # every KEY_PID= in the snapshot, minus the supervisor
+  printf '%s\n' "$1" | sed -n 's/^\([A-Z0-9_]*\)_PID=.*/\1/p' | grep -vx 'DEV' || true
+}
+```
+
+Ports stay explicit: *which* ports must be listening is a real per-project
+assertion, and `state.env` also carries ports that aren't liveness signals (an
+aux container's published port).
+
+## Commands that read stdin inside `while read` loops silently eat the stream
+
+`docker exec -i` (what `app_psql` wraps), `gh`, `ssh`, `ffmpeg` — anything that
+reads stdin — will, inside a `while read` loop fed on stdin, slurp the rest of
+the loop's input as *its* stdin. No error: the loop just ends after the first
+iteration that ran such a command. In a sweep like `bin/gc` that means "removed
+one worktree, silently skipped the rest".
+
+Fix: feed the loop on a **different file descriptor** so the commands inside
+keep their normal stdin:
+
+```bash
+while IFS=$'\t' read -r -u 3 wt br locked prunable; do
+  ...app_psql / gh calls...
+done 3<<<"$records"
+```
+
+(`read -u 3` + `3<<<` — the gc template does exactly this.)
+
+## macOS `TMPDIR` has a trailing slash — `"$TMPDIR"/*` patterns break
+
+On macOS, `TMPDIR` is set to something like `/var/folders/.../T/` — **with a
+trailing slash**. Appending `/*` yields `.../T//*`, and in a `case` glob (or any
+pattern match) the double slash must match literally, so real tmp paths (from
+`mktemp -d`, no double slash) silently fail the match. Anything gated on "is
+this path under tmp?" — e.g. a guard that only `rm -rf`s recorded paths inside
+tmp — then never fires on macOS.
+
+Fix: strip the trailing slash before appending (two steps — bash can't nest
+`${${TMPDIR:-/tmp}%/}`):
+
+```bash
+tmp="${TMPDIR:-/tmp}"; tmp="${tmp%/}"
+case "$path" in
+  /tmp/*|"$tmp"/*) rm -rf "$path" ;;
+esac
+```

--- a/.agents/skills/agent-dev-workflow/references/migrations-and-seeds.md
+++ b/.agents/skills/agent-dev-workflow/references/migrations-and-seeds.md
@@ -1,0 +1,111 @@
+# Migrations & seeds — the project-specific wiring
+
+`app_migrate()` in `_common.sh` is the one helper that's almost always
+project-specific. Everything else in the pattern is migration-tool-agnostic; this
+is where you adapt.
+
+## Migrations
+
+Set `app_migrate()` to however the project applies migrations. Three shapes seen
+across real projects:
+
+- **A package script** (simplest — reuse what `package.json` already defines):
+
+  ```bash
+  app_migrate() {
+    local url="$1"
+    echo "Running migrations..." >&2
+    (cd "$(app_server_dir)" && DATABASE_URL="$url" bun run db:migrate) >&2
+  }
+  ```
+
+  e.g. `db:migrate` → `drizzle-kit migrate`. The drizzle config reads
+  `DATABASE_URL` from env, so passing it through is enough.
+
+- **A migration runner script** (when there's a dedicated entrypoint):
+
+  ```bash
+  app_migrate() {
+    local url="$1"
+    echo "Running migrations..." >&2
+    DATABASE_URL="$url" bun run "$(app_server_dir)/src/db/run-migrations.ts" >&2
+  }
+  ```
+
+- **A self-migrating app** — the app runs its own programmatic migration runner
+  at boot: fresh-bootstrap when the DB is empty, baseline detection on an
+  existing schema, then additive incremental migrations. The division of labor
+  flips: **`bin/dev` needs no migrate step** (starting the app *is* migrating),
+  and `bin/setup` + the test preload call the app's own runner instead of
+  shelling out to a migration CLI. For `bin/setup` that means a thin entrypoint
+  into the runner:
+
+  ```bash
+  app_migrate() {
+    local url="$1"
+    echo "Running migrations..." >&2
+    (cd "$(app_server_dir)" && DATABASE_URL="$url" \
+      uv run python -c 'from app.db.migrations import run; run()') >&2
+  }
+  ```
+
+  Keep the `app_migrate` call in `setup`/`reset-db` anyway — it makes the DB
+  queryable via `bin/db` before first boot, and a skipped migrate is
+  self-healing here (the next app start covers it).
+
+The **test preload** migrates in-process instead of shelling out (it's already in
+the app's language and wants no Docker dependency) — drizzle-orm's programmatic
+`migrate(drizzle(sql), { migrationsFolder })`, or for a self-migrating app,
+importing and awaiting the app's own runner. Both read the same migration set as
+`app_migrate`; they're two callers of one migration system, not two systems.
+
+Non-bun stacks: `alembic upgrade head` (Python), `rails db:migrate`,
+`migrate -path … up` (golang-migrate), etc. — same idea, swap the command.
+
+### The `/docker-entrypoint-initdb.d` mount — recognize it, then retire it
+
+A common pre-`bin/` idiom you'll meet during adoption: the compose file mounts
+the migrations directory into the Postgres container at
+`/docker-entrypoint-initdb.d`, so the official image applies the `.sql` files
+itself. Its trap: those scripts run **only on the first boot of an empty
+volume**. Add a migration later and every existing volume silently never sees
+it — the "migration system" stops migrating the moment anyone has data. It also
+couples schema application to container creation, which the shared-container
+pattern deliberately decouples.
+
+Retirement path: point `app_migrate` at the same migration files via a real
+runner (any of the three shapes above), drop the mount from the container
+definition, and let `bin/setup`/`bin/reset-db` own schema application. Existing
+volumes don't need recreating — the runner brings them forward.
+
+## Seeds (optional) — three postures
+
+How you populate a fresh dev DB is a project choice. Three postures seen across real
+repos:
+
+1. **Synthetic seeds** — hand-authored idempotent `seed*.sql`
+   (`INSERT … ON CONFLICT DO NOTHING`) run on a fresh non-snapshot DB, plus an
+   optional local `.scratch/extra-seed.sql` for personal data. Right when the curated
+   dataset *is* the product (e.g. a demo app).
+2. **Snapshot-as-seed** — no hand-written fixtures at all; `bin/load-snapshot`
+   (default → latest prod) *is* the seed. Right when real prod data exists; often the
+   only synthetic thing left is a dev auth token/secret applied at runtime, not at
+   setup. See **`references/snapshots.md`**. This is the guardrail's ideal — nothing
+   to maintain.
+3. **Empty + per-suite fixtures** — `setup` leaves the DB empty (just migrated) and
+   tests build their own fixtures per suite. Right when there's no meaningful shared
+   dev dataset (and prod data is PII you wouldn't pull to a laptop).
+
+Decision rule: **do you have meaningful prod data to pull?** Yes → snapshot-as-seed.
+No, but the dataset is the deliverable → synthetic. Neither → empty + fixtures.
+
+Whichever you pick: keep seeds **idempotent**, **don't seed when loading a snapshot**
+(it already has data), and **don't seed the test DB** (suites own their fixtures). To
+wire posture 1, uncomment the seed lines in `setup`/`reset-db`.
+
+## A note on what NOT to put here
+
+Resist baking application-specific data setup into these scripts beyond a thin
+seed hook. The scripts manage the *database lifecycle*; rich fixture/demo data is
+the app's concern and tends to churn. Keep the boundary clean so the scripts stay
+portable across projects.

--- a/.agents/skills/agent-dev-workflow/references/orchestrator-integration.md
+++ b/.agents/skills/agent-dev-workflow/references/orchestrator-integration.md
@@ -1,0 +1,89 @@
+# Orchestrator integration (Conductor, etc.)
+
+The reason this pattern exists: AI agent orchestrators spin up a **separate git
+worktree per session** and let you register **setup / run / cleanup** commands.
+Many sessions run on one machine at once, so each needs its own database and port
+with zero manual config. These scripts provide exactly that contract.
+
+## The contract
+
+- **setup** → `bin/setup`. Idempotent: ensures the shared container, creates this
+  worktree's DB (derived from its path), installs deps, migrates. It **prints
+  `KEY=VALUE` env lines to stdout** and all human status to **stderr** — so an
+  orchestrator can capture stdout and inject those vars into the run step. The
+  stdout block must be **complete**: `DATABASE_URL` + `APP_DATABASE`, *every*
+  derived port (one per process kind — `PORT`, `GRPC_PORT`, `VITE_PORT`, …), the
+  inter-service wiring vars (`ORCHESTRATOR_URL=http://localhost:${GRPC_PORT}`),
+  and the shared aux-service endpoints (`VALIDATOR_URL=…` — see SKILL.md
+  "Auxiliary services"). Apps that read discrete `DB_*` vars instead of a URL:
+  emit both forms (`app_db_env`).
+- **run** → `bin/dev` (or `bin/server`). Picks the same free ports and derives the
+  same DB, so it works whether or not the orchestrator threaded `setup`'s output
+  through. The single-service variant `exec`s for clean signal handling; the
+  fullstack variant is a supervised singleton with its own attach/status/stop
+  contract (next section). Binds **loopback by default**
+  (`HOST=127.0.0.1`): an orchestrator that needs LAN exposure must opt in
+  explicitly — and must never widen a dev-auth-bypass instance (an
+  AUTH_DISABLED-style everyone-is-admin mode) beyond loopback. If the
+  orchestrator health-checks the service, `curl` works for HTTP ports but **not
+  gRPC** — probe those with a plain TCP connect.
+- **cleanup** → `bin/cleanup`. Drops this worktree's DB (refuses the canonical
+  one without `--force`); stops the recorded dev session first (`app_dev_stop`
+  handles both `.dev/state.env` sessions and legacy `.dev.pid` ones). Leaves
+  the shared container up for other worktrees.
+
+## The dev-session contract (fullstack `bin/dev`)
+
+The fullstack `dev` template is a **per-worktree singleton** with an explicit
+machine contract, so an orchestrator (or a second agent in the same worktree)
+can discover, attach to, health-check, and stop a session without guessing:
+
+- **Singleton + attach.** One session per worktree. A second `bin/dev` against
+  a healthy session starts nothing — it prints the running session's endpoints
+  and exits 0. A session still *booting* (another `bin/dev`'s pre-flight:
+  postgres ensure, migrate) is waited on and then attached, never torn down. A
+  stale or half-dead session (a child gone, recycled pids after a reboot) is
+  torn down and replaced automatically. `bin/dev --restart` bounces whatever is
+  there.
+- **`KEY=VALUE` on stdout.** Start and attach both emit the session's env block
+  (`STATUS=running`, `DEV_PID`, `DATABASE_URL`, `PORT`, `VITE_PORT`, `LOG_DIR`)
+  on stdout — human status stays on stderr, same discipline as `bin/setup` — so
+  one stdout capture tells the orchestrator where the stack landed either way.
+- **`bin/dev status` exit codes.** `0` running (healthy: every recorded pid is
+  the exact recorded process *and* every port listens) / `1` stopped (no
+  session) / `2` unhealthy (recorded session not fully up — replace or stop it)
+  / `3` starting (boot in progress — re-check shortly, or run `bin/dev` to wait
+  and attach). Script against the codes; the stdout block accompanies 0 and 3.
+- **On-disk logs.** Each service's full output lands in
+  `.dev/logs/<service>.log` (e.g. `server.log`, `web.log`) — fresh per session,
+  kept after exit for post-mortems, size-capped for long-lived sessions
+  (`APP_DEV_LOG_CAP_BYTES`). Agents read the files; humans can `bin/dev logs
+  [service]` from any terminal.
+- **Attach refusal on mismatch.** Attaching exits 2 when the running session
+  wasn't started with the caller's explicit `DATABASE_URL`/`PORT`/`VITE_PORT`
+  overrides — never exit 0 with settings the caller didn't ask for.
+- **`bin/dev stop`** stops the recorded session from any terminal; one child
+  dying tears down the whole stack loudly (never a half-dead session serving
+  errors from still-bound ports).
+
+## Why stdout/stderr discipline matters
+
+An orchestrator captures a script's stdout to learn where the service landed
+(`PORT=4002`). If status chatter ("Creating database…", "Running migrations…")
+goes to stdout too, it pollutes that capture. Rule: **machine-parseable env →
+stdout; everything humans read → stderr.** Every template here follows it.
+
+## Identity is the worktree path
+
+DB name and port both derive from the worktree, so two sessions never collide and
+re-running setup in the same worktree is a no-op-or-reset (not a duplicate).
+`git worktree list --porcelain | head -1` identifies the main worktree (canonical
+DB + default port); everything else is a hashed-path derivative. An orchestrator
+needs no per-session config — just register the three scripts once.
+
+## Override hooks
+
+Every derived value has an env override for when an orchestrator wants explicit
+control: `APP_DATABASE`, `APP_PG_PORT`, `PORT`, `VITE_PORT`, plus one per extra
+process kind (`GRPC_PORT`, …) and `HOST` (default loopback). Honor these first in
+every script (the templates do).

--- a/.agents/skills/agent-dev-workflow/references/snapshots.md
+++ b/.agents/skills/agent-dev-workflow/references/snapshots.md
@@ -1,0 +1,70 @@
+# Production snapshots (optional — only if the project has a prod DB)
+
+Some projects want to load production-like data locally. This is **purely
+opt-in** and only makes sense once there's a production database to snapshot. A
+greenfield project (no prod yet) should skip all of this — adding it early is
+dead weight.
+
+When a project *does* have real prod data, this is usually its **seeding
+strategy**: `bin/load-snapshot` (default → latest) replaces hand-written fixtures
+entirely (the "snapshot-as-seed" posture in **`migrations-and-seeds.md`**). One
+caveat for clean restores: pin the **same Postgres major as production** locally, so
+an `app_strip_snapshot`'d dump doesn't hit version-mismatch surprises.
+
+Two scripts, both built on helpers already in `_common.sh`.
+
+## bin/snapshot — export prod → object storage
+
+For a GCP Cloud SQL prod instance, export server-side (no public IP / maintenance
+mode needed) to a bucket:
+
+```bash
+gcloud sql export sql "$INSTANCE" "gs://${BUCKET}/${filename}" \
+  --database="$DATABASE" --project="$PROJECT" --clean --if-exists --quiet
+```
+
+Cloud SQL refuses to overwrite an existing object, so `rm` it first. The Cloud
+SQL service account needs write access to the bucket (`roles/storage.objectAdmin`
+on the bucket, or reuse an existing tfstate/snapshots bucket). A bucket lifecycle
+rule (e.g. delete after 30 days) keeps snapshots from accumulating.
+
+## bin/load-snapshot — load a snapshot into this context's DB
+
+Accept a local path **or** a `gs://` URL (stream straight from the bucket — no
+local download). Drop → recreate → load → migrate:
+
+```bash
+snapshot="${1:-gs://${BUCKET}/latest.sql}"
+app_recreate_db "$(app_db_name)"
+if [[ "$snapshot" == gs://* ]]; then
+  gcloud storage cat "$snapshot" | app_strip_snapshot | app_psql -d "$(app_db_name)"
+else
+  app_strip_snapshot < "$snapshot" | app_psql -d "$(app_db_name)"
+fi
+app_migrate "$(app_database_url)"   # applies any migrations newer than the snapshot
+```
+
+`bin/setup <snapshot>` does the same in one step (see the setup template).
+
+## app_strip_snapshot — the provider filter hook
+
+Managed Postgres dumps carry directives a vanilla local Postgres chokes on, so
+`bin/setup` pipes every snapshot through `app_strip_snapshot`. `_common.sh`
+ships it as an **identity filter** (`cat`) — a plain `pg_dump` needs no
+filtering, and shipping it defined is what keeps `bin/setup <snapshot>` from
+dying with a bare `command not found` on a verbatim copy of the template.
+
+Override it per provider. Cloud SQL's wrapper injects `\restrict`/`\unrestrict`
+psql meta-commands and `GRANT … TO cloudsqlsuperuser` (a role that doesn't exist
+locally):
+
+```bash
+app_strip_snapshot() {
+  grep -v -E '^\\(restrict|unrestrict) |cloudsqlsuperuser'
+}
+```
+
+Non-GCP equivalents: AWS RDS → `aws rds ...` or `pg_dump` over the wire to S3;
+self-hosted → plain `pg_dump`. The shape is identical (export → object store →
+stream into `app_recreate_db` + load + migrate); only the export command and the
+provider-specific `app_strip_snapshot` filter change.

--- a/.agents/skills/agent-dev-workflow/references/test-isolation.md
+++ b/.agents/skills/agent-dev-workflow/references/test-isolation.md
@@ -1,0 +1,232 @@
+# Test isolation — never let tests clobber dev data
+
+The single highest-value payoff of this pattern: **tests run against their own
+database (`app_test`), so a test suite's `truncate`/reset can never wipe the dev
+data you're demoing against.** `bin/test` handles this, but the robust fix is a
+**test-runner preload** so that even a bare `bun test` (someone forgetting `bin/`,
+or an IDE test button) is safe too.
+
+This reference has two halves: the **plumbing** — a dedicated, auto-migrated test DB
+(immediately below) — and, once that's in place, **how to author suites against it**
+("Authoring tests against the isolated DB", further down).
+
+## The preload (bun example)
+
+`bunfig.toml`:
+
+```toml
+[test]
+preload = ["./test/setup.ts"]
+```
+
+Mind existing `[test]` config: `bun test` globs **across nested packages**, so a
+monorepo's root `bunfig.toml` may already carry `[test] pathIgnorePatterns` to
+keep sub-package suites out of the root run. **Extend that existing `[test]`
+block** with the `preload` key — pasting the snippet as a second `[test]` block
+(or overwriting the file) clobbers the ignore patterns and suddenly pulls every
+nested package's tests into the run.
+
+`test/setup.ts` runs once before any test file. It must:
+
+1. Default `DATABASE_URL` to the test DB **with `??=`** — so an explicit env
+   (CI, or `bin/test` which `export`s it) always wins.
+2. Create the test DB if missing (connect to the maintenance `postgres` DB first).
+3. Migrate it to the current schema.
+
+```ts
+import postgres from 'postgres'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
+
+const DEFAULT_TEST_URL = 'postgres://app:app@localhost:5432/app_test'
+const usingDefault = process.env.DATABASE_URL === undefined
+
+process.env.DATABASE_URL ??= DEFAULT_TEST_URL
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+// ...other required env with ??=
+
+const url = process.env.DATABASE_URL
+
+// Create the DB only when we own the default (CI provides its own, already created).
+if (usingDefault) {
+  const dbName = new URL(url).pathname.slice(1)
+  const adminUrl = new URL(url); adminUrl.pathname = '/postgres'
+  const admin = postgres(adminUrl.toString(), { max: 1 })
+  try {
+    const rows = await admin`SELECT 1 FROM pg_database WHERE datname = ${dbName}`
+    if (rows.length === 0) await admin.unsafe(`CREATE DATABASE ${dbName}`)
+  } finally { await admin.end({ timeout: 5 }) }
+}
+
+const sql = postgres(url, { max: 1 })
+try { await migrate(drizzle(sql), { migrationsFolder: './migrations' }) }
+finally { await sql.end({ timeout: 5 }) }
+```
+
+Then delete the per-file `process.env.DATABASE_URL = …` lines from each test —
+the preload centralizes them. Keep any per-suite *override* (e.g. a suite that
+sets `MIN_SUPPORTED_BUILD=500` to exercise a code path) — just drop the shared DB/secret defaults.
+
+Apps that read discrete `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD`
+vars instead of a URL: `??=` each discrete var the same way — or better, teach
+the app to accept `DATABASE_URL` with a discrete-var fallback, so the preload,
+`bin/`, and CI all speak one URL.
+
+## Why `??=` and not `=`
+
+`??=` only fills in a default when nothing was provided. CI sets `DATABASE_URL`
+explicitly to its ephemeral service-container DB and migrates that itself, so the
+preload must defer to it. Using `=` would override CI and break it.
+
+## CI stays untouched
+
+CI already points at a throwaway service-container DB via an explicit
+`DATABASE_URL` and runs its own migrate step. This whole pattern is a **local-dev**
+change — verify CI is green after adding the preload, but you should not need to
+edit the CI workflow.
+
+**Unless CI deliberately has no database.** Some repos run CI DB-less: live-DB
+suites self-skip (`describe.skipIf(...)`) and only pure suites gate merges. The
+preload as written breaks that CI — it unconditionally connects and migrates,
+and there's nothing to connect to. Two legitimate postures; pick one on purpose:
+
+- **Add a service container** (the `ci-quality-gates` default) — DB coverage on
+  every PR; the preload works unchanged.
+- **Skip when unreachable** — the preload probes Postgres with a
+  short-timeout connect; on failure it sets a flag the live-DB suites check
+  (feeding their `skipIf`) and returns instead of throwing. Keeps fork PRs and
+  minimal runners green at the cost of DB coverage in that lane.
+
+Don't leave it implicit — a preload that hard-fails in a deliberately DB-less CI
+looks like a flaky suite, not a design choice.
+
+## Residual footgun to document, not over-engineer
+
+If a dev copies `.env.example` → `.env` with `DATABASE_URL=…/app` (the dev DB),
+the test runner auto-loads `.env` and a *bare* `bun test` would defer to it
+(the preload uses `??=`). `bin/test` is immune (it `export`s the test URL, which
+beats `.env`). Don't try to guard by DB *name* — CI's throwaway DB may legitimately
+share the dev name. Just tell people: prefer `bin/test`.
+
+## Verifying it actually works (do this once)
+
+Seed a sentinel row into the dev DB, run the suite both ways, confirm it survived:
+
+```bash
+bin/db "INSERT INTO <some_table> (...) VALUES ('SENTINEL — do not delete', ...)"
+bin/test                                   # and: (cd <server> && bun test)
+bin/db "SELECT count(*) FROM <some_table> WHERE ... LIKE 'SENTINEL%'"  # → still 1
+```
+
+Other runners: pytest → a `conftest.py` fixture; vitest → `globalSetup`. Same
+three responsibilities (default env, ensure DB, migrate).
+
+# Authoring tests against the isolated DB
+
+The preload gives every run a clean, migrated `app_test`. This is the pattern for
+writing suites against it.
+
+> **This half is a single-project pattern** — generalized from the one adopter with
+> a real suite so far, so it's n=1. The plumbing above is solid; the conventions
+> below are a starting point to **refine after the next project applies them** (see
+> the closing note).
+
+## The canonical suite shape
+
+Import the **real app** and drive it **in-process** — no network listener:
+
+```ts
+import { afterAll, beforeAll, beforeEach, expect, test } from 'bun:test'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// DATABASE_URL / JWT_SECRET / … come from the preload (bunfig.toml).
+const { app } = await import('../src/app.ts')
+
+let server: FastifyInstance
+
+beforeAll(async () => {
+  server = Fastify({ logger: false })
+  await server.register(app)
+  await server.ready()
+})
+afterAll(async () => {
+  await server.close()
+})
+beforeEach(async () => {
+  // wipe only the tables THIS suite touches
+  await server.sql`truncate profile, friendship cascade`
+})
+
+test('accepting a request connects both ways', async () => {
+  const res = await server.inject({ method: 'GET', url: '/v1/friends', headers: alice.auth })
+  expect(res.statusCode).toBe(200)
+})
+```
+
+Four decisions in there are what make isolation actually hold:
+
+### 1. In-process via `inject` — never bind a port
+
+`server.inject(...)` runs the request through the app in memory; the suite never
+calls `listen()`. This is the quiet linchpin: a whole directory of suites can run
+without fighting over a port — the runner only has to serialize the *database*, not
+a socket. It also removes teardown races on a port.
+
+### 2. Reset with a scoped `truncate`, not a global wipe
+
+Each suite truncates **only the tables it touches**, in `beforeEach`, through the
+app's own DB handle (`server.sql`, decorated by the app). `… cascade` handles FK
+order. Truncate-between-tests is the simplest hermetic reset; a
+transaction-per-test rollback is the main alternative (faster, but fights code that
+opens its own transactions — start with truncate).
+
+### 3. Fixtures: insert + mint a token, return a handle
+
+Build state through the app's own primitives rather than over HTTP where you can —
+insert the row with `server.sql`, mint auth with the app's token signer, hand back a
+reusable handle:
+
+```ts
+async function makeUser(phone: string) {
+  const [row] = await server.sql<{ id: string }[]>`
+    insert into profile (phone, claimed_at) values (${phone}, now()) returning id`
+  const token = server.signAccessToken(row.id)   // app-decorated signer
+  return { id: row.id, auth: { authorization: `Bearer ${token}` } }
+}
+```
+
+Then drive behaviour over `inject` with `headers: user.auth`. Prefer minting tokens
+to replaying the full login flow — exercise the real auth path in the *auth* suite,
+and shortcut it everywhere else.
+
+### 4. One process, one DB — so guard shared state
+
+The runner executes every test file in **one process against the one shared
+`app_test`**. That's what makes scoped truncates safe — but it means **mutable
+process state leaks across suites**:
+
+- **`process.env` bleeds.** A suite that bumps an env knob (e.g. raising a
+  minimum-supported-build floor to exercise a 4xx path) must capture the prior value
+  in `beforeAll` and **restore it in `afterAll`** — otherwise the override silently
+  changes every later suite. Frameworks that read env *at registration time* (e.g.
+  `@fastify/env`) sharpen this: set the override *before* `register`, restore after
+  `close`.
+- **Don't parallelize files against the shared DB.** Scoped truncates assume serial
+  execution; running suites concurrently against one DB lets one suite's `truncate`
+  yank another's rows mid-test. If you ever need parallelism, give each worker its
+  own DB (a per-worker suffix on `app_test`) — don't loosen the reset.
+
+## Stay hermetic (the `ci-quality-gates` line)
+
+Everything above needs only Postgres — no secrets, no outbound calls — so these
+suites run in the pre-merge gate (**`ci-quality-gates`**) and on fork PRs. The moment
+a test needs real credentials or a third-party endpoint it's a different, later gate;
+don't drag secrets into this set. Stub external providers at the app boundary.
+
+## Refine after the next adopter
+
+This authoring playbook is n=1. When the next project picks it up, come back and:
+promote what generalized, flag what was project-specific (the framework's
+`inject`/decorator details, the truncate-vs-rollback call, the token-minting helper
+shape), and add whatever that project hit that this one didn't. Until then, treat the
+conventions as defaults to question, not rules.

--- a/.claude/skills/agent-dev-workflow
+++ b/.claude/skills/agent-dev-workflow
@@ -1,0 +1,1 @@
+../../.agents/skills/agent-dev-workflow

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -89,11 +89,15 @@ sq_hash() {
   fi
 }
 
+# The repo's main worktree — `git worktree list` always reports it first.
+# Single source of truth for the DB naming and the port pickers, which each
+# used to reimplement this pipeline.
+sq_main_worktree() {
+  git -C "${1:-$(sq_root)}" worktree list --porcelain | head -1 | sed 's/^worktree //'
+}
+
 is_main_worktree() {
-  local worktree_root main_worktree
-  worktree_root="$(sq_root)"
-  main_worktree="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
-  [ "$worktree_root" = "$main_worktree" ]
+  [ "$(sq_root)" = "$(sq_main_worktree)" ]
 }
 
 # The database name for this context:

--- a/bin/stop
+++ b/bin/stop
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Stop the shared Postgres container — the machine-scoped counterpart to
+# `ensure_postgres`. Every other teardown script in this set is worktree-scoped
+# (bin/cleanup drops one derived DB, bin/dev stop ends one session, bin/gc
+# sweeps merged worktrees); none of them stops a container, deliberately: no
+# single worktree can know whether another still needs it. This script is the
+# one place allowed to make that machine-wide call, and it only does so after
+# PROVING the container is idle.
+#
+#   bin/stop                     # stop the container iff nothing is using it
+#   bin/stop --dry-run           # print the same verdict; mutate nothing
+#   bin/stop --force             # stop it regardless of sessions/connections
+#   bin/stop --force --dry-run   # combinable: preview what --force would do
+#
+# Idleness proof — ALL must hold (mirrors bin/gc's prove-then-act structure):
+#
+#   no live dev session — every worktree of this repo is checked for a
+#                         .dev/state.env recording a live supervisor
+#                         (pid + start time, never bare `kill -0`). SKIPPED in
+#                         single-service repos with no session machine; the
+#                         verdict line says so, and a running dev server is
+#                         still caught by the connection proof below.
+#   no client backends  — no non-superuser client connected to any database
+#                         in the container, other than this script's own psql
+#
+# Anything unproven is reported with a one-line reason and the container is
+# left running. Exit 0 either way; --dry-run and a refusal are not errors.
+#
+# Data is on a named volume, so stopping is non-destructive — the next
+# `bin/setup` starts the same container with every database intact.
+#
+# RACE, by design: a concurrent `bin/setup` in another session calls
+# ensure_postgres and brings the container straight back. Availability wins
+# over shutdown — this script re-verifies immediately before stopping to keep
+# the window small, but it does not lock other sessions out. If a container
+# keeps coming back, another session is actively working in the repo; that is
+# information, not a failure.
+#
+# Env overrides: SQ_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+usage() { echo "usage: bin/stop [--dry-run] [--force]"; }
+
+# --dry-run and --force are ORTHOGONAL and combinable: --force says "ignore the
+# idleness proof", --dry-run says "don't mutate anything". Parsing them as one
+# mutually-exclusive mode makes `bin/stop --force --dry-run` silently perform a
+# real stop when a preview was asked for — a destructive misread of the flag
+# that reads as the safest possible invocation.
+dry=0
+force=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry=1 ;;
+    --force) force=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "bin/stop: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+container="$SQ_CONTAINER_NAME"
+
+if ! docker inspect "$container" &>/dev/null; then
+  echo "no container named ${container} — nothing to stop"
+  exit 0
+fi
+if [ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo false)" != "true" ]; then
+  echo "${container} already stopped"
+  exit 0
+fi
+
+# ── Proof 1: no live bin/dev session in any worktree of this repo ────────────
+# Worktrees are enumerated from git, not from a directory glob: a worktree
+# registered outside .claude/worktrees/ (a scratch dir, ~/.worktrees/, /tmp)
+# still holds a session, and missing it would strand a running stack.
+# Repos on the single-service `dev` have no .dev/state.env session machine and
+# therefore no sq_pid_is / sq_snap_get. Skip this proof there instead of
+# dying on a missing function — containment is not lost, because a running
+# single-service dev server still holds a database connection and is caught by
+# proof 2 below. The verdict line says the check was SKIPPED rather than
+# claiming "no dev sessions" for a check that never ran.
+live_sessions=""
+if command -v sq_pid_is >/dev/null 2>&1; then
+  session_proof="ok"
+else
+  session_proof="skipped — no dev-session state machine in this repo"
+fi
+while [ "$session_proof" = "ok" ] && IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  [ -d "$wt" ] || continue
+  snap="$(cat "${wt}/.dev/state.env" 2>/dev/null || true)"
+  [ -n "$snap" ] || continue
+  # A booting session counts as live too — its ports are not up yet, so a
+  # port/connection check alone would call it idle and pull the DB out from
+  # under a stack that is still coming up.
+  if sq_pid_is "$(sq_snap_get "$snap" DEV_PID)" \
+                "$(sq_snap_get "$snap" DEV_PID_LSTART)"; then
+    live_sessions="${live_sessions}  ${wt} (PHASE=$(sq_snap_get "$snap" PHASE), PID $(sq_snap_get "$snap" DEV_PID))"$'\n'
+  fi
+done < <(git -C "$SCRIPT_DIR" worktree list --porcelain | sed -n 's/^worktree //p')
+
+# ── Proof 2: no client backends on any database in the container ────────────
+# Excludes this script's own psql (pg_backend_pid) and background workers /
+# autovacuum (backend_type filter). Counts connections to EVERY database, not
+# just this worktree's: another repo checkout or a stray tool may hold one.
+clients="$(sq_psql -d postgres -tAc "
+  SELECT coalesce(string_agg(DISTINCT datname || ' <- ' || coalesce(host(client_addr), 'local') || ' (' || usename || ')', '; '), '')
+  FROM pg_stat_activity
+  WHERE backend_type = 'client backend' AND pid <> pg_backend_pid()
+" 2>/dev/null | tr -d '\r' || true)"
+
+blocked=0
+if [ -n "$live_sessions" ]; then
+  echo "in use: live bin/dev session(s):"
+  printf '%s' "$live_sessions"
+  blocked=1
+fi
+if [ -n "$clients" ]; then
+  echo "in use: client connection(s): ${clients}"
+  blocked=1
+fi
+
+if [ "$blocked" -eq 1 ] && [ "$force" -eq 0 ]; then
+  echo "refusing to stop ${container} — run bin/stop --force to override, or stop the sessions first"
+  exit 0
+fi
+if [ "$blocked" -eq 0 ]; then
+  if [ "$session_proof" = "ok" ]; then
+    echo "idle: no dev sessions, no client connections"
+  else
+    echo "idle: no client connections; session check ${session_proof}"
+  fi
+fi
+
+if [ "$dry" -eq 1 ]; then
+  echo "would stop ${container}"
+  exit 0
+fi
+
+# Re-verify liveness immediately before acting: between the proof above and
+# here, another session's bin/setup may have started a stack. Cheap, and it
+# shrinks (never closes — see RACE above) the window.
+if [ "$force" -eq 0 ] && [ "$session_proof" = "ok" ]; then
+  while IFS= read -r wt; do
+    [ -n "$wt" ] || continue
+    [ -d "$wt" ] || continue
+    snap="$(cat "${wt}/.dev/state.env" 2>/dev/null || true)"
+    [ -n "$snap" ] || continue
+    if sq_pid_is "$(sq_snap_get "$snap" DEV_PID)" \
+                  "$(sq_snap_get "$snap" DEV_PID_LSTART)"; then
+      echo "aborted: a dev session started in ${wt} while checking — container left running"
+      exit 0
+    fi
+  done < <(git -C "$SCRIPT_DIR" worktree list --porcelain | sed -n 's/^worktree //p')
+fi
+
+docker stop "$container" >/dev/null
+echo "stopped ${container} (data preserved on volume ${SQ_VOLUME_NAME}; bin/setup restarts it)"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "agent-dev-workflow": {
+      "source": "JarvusInnovations/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/agent-dev-workflow/SKILL.md",
+      "computedHash": "d7645eeaffa5d1732d5177b85727ae15a7020e308cba48256fb1479d10b05110"
+    },
     "dart-add-unit-test": {
       "source": "dart-lang/skills",
       "sourceType": "github",


### PR DESCRIPTION
Brings this repo onto the current agent-dev-workflow model: vendors the skill it already implements, and adds the machine-scoped `bin/stop` from JarvusInnovations/agent-skills#44.

## Vendoring

This repo has run the pattern for a while — `bin/` task runner over a shared Postgres container, worktree-derived database and ports, plus the dedicated test database wired through `bin/test` — but never vendored the skill, so the guidance lived only in whoever last touched `bin/`. Now pinned alongside the scripts that implement it, the same as continuous-gtfs and transit-lake.

(To be clear about the recent `retire-squadquest-v2-db` work: that retired the Terraform/Cloud SQL instance. The local dev container is untouched and `bin/setup`, `bin/dev`, `bin/test` and `bin/reset-db` all still go through `ensure_postgres`.)

## `bin/stop`

The machine-scoped counterpart to `ensure_postgres`. Every other teardown script here is worktree-scoped (`bin/cleanup` drops one derived database, `bin/reset-db` recreates one), so nothing could say "this container is idle, stop it" — the only recourse was `docker stop` by hand, which throws away every guard the rest of the pattern provides. It stops the shared container only after proving it idle, and never removes the container or volume, so `bin/setup` restarts it with every database intact.

This repo runs the **single-service `dev`**, so there's no `.dev/state.env` session machine and no `sq_pid_is`/`sq_snap_get`. The session proof is guarded on those helpers and **degrades honestly** when they're absent:

```
idle: no client connections; session check skipped — no dev-session state machine in this repo
```

rather than claiming "no dev sessions" for a check that never ran. Containment isn't lost — a running dev server holds a database connection and is caught by the connection proof. The upstream template carries the same guard (agent-skills#45); the vendored copy here predates it by one commit and picks it up on the next re-sync.

For the same reason, the upstream teardown fix (escalating SIGTERM to SIGKILL in the fullstack session stop) has nothing to act on here and was not ported.

## Smaller change

**`sq_main_worktree`** single-sources the `git worktree list | head -1 | sed` pipeline that the DB naming and the port pickers had each reimplemented.

## Verification

Every `bin/` script passes `bash -n`. Because this container doesn't exist on the test machine, it was stood up through this repo's own `ensure_postgres` to exercise the real paths: reports idle with the session check honestly marked skipped, **refuses** while a client connection is open, `--force` overrides and stops it, and the no-container case exits cleanly with `nothing to stop`. The test container and its volume were removed afterwards — neither existed beforehand.