### PR TITLE
chore(bin): re-sync skill, warn on postgres bind drift

### DIFF
--- a/.agents/skills/agent-dev-workflow/SKILL.md
+++ b/.agents/skills/agent-dev-workflow/SKILL.md
@@ -81,6 +81,10 @@ know which parts you copy verbatim and which you adapt.
 **Project-specific** (the knobs you set):
 
 - the prefix, PG user/password/image, container/volume names
+- the **publish address** (`APP_PG_BIND`, default `127.0.0.1`) — keep it on
+  loopback unless a container genuinely must be reachable off-box. Note this is
+  frozen at container creation: changing it later does nothing until the
+  container is re-created, so `ensure_postgres` warns on the drift (see gotchas)
 - the **base port band** — the default PG port plus one worktree range **per
   process kind** (backend HTTP, gRPC, frontend, …). This is the project's claim on
   the machine: worktree isolation keeps a project's *own* copies apart, but the
@@ -165,6 +169,13 @@ after proving it idle: no live `bin/dev` session in **any** worktree of the repo
 still count), and no client backends connected to any database in it. Unproven →
 one-line reason, container left running, exit 0. Same prove-then-act shape as
 `bin/gc`; `--dry-run` and `--force` are combinable.
+
+One portability note: the session proof needs the fullstack `dev`'s
+`.dev/state.env` machinery. In single-service repos those helpers don't exist,
+so the proof is **skipped** and the verdict line says so rather than claiming
+"no dev sessions" for a check that never ran. Containment survives, because a
+running single-service dev server holds a database connection and is caught by
+the connection proof.
 
 Two things it deliberately does **not** do. It never removes the container or
 volume — stopping is non-destructive and `bin/setup` restarts it with every

--- a/.agents/skills/agent-dev-workflow/references/bin/_common.sh
+++ b/.agents/skills/agent-dev-workflow/references/bin/_common.sh
@@ -117,9 +117,30 @@ app_strip_snapshot() {
 
 # ── Shared Postgres container ────────────────────────────────────────────────
 ensure_postgres() {
-  local container="$APP_CONTAINER_NAME" port
+  local container="$APP_CONTAINER_NAME" port bind actual
   port="$(app_pg_port)"
+  bind="${APP_PG_BIND:-127.0.0.1}"
   if docker inspect "$container" &>/dev/null; then
+    # BIND DRIFT (see gotchas.md): a container is reused by name and NEVER
+    # re-created, so its published address is frozen at creation time. Change
+    # the bind here and every existing container keeps the old one silently —
+    # which is how a box ends up with Postgres on 0.0.0.0 long after the
+    # default moved to loopback. Docker reports an empty HostIp as all
+    # interfaces; normalise before comparing.
+    # A container may publish on SEVERAL addresses, so emit one per line and
+    # collapse to a space-separated list — concatenating them yields nonsense
+    # like "127.0.0.1100.116.60.123". An empty HostIp means all interfaces.
+    actual="$(docker inspect \
+      -f '{{range $p, $b := .HostConfig.PortBindings}}{{range $b}}{{if .HostIp}}{{.HostIp}}{{else}}0.0.0.0{{end}}{{"\n"}}{{end}}{{end}}' \
+      "$container" 2>/dev/null | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ *$//')"
+    [ -n "$actual" ] || actual="0.0.0.0"
+    if [ "$actual" != "$bind" ]; then
+      echo "WARNING: ${container} publishes on ${actual}:${port}, not ${bind}:${port}." >&2
+      echo "         It was created before the current bind setting and docker cannot" >&2
+      echo "         re-publish a running container. To fix (data is on volume" >&2
+      echo "         ${APP_VOLUME_NAME} and survives):" >&2
+      echo "           docker rm -f ${container} && bin/setup" >&2
+    fi
     if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
       echo "Starting existing postgres container..." >&2
       docker start "$container" >/dev/null
@@ -128,7 +149,7 @@ ensure_postgres() {
     echo "Creating postgres container on port ${port}..." >&2
     docker run -d \
       --name "$container" \
-      -p "${APP_PG_BIND:-127.0.0.1}:${port}:5432" \
+      -p "${bind}:${port}:5432" \
       -e POSTGRES_USER="$APP_PG_USER" \
       -e POSTGRES_PASSWORD="$APP_PG_PASSWORD" \
       -e POSTGRES_DB=app \

--- a/.agents/skills/agent-dev-workflow/references/bin/stop
+++ b/.agents/skills/agent-dev-workflow/references/bin/stop
@@ -16,7 +16,10 @@
 #
 #   no live dev session — every worktree of this repo is checked for a
 #                         .dev/state.env recording a live supervisor
-#                         (pid + start time, never bare `kill -0`)
+#                         (pid + start time, never bare `kill -0`). SKIPPED in
+#                         single-service repos with no session machine; the
+#                         verdict line says so, and a running dev server is
+#                         still caught by the connection proof below.
 #   no client backends  — no non-superuser client connected to any database
 #                         in the container, other than this script's own psql
 #
@@ -76,8 +79,19 @@ fi
 # Worktrees are enumerated from git, not from a directory glob: a worktree
 # registered outside .claude/worktrees/ (a scratch dir, ~/.worktrees/, /tmp)
 # still holds a session, and missing it would strand a running stack.
+# Repos on the single-service `dev` have no .dev/state.env session machine and
+# therefore no app_pid_is / app_snap_get. Skip this proof there instead of
+# dying on a missing function — containment is not lost, because a running
+# single-service dev server still holds a database connection and is caught by
+# proof 2 below. The verdict line says the check was SKIPPED rather than
+# claiming "no dev sessions" for a check that never ran.
 live_sessions=""
-while IFS= read -r wt; do
+if command -v app_pid_is >/dev/null 2>&1; then
+  session_proof="ok"
+else
+  session_proof="skipped — no dev-session state machine in this repo"
+fi
+while [ "$session_proof" = "ok" ] && IFS= read -r wt; do
   [ -n "$wt" ] || continue
   [ -d "$wt" ] || continue
   snap="$(cat "${wt}/.dev/state.env" 2>/dev/null || true)"
@@ -117,7 +131,11 @@ if [ "$blocked" -eq 1 ] && [ "$force" -eq 0 ]; then
   exit 0
 fi
 if [ "$blocked" -eq 0 ]; then
-  echo "idle: no dev sessions, no client connections"
+  if [ "$session_proof" = "ok" ]; then
+    echo "idle: no dev sessions, no client connections"
+  else
+    echo "idle: no client connections; session check ${session_proof}"
+  fi
 fi
 
 if [ "$dry" -eq 1 ]; then
@@ -128,7 +146,7 @@ fi
 # Re-verify liveness immediately before acting: between the proof above and
 # here, another session's bin/setup may have started a stack. Cheap, and it
 # shrinks (never closes — see RACE above) the window.
-if [ "$force" -eq 0 ]; then
+if [ "$force" -eq 0 ] && [ "$session_proof" = "ok" ]; then
   while IFS= read -r wt; do
     [ -n "$wt" ] || continue
     [ -d "$wt" ] || continue

--- a/.agents/skills/agent-dev-workflow/references/gotchas.md
+++ b/.agents/skills/agent-dev-workflow/references/gotchas.md
@@ -115,6 +115,47 @@ share one Postgres. Don't `docker run` unconditionally — you'll get a name cla
 or orphaned data. If you ever change Postgres image/version, you must `docker rm`
 the old container (and possibly the volume) once, deliberately.
 
+## A container's published address is frozen at creation — changing the bind silently does nothing
+
+`ensure_postgres` reuses a container by name and only ever `docker start`s it
+(that reuse is the whole point — it is what lets many worktrees share one
+Postgres). Docker cannot re-publish an existing container, so **the `-p` address
+is fixed at creation time**. Change `APP_PG_BIND` — or adopt the loopback
+default after the fact — and every container created earlier keeps its old
+publish, forever, with no error and no diff to notice.
+
+This is how a machine ends up serving Postgres on `0.0.0.0` months after the
+code moved to `127.0.0.1`. Seen in the wild: a container created in March still
+published on all interfaces in August, on a box with a public IP, while its
+repo's `_common.sh` had said `${APP_PG_BIND:-127.0.0.1}` the entire time. Every
+code review of that file would pass.
+
+The template now detects the drift and says what to do (normalising docker's
+empty `HostIp`, which means all-interfaces):
+
+```bash
+# one address per line — a container can publish on SEVERAL, and concatenating
+# them yields nonsense like "127.0.0.1100.116.60.123"; empty HostIp = all ifaces
+actual="$(docker inspect \
+  -f '{{range $p, $b := .HostConfig.PortBindings}}{{range $b}}{{if .HostIp}}{{.HostIp}}{{else}}0.0.0.0{{end}}{{"\n"}}{{end}}{{end}}' \
+  "$container" | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ *$//')"
+[ -n "$actual" ] || actual="0.0.0.0"
+[ "$actual" = "$bind" ] || echo "WARNING: ${container} publishes on ${actual}, not ${bind}" >&2
+```
+
+It warns rather than auto-recreating: recreating a container is the caller's
+call, not a side effect of `bin/setup`. The fix is one deliberate command, and
+the data is on a named volume so it survives:
+
+```bash
+docker rm -f <container> && bin/setup
+```
+
+The same freeze applies to any other creation-time setting — image/major
+version, volume mount, env. Container reuse (below) is the general case; the
+bind is the one where the silent failure is a *security* regression rather than
+a broken container you would notice immediately.
+
 ## md5 binary differs across platforms
 
 Linux/coreutils has `md5sum`; BSD/macOS has `md5 -q`. The `app_hash` helper

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -121,10 +121,27 @@ sq_database_url() {
 }
 
 ensure_postgres() {
-  local container="$SQ_CONTAINER_NAME" port
+  local container="$SQ_CONTAINER_NAME" port bind actual
   port="$(sq_pg_port)"
+  bind="${SQ_PG_BIND:-127.0.0.1}"
 
   if docker inspect "$container" &>/dev/null; then
+    # BIND DRIFT (see the vendored skill's gotchas.md): a container is reused
+    # by name and NEVER re-created, so its published address is frozen at
+    # creation time. Change the bind here and every existing container keeps
+    # the old one silently — which is how a box ends up serving Postgres on
+    # 0.0.0.0 long after the default moved to loopback.
+    actual="$(docker inspect \
+      -f '{{range $p, $b := .HostConfig.PortBindings}}{{range $b}}{{if .HostIp}}{{.HostIp}}{{else}}0.0.0.0{{end}}{{"\n"}}{{end}}{{end}}' \
+      "$container" 2>/dev/null | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ *$//')"
+    [ -n "$actual" ] || actual="0.0.0.0"
+    if [ "$actual" != "$bind" ]; then
+      echo "WARNING: ${container} publishes on ${actual}:${port}, not ${bind}:${port}." >&2
+      echo "         It was created before the current bind setting and docker cannot" >&2
+      echo "         re-publish a running container. To fix (data is on volume" >&2
+      echo "         ${SQ_VOLUME_NAME} and survives):" >&2
+      echo "           docker rm -f ${container} && bin/setup" >&2
+    fi
     if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
       echo "Starting existing postgres container..." >&2
       docker start "$container" >/dev/null
@@ -133,7 +150,7 @@ ensure_postgres() {
     echo "Creating postgres container on port ${port}..." >&2
     docker run -d \
       --name "$container" \
-      -p "127.0.0.1:${port}:5432" \
+      -p "${bind}:${port}:5432" \
       -e POSTGRES_USER="$SQ_PG_USER" \
       -e POSTGRES_PASSWORD="$SQ_PG_PASSWORD" \
       -e POSTGRES_DB=squadquest_v2 \

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "JarvusInnovations/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/agent-dev-workflow/SKILL.md",
-      "computedHash": "d7645eeaffa5d1732d5177b85727ae15a7020e308cba48256fb1479d10b05110"
+      "computedHash": "2d73ba20e7cfd362cf3fc8e90bd9dc49e208f7333617069b3fad134485de8b17"
     },
     "dart-add-unit-test": {
       "source": "dart-lang/skills",


### PR DESCRIPTION
Two changes, both from upstream agent-skills.

## 1. Re-sync the vendored skill

Picks up the `bin/stop` session-proof guard (agent-skills#45) and the published-address drift detection (agent-skills#46).

## 2. Warn on published-address drift

`ensure_postgres` reuses the container by name and only `docker start`s it, and **docker cannot re-publish an existing container** — so the `-p` address is frozen at creation time. Changing the bind, or adopting the loopback default after the fact, leaves every earlier container on its old publish forever, with no error and nothing in the diff to notice.

This isn't hypothetical. A container on our dev box created in **March** was still published on `0.0.0.0` in **August**, on a machine with a public IP, while `_common.sh` had specified loopback the entire time. The exposure lived purely in docker state, invisible to code review.

`ensure_postgres` now compares the actual published address against the desired bind and warns with the single command that fixes it:

```
WARNING: <container> publishes on 0.0.0.0:<port>, not 127.0.0.1:<port>.
         It was created before the current bind setting and docker cannot
         re-publish a running container. To fix (data is on volume
         <volume> and survives):
           docker rm -f <container> && bin/setup
```

It **warns rather than auto-recreating** — tearing down a container is the caller's decision, not a side effect of `bin/setup`. Data is on a named volume and survives.

The comparison handles a container publishing on **several** addresses (naive concatenation yields nonsense like `127.0.0.1100.116.60.123`) and docker's **empty** `HostIp` meaning all-interfaces.

## Verification

`bash -n` clean. The check was run against the real containers on the dev box: silent for the correctly bound ones, and correctly loud for the one genuinely published on `0.0.0.0`.